### PR TITLE
[1.29] bump kubernetes release information page

### DIFF
--- a/external-sources/kubernetes/sig-release
+++ b/external-sources/kubernetes/sig-release
@@ -1,1 +1,1 @@
-"/releases/release-1.28/README.md","/resources/release/index.md"
+"/releases/release-1.29/README.md","/resources/release/index.md"


### PR DESCRIPTION
PR updates the https://www.kubernetes.dev/resources/release/ page to point to the ongoing [1.29 Release cycle timeline](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.29/README.md).


cc: @kubernetes/sig-release-leads, @salaxander 