### PR TITLE
Add 2019 award winners.

### DIFF
--- a/content/en/community/awards/2019/index.md
+++ b/content/en/community/awards/2019/index.md
@@ -1,0 +1,38 @@
+---
+title: "2019 Awards"
+weight: 1
+aliases: [ "/awards/2019" ]
+type: docs
+slug: "2019"
+description: "2019 Contributor Award Recipients"
+---
+
+By Special Interest Group (SIG)
+
+#### SIG Cloud Provider
+
+* Lubomir Ivanov
+
+#### SIG Instrumentation
+
+* Han Kang
+
+#### SIG Release
+
+* Katharine Berry
+
+#### SIG Scheduling
+
+* Huang Wei
+
+#### SIG Storage
+
+* Michelle Au
+
+#### SIG Windows
+
+* Jordan Liggitt
+
+#### WG Multitenancy
+
+* Ryan Bezdicek


### PR DESCRIPTION
Add contributor awardees from 2019.

/sig contributor-experience