### PR TITLE
Add 2022 contributor award winners

### DIFF
--- a/content/en/community/awards/2022/index.md
+++ b/content/en/community/awards/2022/index.md
@@ -1,0 +1,184 @@
+---
+title: "2022 Awards"
+weight: 1
+aliases: [ "/awards/2022" ]
+type: docs
+slug: "2022"
+description: "2022 Contributor Award Recipients"
+---
+
+By Special Interest Group (SIG) with listed message/nomination reason   
+
+#### API Machinery
+
+*Joe Betz, [@jpbetz](https://github.com/jpbetz)*
+For his leadership and contributions introducing CEL as a powerful feature for Kubernetes, and leading the strategy and execution of all the subsequent projects like CRD Validation, Admission Control, and more to come. 
+
+*Antonio Ojea, [@aojea](https://github.com/aojea)*  
+For the long list of sustained contributions, especially for the cross-over from networking to apimachinery/client-go, picking up bug fixes, backports, and code reviews.
+
+#### Apps
+
+*Aldo Culquicondor, [@alculquicondor](https://github.com/alculquicondor)*
+Aldo continues working on the job controller improving its functionality coming from wg-batch, and fixing long-standing issues with calculating pods, among other things.
+
+#### Architecture
+
+*Kirsten Garrison, [@kikisdeliveryservice](https://github.com/kikisdeliveryservice)*
+Kirsten has been advocating for better enhancements process for a while now. She has been able to build a band of folks along with sig-release folks to roll out a new process for 1.26 which will make life much easier for everyone
+
+*Riann Kleinhans, [@Riaankl](https://github.com/Riaankl)*
+Riann has been leading the charge to close the gap in our conformance test suite which assures end users that the kubernetes distribution works as expected. Due to his leadership we are very close to paying down the debt on our older APIs.
+
+*Patrick Ohly, [@pohly](https://github.com/pohly)*
+Patrick has been awesome across multiple fronts in code organization. He’s especially led updates to klog and how we get to structured logging across kubernetes code base
+
+#### Auth
+
+*Anish Ramasekar, [@aramase](https://github.com/aramase)*
+For driving KMS v2alpha1 and maintaining the Secrets Store CSI Driver subproject
+
+#### CLI
+
+*Arda Güçlü, [@ardaguclu](https://github.com/ardaguclu)*
+Arda joined SIG CLI at the end of 2021 and almost from the beginning caught our attention by being very diligent and patient proposing fixes and improvements to kubectl. Since then he grew into a valued member of our SIG, and is currently a member of our reviewers cohort, on the path to becoming a reviewer.
+
+#### Cluster Lifecycle
+
+*Stefan Büeringer, [sbueringer](https://github.com/sbueringer)*
+We love Stefan because he is not only an amazing contributor, but also  such a lovely and nice person that truly represent the spirit of this community by being relentless in trying to help people, on every issue, PR, slack thread, always providing valuable and constructive feedback. Thanks Stefan for all your hard work and enjoy this well deserved award!
+
+
+#### Contributor Experience
+
+*Marky Jackson,	[@markyjackson-taulia](https://github.com/markyjackson-taulia)*
+For stepping up to do the unglamorous but necessary work of community management
+
+*Nabarun Pal, [@palnabarun](https://github.com/palnabarun)*
+For driving continuous improvement of community github administration
+
+#### Docs
+
+*Shannon Kularathna, [@shannonxtreme](https://github.com/shannonxtreme)*
+For high-quality contributions, both to content and processes, across SIG Docs and achieving reviewer status
+
+*Seokho Son, [@seokho-son]https://github.com/seokho-son)*
+For consistently leading and maintaining the Korean Localization
+
+*Anubhav Vardhan, [@anubha-v-ardhan](https://github.com/anubha-v-ardhan)*
+For leading the launch of the Hindi Localization, our first using the Devanagari script
+
+*Yung-Hsiang (Sean) Wei, [@Sea-n](https://github.com/Sea-n)*
+For achieving reviewer status on the Chinese Localization team and continued contributions to SIG Docs English PRs
+
+#### Instrumentation
+
+*Patrick Ohly, [@pohly](https://github.com/pohly)*
+For their continued contributions to WG Structured Logging and for driving the contextual logging effort
+
+*Sally O'Malley, [@sallyom])https://github.com/sallyom)*
+For driving the kubelet tracing effort and sticking with it through a years-long review process
+
+#### K8s Infra
+
+*Caleb Woodbine, [@BobyMCbobs](https://github.com/BobyMCbobs)*
+For his critical role in building the AWS infrastructure of registry.k8s.io and other efforts in sig-k8s-infra.
+
+
+#### Network
+
+*Antonio Ojea, [@aojea](https://github.com/aojea)*
+Antonio is prolific, invariably helpful, and consistently volunteers to take on the hardest, dirtiest problems.  He values quality and reliability, and strives to make sure that every PR makes the project better.  He exemplifies the idea of "maintainer", and lifts up everyone who has the opportunity to work with him.
+
+#### Node
+
+*Vinay Kulkarni, [@vinaykul](https://github.com/vinaykul)*
+For driving long standing and complicated in-place pod vertical autoscaling project
+
+*Danielle Lancashire, [@endocrimes](https://github.com/endocrimes)*
+For driving broad community participation and coordinating SIG Node CI project
+
+*Brian McQueen, [@xmcqueen](https://github.com/xmcqueen)*
+For improving and sustaining the health of SIG Node CI
+
+*Mrunal Patel, [@mrunalp](https://github.com/mrunalp)*
+For driving broad community participation and coordinating release feature goals
+
+*David Porter, [@bobbypage](https://github.com/bobbypage)*
+Driving several critical initiatives including cgroup v2 and graceful node shutdown
+
+#### Release
+
+*Lauri Apple, [@lappleapple](https://github.com/lappleapple)*
+Lauri has been instrumental in helping to organize the SIG Release roadmap and continues to play an important part in helping SIG Release focus and deliver. She welcomes new contributors,  seeks to unblock stalled efforts, and above all has helped to ensure that critical initiatives make forward progress. Thank you Lauri for shaping the future of our SIG!
+
+*Verónica López, [@verolop](https://github.com/verolop)*
+Verónica is a phenomenal Release Manager and has served as the branch manager for several releases, most recently Kubernetes 1.23 and Kubernetes 1.25. During both of these releases, she also served as a mentor for a Branch Manager Shadow and ensured that they were empowered to learn and able to take up the role for the next release. A special thanks to you Verónica for continuously driving our release machine!
+
+*Marko Mudrinić, [@xmudrii](https://github.com/xmudrii)*
+Marko is a profound current Release Manager and has been a long term contributor to SIG Release. We want to recognize his dedication to the project and to the success of SIG Release. He has balanced university and his contributions to the SIG and always brings a valuable perspective to the table when we are addressing issues. Thank you Marko for your outstanding efforts within our community!
+
+#### Scalability
+
+*Maciek Borsz, [mborsz](https://github.com/mborsz)*
+For outstanding contributions to SIG Scalability
+
+#### Security
+
+*Cailyn Edwards, [@cailynse](https://github.com/cailynse)*
+Cailyn as done stellar job in making SIG Security related artifacts better through their hands on expertise and review comments! Cailyn has also brought in new contributors into the community and made the group richer through their valuable contributions!"
+
+*Robert Ficcagilia, [@rficcaglia](https://github.com/rficcaglia)*
+For oustanding contributions to SIG Security with the third-party security audit subproject and Cluster API security self-assessment
+
+*Rory McCune, [@raesene](https://github.com/raesene)*
+Rory is a thought leader and an amazing example of how to be inclusive, share knowledge in public and improve the project through community collaboration. This is one of those cases where Kubernetes Org is lucky that Rory would like to be its member
+
+*Mahé Tardy, [@mtardy](https://github.com/mtardy)*
+Mahé as been a regular member of SIG Security and a repeat contributor on 
+Kubernetes security related issues and PRs. He has also presented a 
+learning session to the community on an opensource pentest tool - kdigger that he co-created!"
+
+#### Scheduling
+
+*Kensei Nakada, [@sanposhiho](https://github.com/sanposhiho)*
+For being a top contributor in scheduler, making continuous and diligent work on PR reviews, issue triaging, KEP design/impl., as well as maintaining some of sig-scheduling sub-projects. We hope to use this chance to thank their efforts to the community.
+
+*Kante Yin, [@kerthcet](https://github.com/kerthcet)*
+For being a top contributor in scheduler, making continuous and diligent work on PR reviews, issue triaging, KEP design/impl., as well as maintaining some 
+of sig-scheduling sub-projects. We hope to use this chance to thank their efforts to the community.
+
+#### Storage
+
+*Jing Xu, [@jingxu97](https://github.com/jingxu97*
+Jing Xu worked on many projects in SIG Storage, including GA features such as CSI Volume Snapshots and CSI Windows, etc. Most recently in 1.25, she moved Local Storage Capacity Isolation to GA. Jing has been helping with hosting CSI Implementation meetings, tracking features in Kubernetes releases, reviewing KEPs and PRs, as well as fixing bugs such as mount issues.
+
+*Andy Zhang, [@andyzhangx](https://github.com/andyzhangx)*
+Andy Zhang is the maintainer of CSI drivers for Azure Disk and Azure File. He made sure CSI Migration for Azure in-tree plugins are progressing as planned. He is also a maintainer of the SMB and NFS CSI Drivers. In addition, he helps fixing CI issues in the CSI spec repo by introducing GitHub actions and helps catching vulnerability issues in the CSI sidecars.
+
+
+#### Testing
+
+* Dave Chen, [@chendave](https://github.com/)*
+For the huge Kubernetes e2e test ginkgo v2 migration
+
+* Michelle Shepardson, [@michelle192837](https://github.com/michelle192837)*
+For helping run the SIG: a huge help running meetings, organizing the SIG annual report etc
+
+* Antonio Ojea, [@aojea](https://github.com/aojea)*
+For the huge Kubernetes e2e test ginkgo v2 migration
+
+* Patrick Ohly, [@pohly](https://github.com/pohly)*
+For the huge Kubernetes e2e test ginkgo v2 migration
+
+* Eddie Zane, [@eddiezane](https://github.com/eddiezane)*
+For helping run the SIG: a huge help running meetings, organizing the SIG annual report etc
+
+#### UI
+
+*Cédric de Saint Martin, [@desaintmartin](https://github.com/desaintmartin)*
+For outstanding contributions to SIG UI
+
+#### Windows
+*Aravindh Puthiyaparambil, [@aravindhp](https://github.com/aravindhp)*
+For continued participation in bug triage, backlog grooming, and all of the work on done for the node service log viewer enhancement.


### PR DESCRIPTION
This PR adds the 2022 Kubernetes Contributor Award winners to kubernetes.dev/awards