### PR TITLE
Add sftim to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,4 @@ approvers:
   - jberkus
   - jeefy
   - mrbobbytables
+  - sftim


### PR DESCRIPTION
This adds @sftim to the list of approvers for Contributor Site.

Tim has been editing contributor site blog posts for the last several months.  It'll be useful if he can approve them as well, given timing issues.

Attn: @mrbobbytables @jeefy 