### PR TITLE
Adding Mastodon Verification

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -10,3 +10,5 @@ description: Welcome to the Kubernetes Contributor Community!
     color="orange" >}}
 
 {{< /blocks/cover >}}
+
+<a rel="me" href="https://hachyderm.io/@K8sContributors"></a>


### PR DESCRIPTION
A Mastodon account to mirror K8sContributors on Twitter has been created https://hachyderm.io/@K8sContributors

This line will provide "verification" that this is the one true Kubernetes Contributor account.