### PR TITLE
Fix link format in 'community/awards/2022'

### DIFF
--- a/content/en/community/awards/2022/index.md
+++ b/content/en/community/awards/2022/index.md
@@ -62,7 +62,7 @@ For driving continuous improvement of community github administration
 *Shannon Kularathna, [@shannonxtreme](https://github.com/shannonxtreme)*
 For high-quality contributions, both to content and processes, across SIG Docs and achieving reviewer status
 
-*Seokho Son, [@seokho-son]https://github.com/seokho-son)*
+*Seokho Son, [@seokho-son](https://github.com/seokho-son)*
 For consistently leading and maintaining the Korean Localization
 
 *Anubhav Vardhan, [@anubha-v-ardhan](https://github.com/anubha-v-ardhan)*
@@ -76,7 +76,7 @@ For achieving reviewer status on the Chinese Localization team and continued con
 *Patrick Ohly, [@pohly](https://github.com/pohly)*
 For their continued contributions to WG Structured Logging and for driving the contextual logging effort
 
-*Sally O'Malley, [@sallyom])https://github.com/sallyom)*
+*Sally O'Malley, [@sallyom](https://github.com/sallyom)*
 For driving the kubelet tracing effort and sticking with it through a years-long review process
 
 #### K8s Infra
@@ -150,7 +150,7 @@ of sig-scheduling sub-projects. We hope to use this chance to thank their effort
 
 #### Storage
 
-*Jing Xu, [@jingxu97](https://github.com/jingxu97*
+*Jing Xu, [@jingxu97](https://github.com/jingxu97)*
 Jing Xu worked on many projects in SIG Storage, including GA features such as CSI Volume Snapshots and CSI Windows, etc. Most recently in 1.25, she moved Local Storage Capacity Isolation to GA. Jing has been helping with hosting CSI Implementation meetings, tracking features in Kubernetes releases, reviewing KEPs and PRs, as well as fixing bugs such as mount issues.
 
 *Andy Zhang, [@andyzhangx](https://github.com/andyzhangx)*


### PR DESCRIPTION
There are some sections on the "2022 Contributor Award Recipients" page [1] that don't have the "profile links" with the correct formatting.

This PR fixes the formatting on those links for proper display.

> [1] https://k8s.dev/community/awards/2022/