### PR TITLE
Replace schedule with sched

### DIFF
--- a/content/en/events/kcseu/schedule.md
+++ b/content/en/events/kcseu/schedule.md
@@ -38,26 +38,10 @@ SIG-Docs will have a full-day Documentation working session during the Summit.
 If you contribute to the docs -- and who doesn't -- or you want to learn to
 do it better, join them.
 
-### May 15th
+## Schedule
 
-- 2pm - 6pm - Registration + Vaccine Verification + Badge Pick-up @ the [Feria Valencia]
-
-### May 16th
-
-* 7:30am - 5pm - Registration + Vaccine Verification + Badge Pick-up @ the [Feria Valencia]
-* 9am - 10:30am - Breakfast and chatting, proposal and gathering of Unconference topics
-* 10:30am - 11:30am - Steering AMA
-* 10:30am - 5:00pm - Concurrent SIG Meetings
-* 10:30am - 5:00pm - Doc Sprint
-* 11:30am - 12:30pm - Unconference voting
-* 1:00pm - Announce Unconference schedule
-* 1:30pm - 2:25pm Unconference Session 1
-* 2:30pm - 3:30pm Unconference Session 2
-* 3:30pm - 3:55pm Coffee/Tea
-* 4:00pm - 4:55pm Unconference Session 3
-* 5:00pm - Hotel break
-* 6pm - Transport to the Social venue
-* 6:30pm - 8:30pm - Evening social @ the [La Casa de la Mar]
-
-[Feria Valencia]: /events/kcseu/location/#Feria-Valencia
-[La Casa de la Mar]: /events/kcseu/location/#La-Casa-de-la-Mar
+{{% schedule
+  text="Kubernetes Contributor Summit Europe 2022"
+  link="https://kcseu22.sched.com"
+  script="https://kcseu22.sched.com/js/embed.js"
+%}}


### PR DESCRIPTION
Replaces the hand written schedule with the sched.com embed.

Copied the shortcode from the LA event