### PR TITLE
Bump release info page to 1.23

### DIFF
--- a/external-sources/kubernetes/sig-release
+++ b/external-sources/kubernetes/sig-release
@@ -1,1 +1,1 @@
-"/releases/release-1.22/README.md","/resources/release/index.md"
+"/releases/release-1.23/README.md","/resources/release/index.md"


### PR DESCRIPTION
Bump release info page to 1.23.
The 1.23 release cycle starts today, Aug 23, 2021.
/cc @JamesLaverack @jrsapi @mkorbi @MonzElmasry 
/assign @mrbobbytables @cblecker 