### PR TITLE
Update links on the welcome page

### DIFF
--- a/content/en/welcome/_index.md
+++ b/content/en/welcome/_index.md
@@ -64,7 +64,6 @@ There are many ways you can stay involved with the Kubernetes Contributor commun
   <li>Join one of our <a href="/community/community-groups">community groups</a></li>
   <li>Contribute to and explore our <a href="/docs/guide">contributor</a> and <a href=" https://git.k8s.io/community/contributors/devel/">developer</a> guides</li>
   <li>Voice your thoughts and have them heard at one of our weekly <a href="https://git.k8s.io/community/sig-contributor-experience#meetings">Contributor Experience meetings</a></li>
-  <li>Learn more about our community by joining in our <a href="https://git.k8s.io/community/events/community-meeting.md#kubernetes-monthly-community-meeting">monthly community meeting</a></li>
   <li>Take a journey to <a href="https://git.k8s.io/community/community-membership.md">becoming a reviewer or approver</a></li>
   <li>Find out how we make decisions, organize, and how to get involved in <a href="http://git.k8s.io/community/governance.md">governance</a></li>
 </ul>

--- a/content/en/welcome/_index.md
+++ b/content/en/welcome/_index.md
@@ -64,8 +64,7 @@ There are many ways you can stay involved with the Kubernetes Contributor commun
   <li>Join one of our <a href="/community/community-groups">community groups</a></li>
   <li>Contribute to and explore our <a href="/docs/guide">contributor</a> and <a href=" https://git.k8s.io/community/contributors/devel/">developer</a> guides</li>
   <li>Voice your thoughts and have them heard at one of our weekly <a href="https://git.k8s.io/community/sig-contributor-experience#meetings">Contributor Experience meetings</a></li>
-  <li>Meet our contributors by joining our <a href="/events/meet-our-contributors">monthly one hour meeting</a></li>
-  <li>Learn more about our community by joining in our <a href="/community/community-meeting">monthly community meeting</a></li>
+  <li>Learn more about our community by joining in our <a href="https://git.k8s.io/community/events/community-meeting.md#kubernetes-monthly-community-meeting">monthly community meeting</a></li>
   <li>Take a journey to <a href="https://git.k8s.io/community/community-membership.md">becoming a reviewer or approver</a></li>
   <li>Find out how we make decisions, organize, and how to get involved in <a href="http://git.k8s.io/community/governance.md">governance</a></li>
 </ul>


### PR DESCRIPTION
Fixes #390

**Problem Analysis:**

- Community Meeting details where removed from contributor site as part of [contributor-site/PR#380](https://github.com/kubernetes/contributor-site/pull/380) 
- The references of Meet our contributors were removed as part of [community/PR#7070](https://github.com/kubernetes/community/pull/7070)

**Proposed Solution:**

- ~Added direct link to the file for Kubernetes Monthly Community Meeting - [community-meeting.md](https://git.k8s.io/community/events/community-meeting.md#kubernetes-monthly-community-meeting)~  The community meeting reference has been removed (Update)
- Removed the mention on _Meet our contributors_ program from the page.
