### PR TITLE
Updated dead link on welcome page

### DIFF
--- a/content/en/welcome/_index.md
+++ b/content/en/welcome/_index.md
@@ -65,7 +65,7 @@ There are many ways you can stay involved with the Kubernetes Contributor commun
   <li>Contribute to and explore our <a href="/docs/guide">contributor</a> and <a href=" https://git.k8s.io/community/contributors/devel/">developer</a> guides</li>
   <li>Voice your thoughts and have them heard at one of our weekly <a href="https://git.k8s.io/community/sig-contributor-experience#meetings">Contributor Experience meetings</a></li>
   <li>Meet our contributors by joining our <a href="/events/meet-our-contributors">monthly one hour meeting</a></li>
-  <li>Learn more about our community by joining in our <a href="/events/community-meeting">monthly community meeting</a></li>
+  <li>Learn more about our community by joining in our <a href="/community/community-meeting">monthly community meeting</a></li>
   <li>Take a journey to <a href="https://git.k8s.io/community/community-membership.md">becoming a reviewer or approver</a></li>
   <li>Find out how we make decisions, organize, and how to get involved in <a href="http://git.k8s.io/community/governance.md">governance</a></li>
 </ul>


### PR DESCRIPTION
The link for monthly community meetings must have been moved at some point from /events/community-meeting to /community/community-meeting, without it being updated on the welcome page. I went ahead and updated it.