### PR TITLE
Update to k8s.dev/release to 1.25

### DIFF
--- a/external-sources/kubernetes/sig-release
+++ b/external-sources/kubernetes/sig-release
@@ -1,1 +1,1 @@
-"/releases/release-1.24/README.md","/resources/release/index.md"
+"/releases/release-1.25/README.md","/resources/release/index.md"


### PR DESCRIPTION
This PR updates k8s.dev/release page to 1.25