### PR TITLE
Add dotglob for globbing in hack/gen-content.sh

### DIFF
--- a/hack/gen-content.sh
+++ b/hack/gen-content.sh
@@ -288,7 +288,7 @@ main() {
   # file-path: external-sources/kubernetes/community
   # "/contributors/guide", "/guide" 
 
-  shopt -s globstar
+  shopt -s globstar dotglob
   for repo in "${EXTERNAL_SOURCES}"/**; do
     if [[ -f "$repo" ]]; then
       repos+=("$repo")


### PR DESCRIPTION
We are using `hack/gen-content.sh` for <https://fluxcd.io> as well and recently added `dotglob` for globbing to allow us pulling in <https://github.com/fluxcd/.github/> as you can see in <https://github.com/fluxcd/website/blob/main/external-sources/fluxcd/.github>.