### PR TITLE
Add note for Apple Silicon Mac Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ To ensure you can view the site with externally sourced content, run
 `make container-gen-content` before previewing the site by with
 `make container-server`.
 
+**NOTE to Apple Silicon Mac Users**
+
+Before proceeding with the build steps, please ensure that you set the
+`DOCKER_DEFAULT_PLATFORM` environment variable to `linux/amd64` by using the 
+following command: 
+
+```
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
 
 ### Natively
 


### PR DESCRIPTION
Resolves #406


#### Additional Context:
At the Contributor Summit'23 in the 'Working on the Contributor Site' session the suggestion of using `DOCKER_DEFAULT_PLATFORM=linux/amd64 `environment variable helped bypass the error on Apple Silicon Macs. As part of this PR adding a note about this in the readme to assist other users who may encounter the same issue.