### PR TITLE
Adding late-breaking change about testing option

### DIFF
--- a/content/en/events/2022/kcsna/registration.md
+++ b/content/en/events/2022/kcsna/registration.md
@@ -13,9 +13,10 @@ docs for more information. If your application to join is pending, please
 contact us at community@kubernetes.io about registering.
 
 **NOTE:** The summit adheres to KubeCon’s [Health & Safety Guidelines] requiring
-**ALL** in-person attendees to be fully vaccinated against the COVID-19 virus.
+**ALL** in-person attendees to be fully vaccinated against the COVID-19 virus or
+to show proof of a negative COVID-19 test administered by a verified provider.
 
-If you acknowledge the above, please go ahead click below to register:
+If you acknowledge the above, please go ahead and click below to register:
 
 <h3>
 <a href="https://cvent.me/b8BnzD" rel="noopener noreferrer" target="_blank">Register Here</a>


### PR DESCRIPTION
I noticed when I got the email about the contributor summit that it explained the late-breaking changes to the health and safety policy, but then it linked me to a registration page which only listed the previous policy.

I want to ensure that when people register for the contributor summit, they don't have a false sense of security caused by assuming that the summit has stricter requirements than the conference itself, so I am submitting a PR to clarify the change.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>