### PR TITLE
Drop Google Universal Analytics (UA) ID

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,7 +31,8 @@ anchor = "smart"
 
 [services]
 [services.googleAnalytics]
- id = "UA-98841695-5"
+# Fake ID in support of [params.ui.feedback]. The real GA ID is set in the Netlify config.
+id = "UA-00000000-0"
 
 # Hugo internal cacheing
 [caches]
@@ -79,13 +80,13 @@ privacy_policy = ""
 # This menu appears only if you have at least one [params.versions] set.
 version_menu = "Releases"
 
-# Flag used in the "version-banner" partial to decide whether to display a 
+# Flag used in the "version-banner" partial to decide whether to display a
 # banner on every page indicating that this is an archived version of the docs.
 # Set this flag to "true" if you want to display the banner.
 archived_version = false
 
 # The version number for the version of the docs represented in this doc set.
-# Used in the "version-banner" partial to display a version number for the 
+# Used in the "version-banner" partial to display a version number for the
 # current doc set.
 version = "0.0"
 


### PR DESCRIPTION
- Contributes to #355
- Ideally, we'd drop the `services.googleAnalytics` config parameter entirely, but that would require an update of the layouts that refer to it. I'll leave that cleanup for later.