### PR TITLE
KCS China 2023:Update mail address, CFP and registration link

### DIFF
--- a/content/en/events/2023/kcscn/_index.md
+++ b/content/en/events/2023/kcscn/_index.md
@@ -37,7 +37,9 @@ This event is in planning. Find materials here later:
 
 ### Call for Papers
 
-The CFP will go live soon!
+A [CFP] for sessions is open through Sunday, September 10th.
+
+[CFP]: https://wj.qq.com/s2/12996651/2260/
 
 ### Code of Conduct
 

--- a/content/en/events/2023/kcscn/_index.md
+++ b/content/en/events/2023/kcscn/_index.md
@@ -22,7 +22,7 @@ potential SIG and WG group meetings.
 
 This page will be updated as more activities are scheduled. If you have
 questions or comments, please reach out to the Summit Staff by emailing
-summit-staff@kubernetes.io or asking in the
+summit-team@kubernetes.io or asking in the
 <a href="https://kubernetes.slack.com/messages/contributor-summit" rel="noopener noreferrer" target="_blank">#contributor-summit</a>
 slack channel.
 

--- a/content/en/events/2023/kcscn/faq.md
+++ b/content/en/events/2023/kcscn/faq.md
@@ -94,4 +94,4 @@ You can [email us] or pop into the
 <a href="https://kubernetes.slack.com/messages/contributor-summit" rel="noopener noreferrer" target="_blank">
 #contributor-summit</a> Slack channel to ask a question. :)
 
-[email us]: mailto:summit-staff@kubernetes.io
+[email us]: mailto:summit-team@kubernetes.io

--- a/content/en/events/2023/kcscn/registration.md
+++ b/content/en/events/2023/kcscn/registration.md
@@ -16,7 +16,7 @@ contact us at summit-team@kubernetes.io about registering.
 If you acknowledge the above, please go ahead and click below to register:
 
 <h3>
-<a href="TODO" rel="noopener noreferrer" target="_blank">Register Here</a>
+<a href="https://wj.qq.com/s2/12996651/2260/" rel="noopener noreferrer" target="_blank">Register Here</a>
 </h3>
 
 [Kubernetes orgs]: /events/2023/kcscn/faq/#why-do-i-need-to-be-a-kubernetes-org-member-to-attend-in-person

--- a/content/en/events/2023/kcscn/registration.md
+++ b/content/en/events/2023/kcscn/registration.md
@@ -9,7 +9,7 @@ Registration is open to all members of one of the [Kubernetes orgs].
 If you are not yet a member, but active within the project, please consider
 joining! The process of joining is straight forward. See our [org membership]
 docs for more information. If your application to join is pending, please
-contact us at summit-staff@kubernetes.io about registering.
+contact us at summit-team@kubernetes.io about registering.
 
 **NOTE:** The summit adheres to KubeCon’s [Health & Safety Guidelines]
 

--- a/content/en/events/2023/kcscn/schedule.md
+++ b/content/en/events/2023/kcscn/schedule.md
@@ -8,7 +8,9 @@ weight: 3
 
 ## CFP
 
-Check back later! The CFP coming soon!
+A [CFP] for sessions is open through Sunday, September 10th.
+
+[CFP]: https://wj.qq.com/s2/12996651/2260/
 
 ## Unconference
 


### PR DESCRIPTION
Update some info:
- Update contact mail to summit-team@kubernetes.io
- KCS China 2023: Update CFP & registration link

/cc @pacoxu @kevin-wangzefeng 