### PR TITLE
Allow leading spaces for reference links

### DIFF
--- a/hack/gen-content.sh
+++ b/hack/gen-content.sh
@@ -115,7 +115,7 @@ process_content() {
   fi
 
   mapfile -t ref_link_matches < \
-    <(grep -o -i -P '^\[.+\]:\s*(?!mailto|\S+?@|<|>|\?|\!|@|#|\$|%|\^|&|\*)\K\S+$' "$1")
+    <(grep -o -i -P '^\s+\[.+\]:\s*(?!mailto|\S+?@|<|>|\?|\!|@|#|\$|%|\^|&|\*)\K\S+$' "$1")
 
   if [[ -v ref_link_matches ]]; then
     for match in "${ref_link_matches[@]}"; do


### PR DESCRIPTION
Some of the sites that get pulled in use a mix of inline and reference links. Reference links are expected to have the format of the link reference name in brackets, starting at the beginning of the line, followed by a colon and then the linked target.

Some of the external sites have been found to have some variation on this format though. While markdown references show the format as above, it does work when these link references have leading spacing before the opening bracket. This has caused [broken slack links](https://github.com/kubernetes/community/issues/6934), as one example.

This change updates the regex for identifying these reference links in the get-content script to allow for leading spaces.