### PR TITLE
Adding canonical post for 2023 steering election

### DIFF
--- a/content/en/blog/2023/2023-10-02-steering-committee-results-2023.md
+++ b/content/en/blog/2023/2023-10-02-steering-committee-results-2023.md
@@ -1,0 +1,61 @@
+---
+layout: blog
+title: "Announcing the 2023 Steering Committee Election Results"
+date: 2023-10-02
+slug: steering-committee-results-2023
+author: "Kaslin Fields"
+---
+
+The [2023 Steering Committee Election](https://github.com/kubernetes/community/tree/master/events/elections/2023) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2023. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
+
+This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/master/charter.md).
+
+Thank you to everyone who voted in the election; your participation helps support the community’s continued health and success.
+
+## Results
+
+Congratulations to the elected committee members whose two year terms begin immediately (listed in alphabetical order by GitHub handle):
+
+* **Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco**
+* **Paco Xu 徐俊杰 ([@pacoxu](https://github.com/pacoxu)), DaoCloud**
+* **Patrick Ohly ([@pohly](https://github.com/pohly)), Intel**
+* **Maciej Szulik ([@soltysh](https://github.com/soltysh)), Red Hat**
+
+They join continuing members:
+
+* **Benjamin Elder ([@bentheelder](https://github.com/bentheelder)), Google**
+* **Bob Killen ([@mrbobbytables](https://github.com/mrbobbytables)), Google**
+* **Nabarun Pal ([@palnabarun](https://github.com/palnabarun), VMware**
+
+Stephen Augustus is a returning Steering Committee Member.
+
+## Big Thanks!
+
+Thank you and congratulations on a successful election to this round’s election officers:
+
+* Bridget Kromhout ([@bridgetkromhout](https://github.com/bridgetkromhout))
+* Davanum Srinavas ([@dims](https://github.com/dims))
+* Kaslin Fields ([@kaslin](https://github.com/kaslin))
+
+
+Thanks to the Emeritus Steering Committee Members. Your service is appreciated by the community:
+
+
+* Christoph Blecker ([@cblecker](https://github.com/cblecker))
+* Carlos Tadeu Panato Jr. ([@cpanato](https://github.com/cpanato))
+* Tim Pepper ([@tpepper](https://github.com/tpepper))
+
+
+And thank you to all the candidates who came forward to run for election.
+
+## Get Involved with the Steering Committee
+
+This governing body, like all of Kubernetes, is open to all. You can follow along with Steering Committee [backlog items](https://github.com/orgs/kubernetes/projects/40) and weigh in by filing an issue or creating a PR against their [repo](https://github.com/kubernetes/steering). They have an open meeting on [the first Monday at 9:30am PT of every month](https://github.com/kubernetes/steering). They can also be contacted at their public mailing list steering@kubernetes.io.
+
+You can see what the Steering Committee meetings are all about by watching past meetings on the [YouTube Playlist](https://www.youtube.com/playlist?list=PL69nYSiGNLP1yP1B_nd9-drjoxp0Q14qM).
+
+If you want to meet some of the newly elected Steering Committee members, join us for the Steering AMA at the [Kubernetes Contributor Summit in Chicago](https://k8s.dev/summit).
+
+---
+
+_This post was written by the [Contributor Comms Subproject](https://github.com/kubernetes/community/tree/master/communication/contributor-comms). If you want to write stories about the Kubernetes community, learn more about us._


### PR DESCRIPTION
Adding correct canonical location for the blog post that went out yesterday, per @sftim as explained in https://github.com/kubernetes/website/pull/43294#issuecomment-1744076802.

Will follow up with a PR to link the kubernetes.io blog post with the right canonical url frontmatter.