### PR TITLE
Add 2020 awards recipients to contributor site

### DIFF
--- a/content/en/community/awards/2020/index.md
+++ b/content/en/community/awards/2020/index.md
@@ -1,0 +1,94 @@
+---
+title: "2020 Awards"
+weight: 1
+aliases: [ "/awards/2020" ]
+type: docs
+slug: "2020"
+description: "2020 Contributor Award Recipients"
+---
+
+By Special Interest Group (SIG)
+
+#### API Machinery
+
+- Haowei Cai
+- Chao Xu
+
+#### Architecture
+
+- Hippie Hacker
+- Michelle Au
+- Dawn Chen
+- Paris Pittman
+
+#### Authentication
+
+- Shihang Zhang
+
+#### CLI
+
+- Yao Zhou
+- Brian Pursely
+- Syam Sundar Kirubakaran
+
+#### Cloud Provider
+
+- Cici Huang
+
+#### Contributor Experience
+
+- Matthew Broberg
+- Kaslin Fields
+- Noah Kantrowitz
+- Rajula Vineet Reddy
+
+#### Cluster Lifecycle
+
+- Ciprian Hacman
+- John Gardiner Myers
+- Ole Markus
+
+### Documentation
+
+- Tim Bannister
+- Qiming Teng
+- Zachary Sarah Corleissen
+
+#### Instrumentation
+
+- Hongcai Ren
+- Lili Cosic
+- Marek Siarkowicz
+
+#### Network
+
+- Antonio Ojea
+- Jay Vyas
+
+#### Release
+
+- Joyce Kung
+- Daniel Mangum
+
+#### Scheduling
+
+- Aldo Culquicondor
+
+#### Storage
+
+- Patrick Ohly
+
+#### Testing
+
+- Antonio Ojea
+- Daniel Magnum
+
+#### Usability
+
+- Gaby Moreno Cesar
+- Carl J Pearson
+- Josie Pynadath
+
+#### Windows
+
+- James Sturtevant


### PR DESCRIPTION
This PR adds the 2020 Contributor Awards recipients to the contributor site
Source: [List of 2020 Contributor Awards recipients](https://github.com/kubernetes/community/blob/master/events/awards/README.md)
