### PR TITLE
chore: add `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git*
+*.md
+OWNERS


### PR DESCRIPTION
#### What this PR does / why we need it:

- This PR will add a `.dockerignore` file. We need it to reduce the docker image build size and make the build faster. Also good for local development