### PR TITLE
Fix broken Slack server invitation link in "New Contributor Course" slides

### DIFF
--- a/content/en/docs/onboarding/08-community.md
+++ b/content/en/docs/onboarding/08-community.md
@@ -83,7 +83,7 @@ Community-wide notifications and discussions are always sent to the [Kubernetes 
 The Kubernetes Slack server has over 500 channels! 
 
 * First, get familiar with our [Slack communication guidelines](/docs/comms/slack/).
-* Then [join our Slack server here](slack.k8s.io)!
+* Then [join our Slack server here](https://slack.k8s.io)!
 
 ---
 


### PR DESCRIPTION
Fixing a link in the contributor onboard slides.

Resolves #446 