### PR TITLE
Fixing npm error when building a contributor-site docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apk add --no-cache \
     sed \
     npm
 
+WORKDIR /src
+
 # Required for PostCSS
 RUN npm install -G \
     autoprefixer \
@@ -24,7 +26,6 @@ RUN mkdir -p /usr/local/src && \
     addgroup -Sg 1000 hugo && \
     adduser -Sg hugo -u 1000 -h /src hugo
 
-WORKDIR /src
 
 USER hugo:hugo
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ with generating the site by executing `make container-image`.
 
 To ensure you can view the site with externally sourced content, run
 `make container-gen-content` before previewing the site by with
-`make container-serve`.
+`make container-server`.
 
 
 ### Natively


### PR DESCRIPTION
Hello. 

Trying to follow instructions and build a docker image to run contributor website locally. 
Getting below error from npm:
> 
make container-image
docker build . -t k8s-contrib-site-hugo --build-arg HUGO_VERSION=0.69.2
Sending build context to Docker daemon  25.65MB
Step 1/8 : FROM alpine:latest
 ---> 14119a10abf4
Step 2/8 : ARG HUGO_VERSION=0.69.2
 ---> Using cache
 ---> 9f0b486ae2a6
Step 3/8 : RUN apk add --no-cache     bash     build-base     curl     git     grep     libc6-compat     rsync     sed     npm
 ---> Using cache
 ---> 0d785ca3bfea
Step 4/8 : RUN npm install -G     autoprefixer     postcss-cli
 ---> Running in 46980f105b5d
npm ERR! Tracker "idealTree" already exists

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-09-29T18_08_36_087Z-debug.log
The command '/bin/sh -c npm install -G     autoprefixer     postcss-cli' returned a non-zero code: 1
make: *** [Makefile:56: container-image] Error 1
> 
According to StackOverflow: https://stackoverflow.com/questions/57534295/npm-err-tracker-idealtree-already-exists-while-creating-the-docker-image-for all we have to do is specify WORKDIR before running npm install:

_This issue is happening due to changes in nodejs starting version 15. When no WORKDIR is specified, npm install is executed in the root directory of the container, which is resulting in this error. Executing the npm install in a project directory of the container specified by WORKDIR resolves the issue._

I believe it's a trivial fix, please, let me know if you'd like me to open an issue first.