### PR TITLE
Fix/mentoring link

### DIFF
--- a/content/en/events/.gitignore
+++ b/content/en/events/.gitignore
@@ -1,3 +1,4 @@
 community-meeting.md
 meet-our-contributors.md
 office-hours.md
+mentoring.md

--- a/external-sources/kubernetes/community
+++ b/external-sources/kubernetes/community
@@ -16,6 +16,7 @@
 "/contributors/guide/contributor-cheatsheet/README.md","/docs/contributor-cheatsheet.md"
 "/events/community-meeting.md","/events/community-meeting.md"
 "/events/office-hours.md","/events/office-hours.md"
+"/mentoring/README.md","/events/mentoring.md"
 "/mentoring/programs/meet-our-contributors.md","/events/meet-our-contributors.md"
 "/sig-list.md","/resources/community-groups/index.md"
 "/communication/best-practices.md","/docs/comms/notifications.md"


### PR DESCRIPTION
Fixes #175 

I have removed the trailing whitespace in the main repository and added the content to the external sources.