### PR TITLE
Remove Double Heading from Contributor Social Page

### DIFF
--- a/content/en/events/2023/kcseu/social.md
+++ b/content/en/events/2023/kcseu/social.md
@@ -4,7 +4,6 @@ type: docs
 weight: 5
 ---
 
-# Contributor Social
 
 We are still reviewing locations, but should have more info soon! You can expect good food, fun activities and of course, the best company!
 


### PR DESCRIPTION
On the current site, the Contributor Social title is listed twice in big letters. Removing the heading to standardize with other pages.