### PR TITLE
Add CFP for KCSNA 2021

### DIFF
--- a/content/en/events/kcsna2021/cfp.md
+++ b/content/en/events/kcsna2021/cfp.md
@@ -8,13 +8,13 @@ weight: 3
 
 The Call for Proposals (CFP) has some dates to keep in mind.
 
-CFP Opens: Aug 9
+- CFP Opens: Aug 9
 
 #### Session Proposal Dates
 
-CFP closes for sessions: Aug 30
-Notification for sessions: Sept 6
-Schedule announced for sessions: Sept 20
+- CFP closes for sessions: Aug 30
+- Notification for sessions: Sept 6
+- Schedule announced for sessions: Sept 20
 
 #### Unconference Discussion Proposal Dates
 
@@ -22,9 +22,9 @@ As we will be running a hybrid summit this year with some virtual attendees, we
 need to gather topics ahead of time to ensure that we can have a productive
 summit. Use the same CFP form to submit topics for discussion.
 
-CFP closes for unconference: Oct 1
-Notification/dot voting begins for unconference: Oct 1
-Schedule announced for unconference: Oct 4
+- CFP closes for unconference: Oct 1
+- Notification/dot voting begins for unconference: Oct 1
+- Schedule announced for unconference: Oct 4
 
 ### Link
 

--- a/content/en/events/kcsna2021/cfp.md
+++ b/content/en/events/kcsna2021/cfp.md
@@ -1,0 +1,43 @@
+---
+title: "Call for Proposals"
+type: docs
+weight: 3
+---
+
+### Important Dates
+
+The Call for Proposals (CFP) has some dates to keep in mind.
+
+CFP Opens: Aug 9
+
+#### Session Proposal Dates
+
+CFP closes for sessions: Aug 30
+Notification for sessions: Sept 6
+Schedule announced for sessions: Sept 20
+
+#### Unconference Discussion Proposal Dates
+
+As we will be running a hybrid summit this year with some virtual attendees, we
+need to gather topics ahead of time to ensure that we can have a productive
+summit. Use the same CFP form to submit topics for discussion.
+
+CFP closes for unconference: Oct 1
+Notification/dot voting begins for unconference: Oct 1
+Schedule announced for unconference: Oct 4
+
+### Link
+
+The Call for Proposals (CFP) may be found at [this Google Form].
+
+[this Google Form]: https://forms.gle/bt3CvN4LnrU9iCcg6
+
+### Notes
+
+Unconference discussion topics will be held in an open spaces format. A
+moderator will be on hand to ensure that remote attendee participation is
+facilitated with the in-person discussion, but the discussion will be driven by
+the people that are part of the open space. If you are unfamiliar with
+unconference and the open spaces format, see [Schedule] for more information.
+
+[Schedule]: /events/kcsna2021/schedule

--- a/content/en/events/kcsna2021/faq.md
+++ b/content/en/events/kcsna2021/faq.md
@@ -1,7 +1,7 @@
 ---
 title: "Frequently Asked Questions (FAQ)"
 type: docs
-weight: 3
+weight: 4
 ---
 
 - [When is the summit taking place?](#when-is-the-summit-taking-place)

--- a/content/en/events/kcsna2021/location.md
+++ b/content/en/events/kcsna2021/location.md
@@ -1,7 +1,7 @@
 ---
 title: "Location & Venue"
 type: docs
-weight: 4
+weight: 5
 ---
 
 <img align="right" src="/events/kcsna2021/hotel.jpeg" width="25%">

--- a/content/en/events/kcsna2021/schedule.md
+++ b/content/en/events/kcsna2021/schedule.md
@@ -1,7 +1,29 @@
 ---
 title: Schedule
 type: docs
-weight: 5
+weight: 6
 ---
 
-### CFP & unconference information coming soon.
+### CFP
+
+To submit to the CFP, head to [the CFP page].
+
+[the CFP page]: /events/kcsna2021/cfp
+
+### Format
+
+For this year's summit, we will have a small talk track and a large unconference
+track. 
+
+#### Unconference details
+
+Unlike most unconferences where the attendees decide on topics the day of, we
+ask that all topics are proposed, voted on, confirmed, and scheduled ahead of
+time to ensure a smooth hybrid event.
+
+We will use the open spaces facilitation style for unconference sessions at the
+summit. If you are unfamiliar with the unconference format, especially open
+spaces and dot voting, please refer to [this Wikipedia article] to understand
+the process.
+
+[this Wikipedia article]: https://en.wikipedia.org/wiki/Unconference


### PR DESCRIPTION
Adding a page for the CFP, updating the Schedule page with information about the format and an explanation of unconference, and updating the order to put the CFP up with Registration.