### PR TITLE
Bump Hugo version to 0.112

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
     curl \
     git \
     grep \
+    gcompat \
     libc6-compat \
     rsync \
     sed \

--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,17 @@ docker-server:
 	$(MAKE) container-server
 
 container-server: ## Run Hugo locally within a container, available at http://localhost:1313/
+	# no build lock to allow for read-only mounts
 	git submodule update --init --recursive --depth 1
 	$(CONTAINER_RUN) -p 1313:1313 \
 		--mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 \
+		--read-only \
+		--cap-drop=ALL \
+		--cap-drop=AUDIT_WRITE \
 		$(CONTAINER_IMAGE) \
 	hugo server \
 		--verbose \
+		--noBuildLock \
 		--bind 0.0.0.0 \
 		--buildDrafts \
 		--buildFuture \

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,34 @@
+<!-- adapted from Docsy, commit 25f7336 -->
+<!-- OK to remove this once Docsy has been upgraded to work with recent Hugo -->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+{{ hugo.Generator }}
+{{ if eq (getenv "HUGO_ENV") "production" }}
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+{{ else }}
+<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+{{ end }}
+{{ range .AlternativeOutputFormats -}}
+<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+{{ end -}}
+{{ partialCached "favicons.html" . }}
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+<!-- this is where the adaptation from upstream Docsy happens -->
+{{- template "_internal/opengraph.html" . -}}
+{{- template "_internal/schema.html" . -}}
+{{- template "_internal/twitter_cards.html" . -}}
+{{ if eq (getenv "HUGO_ENV") "production" }}
+{{ template "_internal/google_analytics_async.html" . }}
+{{ end }}
+{{ partialCached "head-css.html" . "asdf" }}
+<script
+  src="https://code.jquery.com/jquery-3.5.1.min.js"
+  integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+  crossorigin="anonymous"></script>
+{{ if .Site.Params.offlineSearch }}
+<script
+  src="https://unpkg.com/lunr@2.3.8/lunr.min.js"
+  integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
+  crossorigin="anonymous"></script>
+{{end}}
+{{ partial "hooks/head-end.html" . }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,0 +1,59 @@
+<!-- adapted from Docsy, commit 25f7336 -->
+<!-- OK to remove this once Docsy has been upgraded to work with recent Hugo -->
+{{/* We cache this partial for bigger sites and set the active class client side. */}}
+{{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
+<div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
+  {{ if not .Site.Params.ui.sidebar_search_disable }}
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  {{ else }}
+  <div id="content-mobile">
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  </div>
+  <div id="content-desktop"></div>
+  {{ end }}
+  <nav class="collapse td-sidebar-nav" id="td-section-nav">
+    {{ if  (gt (len .Site.Home.Translations) 0) }}
+    <div class="nav-item dropdown d-block d-lg-none">
+      {{ partial "navbar-lang-selector.html" . }}
+    </div>
+    {{ end }}
+    {{ template "section-tree-nav-section" (dict "page" . "section" .FirstSection "delayActive" $shouldDelayActive)  }}
+  </nav>
+</div>
+{{ define "section-tree-nav-section" }}
+{{ $s := .section }}
+{{ $p := .page }}
+{{ $shouldDelayActive := .delayActive }}
+{{ $active := eq $p.CurrentSection $s }}
+<!-- this is where the adaptation from upstream Docsy happens -->
+{{ $show := cond (or (and (not $p.Site.Params.ui.sidebar_menu_compact) ($p.IsAncestor $s)) ($p.IsDescendant $s) $active) true false }}
+{{ $sid := $s.RelPermalink | anchorize }}
+<ul class="td-sidebar-nav__section pr-md-3">
+  <li class="td-sidebar-nav__section-title">
+    <a  href="{{ $s.RelPermalink }}" class="align-left pl-0 pr-2{{ if not $show }} collapsed{{ end }}{{ if $active}} active{{ end }} td-sidebar-link td-sidebar-link__section">{{ $s.LinkTitle }}</a>
+  </li>
+  <ul>
+    <li class="collapse {{ if $show }}show{{ end }}" id="{{ $sid }}">
+      {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
+      {{ $pages := $pages | first 50 }}
+      {{ range $pages }}
+      {{ if .IsPage }}
+      {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
+      {{ $active := eq . $p }}
+      <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+      {{ else }}
+      {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
+      {{ end }}
+      {{ end }}
+    </li>
+  </ul>
+</ul>
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.89.4"
+HUGO_VERSION = "0.112.3"
 HUGO_ENV = "production"
 
 [context.deploy-preview]


### PR DESCRIPTION
Bump Hugo version to ~0.110~ 0.112 ([preview](https://deploy-preview-374--kubernetes-contributor.netlify.app/)).

There is build-time warning:

<pre>
<i><b>.Path</b> when the page is backed by a file is deprecated and will be removed in a future release. We plan to use <b>Path</b> for a canonical source path and you probably want to check the source is a file. To get the current behaviour, you can use a construct similar to the one below:</i>


  {{ $path := "" }}
  {{ with .File }}
	{{ $path = .Path }}
  {{ else }}
	{{ $path = .Path }}
  {{ end }}
</pre>

Also, update local preview using a container image (copy approach from [k/website](https://github.com/kubernetes/website) `Makefile`). The container image now mounts this Git repo read-only.

Helps with https://github.com/kubernetes/contributor-site/issues/360