### PR TITLE
changed kubernetes/org link

### DIFF
--- a/content/en/resources/services.md
+++ b/content/en/resources/services.md
@@ -219,7 +219,7 @@ For more information on funding requests, see the [Project Funding] page.
 <!-- shared links -->
 [cg]: /resources/community-groups
 [kubernetes/community]: https://github.com/kubernetes/community
-[kubernetes/org]: https://github.com/org
+[kubernetes/org]: https://github.com/kubernetes/org
 [kubernetes/k8s.io]: https://github.com/kubernetes/k8s.io
 [kubernetes]: https://github.com/kubernetes
 [kubernetes-sigs]: https://github.com/kubernetes-sigs


### PR DESCRIPTION
Signed-off-by: Ayushman <ayushvidushi01@gmail.com>

issue #253 changed Link from https://github.com/org to https://github.com/kubernetes/org on Line 222 of content/en/resources/services.md