### PR TITLE
Centralizing aliases under _redirects

### DIFF
--- a/content/en/community/awards/2019/index.md
+++ b/content/en/community/awards/2019/index.md
@@ -1,7 +1,6 @@
 ---
 title: "2019 Awards"
 weight: 1
-aliases: [ "/awards/2019" ]
 type: docs
 slug: "2019"
 description: "2019 Contributor Award Recipients"

--- a/content/en/community/awards/2020/index.md
+++ b/content/en/community/awards/2020/index.md
@@ -1,7 +1,6 @@
 ---
 title: "2020 Awards"
 weight: 1
-aliases: [ "/awards/2020" ]
 type: docs
 slug: "2020"
 description: "2020 Contributor Award Recipients"

--- a/content/en/community/awards/2021/index.md
+++ b/content/en/community/awards/2021/index.md
@@ -1,7 +1,6 @@
 ---
 title: "2021 Awards"
 weight: 1
-aliases: [ "/awards/2021" ]
 type: docs
 slug: "2021"
 description: "2021 Contributor Award Recipients"

--- a/content/en/community/awards/2022/index.md
+++ b/content/en/community/awards/2022/index.md
@@ -1,7 +1,6 @@
 ---
 title: "2022 Awards"
 weight: 1
-aliases: [ "/awards/2022" ]
 type: docs
 slug: "2022"
 description: "2022 Contributor Award Recipients"

--- a/content/en/community/awards/_index.md
+++ b/content/en/community/awards/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Contributor Awards"
 weight: 4
-aliases: [ "/awards" ]
 slug: "awards"
 description: |
   The Kubernetes Contributor Awards are an annual recognition of excellence

--- a/content/en/community/code-of-conduct.md
+++ b/content/en/community/code-of-conduct.md
@@ -1,7 +1,6 @@
 ---
 title: Code Of Conduct
 weight: 500
-aliases: [ "/coc", "/code-of-conduct" ]
 description: |
   The Code of Conduct serves as a set of rules used by the Kubernetes community
   to establish a safe, respectful and inclusive environment.

--- a/content/en/docs/comms/_index.md
+++ b/content/en/docs/comms/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Communication Platform Guidelines and Policies"
 weight: 3
-aliases: [ "/comms", "/communication" ]
 description: |
   The Kubernetes project uses many communication platforms and mediums, such as
   mailing lists, Zoom and Slack. This area covers guidelines, policies and best

--- a/content/en/docs/onboarding/_index.md
+++ b/content/en/docs/onboarding/_index.md
@@ -2,7 +2,6 @@
 title: "New Contributor Course"
 type: docs
 weight: 2
-aliases: [ "/course" ]
 description: |
     A high-level, multi-part course for those who are just starting out
 ---

--- a/content/en/events/2020/kcc/_index.md
+++ b/content/en/events/2020/kcc/_index.md
@@ -2,7 +2,6 @@
 title: "Contributor Celebration"
 weight: 1
 slug: "kcc2020"
-aliases: [ "/kcc2020" ]
 description: |
    It's been a rough year, and without any in person events we've lost the best
    part of the Contributor Summits - the Hallway Track. The Kubernetes Contributor

--- a/content/en/events/2021/kcc/_index.md
+++ b/content/en/events/2021/kcc/_index.md
@@ -2,7 +2,6 @@
 title: "Contributor Celebration"
 weight: 1
 slug: "kcc2021"
-aliases: [ "/celebration", "/kcc2021" ]
 description: |
    The Kubernetes Contributor Celebration is an annual end of year celebration
    where we recognize our accomplishments and have some fun! It's a time for us

--- a/content/en/events/2021/kcsna/_index.md
+++ b/content/en/events/2021/kcsna/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Contributor Summit North America 2021"
 type: docs
-aliases: [ "/kcsna2021" ]
 weight: 1
 description: >
   The Kubernetes Contributor Summits are returning for 2021!

--- a/content/en/events/2022/kcseu/_index.md
+++ b/content/en/events/2022/kcseu/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Contributor Summit Europe 2022"
 type: docs
