### PR TITLE
Replace emoji name strings with emoji

### DIFF
--- a/content/en/blog/2022/meet-our-contributors-APAC-au-nz-region-02.md
+++ b/content/en/blog/2022/meet-our-contributors-APAC-au-nz-region-02.md
@@ -9,7 +9,7 @@ slug: meet-our-contributors-au-nz-ep-02
 
 ---
 
-Good day, everyone :wave:
+Good day, everyone 👋
 
 Welcome back to the second episode of the "Meet Our Contributors" blog post series for APAC.
 
@@ -68,7 +68,5 @@ He asserts the best thing a new contributor can do is to "start contributing". N
 If you have any recommendations/suggestions for who we should interview next, please let us know in [#sig-contribex](https://kubernetes.slack.com/messages/sig-contribex). Your suggestions would be much appreciated. We're thrilled to have additional folks assisting us in reaching out to even more wonderful individuals of the community.
 
 
-We'll see you all in the next one. Everyone, till then, have a happy contributing! :wave: 
-
-
+We'll see you all in the next one. Everyone, till then, have a happy contributing! 👋
 


### PR DESCRIPTION
Fixup for #292

Markdown expects the actual grapheme clusters, and not the name of the emoji with colons around it. Switch to that.