### PR TITLE
Add page to list all KEPs

### DIFF
--- a/.github/workflows/netlify-periodic-build.yml
+++ b/.github/workflows/netlify-periodic-build.yml
@@ -1,7 +1,9 @@
 name: Trigger netlify build
 on:
   schedule:
-  - cron: '30 3 * * *'
+  # The build is triggered every 6 hours so that the KEP page remains fresh.
+  # TODO(future): Revisit the cadence.
+  - cron: '0 */6 * * *'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/content/en/resources/keps/_index.md
+++ b/content/en/resources/keps/_index.md
@@ -1,0 +1,22 @@
+---
+linktitle: Enhancements
+title: Kubernetes Enhancement Proposals (KEPs)
+description: |
+  List of Kubernetes enhancements
+type: docs
+---
+
+These data come from the [kubernetes/enhancements]
+repository on GitHub.
+
+To see the original Enhancement issue, click on the KEP number.  To see a summary of what the KEP does, click on the Title.
+
+{{% alert title="Note" color="info" %}}
+If you notice an empty cell in the table, the KEP may not have updated information.
+Please raise <a href="https://github.com/kubernetes/enhancements/issues">an issue in the kubernetes/enhancemenets</a> repository.
+{{% /alert %}}
+###	KEP List
+
+{{< keps-data >}}
+
+[kubernetes/enhancements]: https://github.com/kubernetes/enhancements

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,25 @@
+{{/*
+    This file is a 1:1 copy of the one in docsy but with adding scripts
+    for enabling Datatables on the KEP page.
+
+    Remove this notice if a better way is found to include the scripts.
+*/}}
+
+{{ with .Site.Params.algolia_docsearch }}
+<!-- scripts for algolia docsearch -->
+{{ end }}
+
+{{ if .HasShortcode "keps-data" }}
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.js"></script>
+<script type="text/javascript">
+    $(document).ready(function () {
+        $('#keps-table').DataTable({
+            lengthMenu: [
+                [10, 25, 50, -1],
+                [10, 25, 50, 'All'],
+            ],
+            order: [[2, 'asc'], [0, 'asc']],
+        });
+    });
+</script>
+{{ end }}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,20 @@
+{{/*
+    This file is a 1:1 copy of the one in docsy but with adding stylesheets
+    for enabling Datatables on the KEP page.
+
+    Remove this notice if a better way is found to include the stylesheets.
+*/}}
+
+{{ with .Site.Params.algolia_docsearch }}
+<!-- stylesheet for algolia docsearch -->
+{{ end }}
+
+{{ if .HasShortcode "keps-data" }}
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.12.1/css/jquery.dataTables.css">
+<style>
+    .kep-milestone {
+        font-weight: bold;
+    }
+
+</style>
+{{ end }}

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,0 +1,86 @@
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.12.1/css/jquery.dataTables.css">
+<style>
+  .kep-milestone {
+    font-weight: bold;
+  }
+</style>
+
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.js"></script>
+<script type="text/javascript">
+  $(document).ready( function () {
+    $('#keps-table').DataTable({
+      lengthMenu: [
+        [10, 25, 50, -1],
+        [10, 25, 50, 'All'],
+      ],
+      order: [[2, 'asc'], [0, 'asc']],
+    });
+});
+</script>
+
+<div>
+  <table id="keps-table" class="table table-hover mt-2 col-md-12 table-sm">
+    <thead class="thead-light">
+      <tr>
+        <th scope="col" class="col-md-1">KEP Number</th>
+        <th scope="col" class="col-md-3">Title</th>
+        <th scope="col" class="col-md-2">SIG</th>
+        <th scope="col" class="col-md-2">Author</th>
+        <th scope="col" class="col-md-1">Created</th>
+        <th scope="col" class="col-md-1">Last Updated</th>
+        <th scope="col" class="col-md-1">Milestone</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{range $index, $data := getJSON "https://storage.googleapis.com/k8s-keps/keps.json" }}
+          <tr>
+            <td>
+              <a href="https://features.k8s.io/{{ $data.kepNumber }}">
+                {{ printf "%s" $data.kepNumber }}
+              </a>
+            </td>
+            <td>
+              <a href="https://github.com/kubernetes/enhancements/tree/master/keps/{{$data.owningSig}}/{{$data.name}}#summary">
+                {{ printf "%s" $data.title }}
+              </a>
+            </td>
+            <td>
+              <a href=" https://github.com/kubernetes/community/tree/master/{{ $data.owningSig }}">
+                {{ strings.TrimPrefix "sig-" $data.owningSig | humanize | title }}
+              </a>
+            </td>
+            <td>
+              {{ range $index, $author := $data.authors }}
+              {{- if $index -}}, {{ end -}}
+              <a href="https://github.com/{{ trim $author "@" }}">
+                <span class="github-user">@{{ trim $author "@" }}</span>
+              </a>
+              {{ end }}
+            </td>
+            <td>
+                {{ if $data.creationDate }}
+                  <time datetime="{{ $data.creationDate }}">{{ $data.creationDate }}</time>
+                {{ end }}
+            </td>
+            <td>
+                {{ if $data.lastUpdated }}
+                  <time datetime="{{ $data.lastUpdated }}">{{ $data.lastUpdated }}</time>
+                {{ end }}
+              </span>
+            </td>
+            <td>
+              <ul class="list-unstyled">
+                {{ range $stage, $milestone := $data.milestone }}
+                  {{ if $milestone }}
+                  <li>
+                    {{ $stage }}:<span class="kep-milestone">{{ $milestone }}</span>
+                  </li>
+                  {{ end }}
+                {{ end }}
+              </ul>
+            </td>
+          </tr>
+      {{ end }}
+    </tbody>
+  </table>
+</div>

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,22 +1,12 @@
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.12.1/css/jquery.dataTables.css">
-<style>
-  .kep-milestone {
-    font-weight: bold;
-  }
-</style>
+{{/*
+  Datatables is used in the page to enrich the list of KEPs.
+  The stylesheets and scripts required are in `partials/hooks/head-end.html`
+  and `partials/hooks/body-end.html` respectively.
 
-<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.js"></script>
-<script type="text/javascript">
-  $(document).ready( function () {
-    $('#keps-table').DataTable({
-      lengthMenu: [
-        [10, 25, 50, -1],
-        [10, 25, 50, 'All'],
-      ],
-      order: [[2, 'asc'], [0, 'asc']],
-    });
-});
-</script>
+  Note: In order to configure Datatable parameters for changing any behavior, edit
+  the `DataTable` initialization in `partials/hooks/body-end.html`
+
+*/}}
 
 <div>
   <table id="keps-table" class="table table-hover mt-2 col-md-12 table-sm">


### PR DESCRIPTION
Part of https://github.com/kubernetes/enhancements/issues/2095

The proposed change now uses [Datatables](https://datatables.net/) for table search, pagination and sorting. No additional custom JS is required. Also, there is no change done to the content generator hack script.

Here is how the page looks:
![image](https://user-images.githubusercontent.com/10010419/190415219-8fc14745-31f2-4cf5-9232-dd9988491022.png)

Supersedes #222 (Thanks, @shekhar-rajak for the initial work 🎉 )

> Note: A lot of future improvements can be done on this page. This is the MVP that we should get to first.