-aliases: [ "/kcseu2022" ]
 weight: 1
 description: >
   Kubernetes Contributor Summit Europe, hosted in Valencia Spain.

--- a/content/en/events/2022/kcsna/_index.md
+++ b/content/en/events/2022/kcsna/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Contributor Summit North America 2022"
 type: docs
-aliases: [ "/kcsna2022", "/summit" ]
 weight: 1
 description: >
   Kubernetes Contributor Summit North America, hosted in Detroit Michigan.

--- a/content/en/events/2023/kcseu/_index.md
+++ b/content/en/events/2023/kcseu/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Contributor Summit Europe 2023"
 type: docs
-aliases: [ "/kcseu2023" , "/summit" ]
 weight: 1
 description: >
   Kubernetes Contributor Summit Europe, hosted in Amsterdam Netherlands.

--- a/content/en/resources/community-calendar.md
+++ b/content/en/resources/community-calendar.md
@@ -4,7 +4,6 @@ linkTitle: Community Calendar
 description: Meetings in the Kubernetes Community
 weight: 1
 type: calendar
-aliases: [ "/calendar" ]
 slug: calendar
 ---
 

--- a/content/en/resources/services.md
+++ b/content/en/resources/services.md
@@ -6,7 +6,6 @@ description: |
   as slack channels, github repos, tweets, netlify sites and more.
 weight: 1
 type: docs
-aliases: [ "/services", "/requests" ]
 slug: services
 ---
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,10 +1,37 @@
-###############################################
-# set server-side redirects in this file      #
-# see https://www.netlify.com/docs/redirects/ #
-# test at https://play.netlify.com/redirects  #
-###############################################
+####################################################
+# set server-side redirects in this file            #
+# see https://docs.netlify.com/routing/redirects/   #
+# test at https://redirects-playground.netlify.app/ #
+#####################################################
 
-/unconf https://github.com/kubernetes/community/issues/7157 302
-/notes  https://drive.google.com/drive/u/0/folders/1f-GChvcrbGW4TOOz2RTV6wRKOAyJRO-j  302
+/awards           /community/awards 301
+/awards/2019      /community/awards/2019 301
+/awards/2020      /community/awards/2020 301
+/awards/2021      /community/awards/2021 301
+/awards/2021      /community/awards/2022 301
 
+/calendar         /resources/calendar    301
 
+/coc              /community/code-of-conduct 301
+/code-of-conduct  /community/code-of-conduct  301
+
+/comms            /docs/comms  301
+/communication    /docs/comms  301
+
+/course           /docs/onboarding  301
+
+/kcc2020          /events/2020/kcc  301
+/kcc2021          /events/2021/kcc  301
+/celebration      /events/2021/kcc  302
+
+/kcsna2021        /events/2021/kcsna  301
+/kcseu2022        /events/2022/kcseu  301
+/kcsna2022        /events/2022/kcsna  301
+/kcsna2023        /events/2023/kcsna  301
+
+/services         /resources/services 301
+/requests         /resources/services 301
+
+/summit           /events/2023/kcsna  302
+/summit/unconf    https://github.com/kubernetes/community/issues/7157 302
+/summit/notes     https://drive.google.com/drive/u/0/folders/1f-GChvcrbGW4TOOz2RTV6wRKOAyJRO-j  302

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,10 @@
+###############################################
+# set server-side redirects in this file      #
+# see https://www.netlify.com/docs/redirects/ #
+# test at https://play.netlify.com/redirects  #
+###############################################
+
+/unconf https://github.com/kubernetes/community/issues/7157 302
+/notes  https://drive.google.com/drive/u/0/folders/1f-GChvcrbGW4TOOz2RTV6wRKOAyJRO-j  302
+
+


### PR DESCRIPTION
I was asked to add some redirects for the Contributor Summit. After some further investigation I found that we had two different /summit aliases. To prevent this in the future, centralizing aliases into one file is in line with the k8s.io site. Plus, it's a one stop shop for new aliases/redirects when they need to be added in the future.