### PR TITLE
[KCSNA2022] CFP is no longer open

### DIFF
--- a/content/en/events/2022/kcsna/schedule.md
+++ b/content/en/events/2022/kcsna/schedule.md
@@ -4,8 +4,6 @@ type: docs
 weight: 3
 ---
 
-CFP is open! More information available here: [CFP](/events/2022/kcsna/cfp)
-
 {{% schedule
   text="Kubernetes Contributor Summit Europe 2022"
   link="https://kcsna2022.sched.com/"


### PR DESCRIPTION
Update the Schedule page for KCSNA2022 to remove statement that the CFP is open.