### PR TITLE
upgrade hugo, swap to hugo modules, upgrade docsy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/docsy"]
-	path = themes/docsy
-	url = https://github.com/google/docsy.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM alpine:latest
-ARG HUGO_VERSION=0.69.2
+FROM golang:1.20.3-alpine
+
+ARG HUGO_VERSION=0.120.4
 
 RUN apk add --no-cache \
     bash \
@@ -20,13 +21,9 @@ RUN npm install -G \
     autoprefixer \
     postcss-cli
 
-RUN mkdir -p /usr/local/src && \
-    cd /usr/local/src && \
-    curl -L https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz | tar -xz && \
-    mv hugo /usr/local/bin/hugo && \
+RUN CGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@v${HUGO_VERSION} && \
     addgroup -Sg 1000 hugo && \
     adduser -Sg hugo -u 1000 -h /src hugo
-
 
 USER hugo:hugo
 

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,9 @@ gen-content: ## Generates content from external sources.
 	hack/gen-content.sh
 
 render: ## Build the site using Hugo on the host.
-	git submodule update --init --recursive --depth 1
 	hugo --verbose --ignoreCache --minify
 
 server: ## Run Hugo locally (if Hugo "extended" is installed locally)
-	git submodule update --init --recursive --depth 1
 	hugo server \
 		--verbose \
 		--buildDrafts \
@@ -67,7 +65,6 @@ docker-render:
 	$(MAKE) container-render
 
 container-render: ## Build the site using Hugo within a container (equiv to render).
-	git submodule update --init --recursive --depth 1
 	$(CONTAINER_RUN) $(CONTAINER_IMAGE) hugo --verbose --ignoreCache --minify
 
 docker-server:
@@ -76,16 +73,12 @@ docker-server:
 
 container-server: ## Run Hugo locally within a container, available at http://localhost:1313/
 	# no build lock to allow for read-only mounts
-	git submodule update --init --recursive --depth 1
 	$(CONTAINER_RUN) -p 1313:1313 \
-		--mount type=tmpfs,destination=/tmp,tmpfs-mode=01777 \
-		--read-only \
-		--cap-drop=ALL \
-		--cap-drop=AUDIT_WRITE \
 		$(CONTAINER_IMAGE) \
 	bash -c 'cd /src && hack/gen-content.sh --in-container && \
 		 cd /tmp/src && \
 		hugo server \
+		--poll 700ms \
 		--verbose \
 		--noBuildLock \
 		--bind 0.0.0.0 \
@@ -128,7 +121,6 @@ clean-all: ## Cleans both build artifacts and files sycned to content directory
 
 production-build: ## Builds the production site (this command used only by Netlify).
 	$(BLOCK_STDOUT_CMD)
-	git submodule update --init --recursive --depth 1
 	hack/gen-content.sh
 	hugo \
 		--verbose \
@@ -137,7 +129,6 @@ production-build: ## Builds the production site (this command used only by Netli
 
 preview-build: ## Builds a deploy preview of the site (this command used only by Netlify).
 	$(BLOCK_STDOUT_CMD)
-	git submodule update --init --recursive --depth 1
 	hack/gen-content.sh
 	hugo \
 		--verbose \

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -132,3 +132,11 @@ $navbar-dark-disabled-color: rgba($white, 0.25);
 
 // The yiq lightness value that determines when the lightness of color changes from "dark" to "light".
 $yiq-contrasted-threshold: 200;
+
+// This is a hack to fix the CSS issues post-Docsy Upgrade
+.font-weight-bold, h1.display-1{
+    font-weight: $font-weight-bold !important;
+}
+div.d-none{
+    display: none !important;
+}

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -45,9 +45,10 @@ $code-color: darken($secondary, 20%);
 
 // UI element colors
 
-$border-color: $gray-300;
-$td-sidebar-bg-color: rgba($primary, 0.03);
-$td-sidebar-border-color: $border-color;
+$border-color: $gray-300 !default;
+$td-sidebar-tree-root-color: $primary !default;
+$td-sidebar-bg-color: rgba($primary, 0.03) !default;
+$td-sidebar-border-color: $border-color !default;
 
 // Background colors for the sections on home page etc. It is a paint by number system, starting at 0, where the number is taken from the shortcode's ordinal
 // if not provided by the user.
@@ -60,6 +61,8 @@ $link-hover-color: darken($link-color, 15%);
 $link-hover-decoration: none;
 
 // Fonts
+
+$font-awesome-font-name: "Open Sans" !default;
 
 $google_font_name: "Open Sans";
 $google_font_family: "Open+Sans:300,300i,400,400i,700,700i";

--- a/content/en/code-of-conduct.md
+++ b/content/en/code-of-conduct.md
@@ -1,0 +1,108 @@
+---
+title: Code Of Conduct
+---
+
+## CNCF Community Code of Conduct v1.3
+
+Other languages available:
+- [Arabic/العربية](code-of-conduct-languages/ar.md)
+- [Bulgarian/Български](code-of-conduct-languages/bg.md)
+- [Chinese/中文](code-of-conduct-languages/zh.md)
+- [Czech/Česky](code-of-conduct-languages/cs.md)
+- [Farsi/فارسی](code-of-conduct-languages/fa.md)
+- [French/Français](code-of-conduct-languages/fr.md)
+- [German/Deutsch](code-of-conduct-languages/de.md)
+- [Hindi/हिन्दी](code-of-conduct-languages/hi.md)
+- [Indonesian/Bahasa Indonesia](code-of-conduct-languages/id.md)
+- [Italian/Italiano](code-of-conduct-languages/it.md)
+- [Japanese/日本語](code-of-conduct-languages/jp.md)
+- [Korean/한국어](code-of-conduct-languages/ko.md)
+- [Polish/Polski](code-of-conduct-languages/pl.md)
+- [Portuguese/Português](code-of-conduct-languages/pt.md)
+- [Russian/Русский](code-of-conduct-languages/ru.md)
+- [Spanish/Español](code-of-conduct-languages/es.md)
+- [Turkish/Türkçe](code-of-conduct-languages/tr.md)
+- [Ukrainian/Українська](code-of-conduct-languages/uk.md)
+- [Vietnamese/Tiếng Việt](code-of-conduct-languages/vi.md)
+
+### Community Code of Conduct
+
+As contributors, maintainers, and participants in the CNCF community, and in the interest of fostering
+an open and welcoming community, we pledge to respect all people who participate or contribute
+through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, attending conferences or events, or engaging in other community or project activities.
+
+We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of age, body size, caste, disability, ethnicity, level of experience, family status, gender, gender identity and expression, marital status, military or veteran status, nationality, personal appearance, race, religion, sexual orientation, socioeconomic status, tribe, or any other dimension of diversity.
+
+## Scope
+
+This code of conduct applies:
+* within project and community spaces,
+* in other spaces when an individual CNCF community participant's words or actions are directed at or are about a CNCF project, the CNCF community, or another CNCF community participant.
+
+### CNCF Events
+
+CNCF events that are produced by the Linux Foundation with professional events staff are governed by the Linux Foundation [Events Code of Conduct](https://events.linuxfoundation.org/code-of-conduct/) available on the event page. This is designed to be used in conjunction with the CNCF Code of Conduct.
+
+## Our Standards
+
+The CNCF Community is open, inclusive and respectful. Every member of our community has the right to have their identity respected.
+
+Examples of behavior that contributes to a positive environment include but are not limited to:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+* Using welcoming and inclusive language
+
+
+Examples of unacceptable behavior include but are not limited to:
+
+* The use of sexualized language or imagery
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment in any form
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Violence, threatening violence, or encouraging others to engage in violent behavior
+* Stalking or following someone without their consent
+* Unwelcome physical contact
+* Unwelcome sexual or romantic attention or advances
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+The following behaviors are also prohibited:
+* Providing knowingly false or misleading information in connection with a Code of Conduct investigation or otherwise intentionally tampering with an investigation.
+* Retaliating against a person because they reported an incident or provided information about an incident as a witness.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect
+of managing a CNCF project.
+Project maintainers who do not follow or enforce the Code of Conduct may be temporarily or permanently removed from the project team.
+
+## Reporting
+
+For incidents occurring in the Kubernetes community, contact the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. You can expect a response within three business days.
+
+For other projects, or for incidents that are project-agnostic or impact multiple CNCF projects, please contact the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) via <conduct@cncf.io>.  Alternatively, you can contact any of the individual members of the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) to submit your report. For more detailed instructions on how to submit a report, including how to submit a report anonymously, please see our [Incident Resolution Procedures](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). You can expect a response within three business days.
+
+For incidents occurring at CNCF event that is produced by the Linux Foundation, please contact <eventconduct@cncf.io>.
+
+## Enforcement
+
+Upon review and investigation of a reported incident, the CoC response team that has jurisdiction will determine what action is appropriate based on this Code of Conduct and its related documentation.
+
+For information about which Code of Conduct incidents are handled by project leadership, which incidents are handled by the CNCF Code of Conduct Committee, and which incidents are handled by the Linux Foundation (including its events team), see our [Jurisdiction Policy](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+
+## Amendments
+
+Consistent with the CNCF Charter, any substantive changes to this Code of Conduct must be approved by the Technical Oversight Committee.
+
+## Acknowledgements
+
+This Code of Conduct is adapted from the Contributor Covenant
+(http://contributor-covenant.org), version 2.0 available at
+http://contributor-covenant.org/version/2/0/code_of_conduct/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/kubernetes/contributor-site
+
+go 1.21
+
+require github.com/google/docsy v0.7.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.7.2 h1:KzhFgTd3taF1jq9HDemH3omlUqn9qfdE68sxRyTySpM=
+github.com/google/docsy v0.7.2/go.mod h1:ol3w2s1FBUzENdKSAEeNjtuaISUzHYHTw60xv5QH3Dg=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hack/gen-content.sh
+++ b/hack/gen-content.sh
@@ -117,7 +117,7 @@ process_content() {
   local ref_link_matches=()
 
   mapfile -t inline_link_matches < \
-    <(grep -o -i -P '\[(?!a\-z0\-9).+?\]\((?!mailto|\S+?@|<|>|\?|\!|@|#|\$|%|\^|&|\*|\))\K\S+?(?=\))' "$1")
+    <(grep -o -i -P '/\[(?!a\-z0\-9).+?\]\((?!mailto|\S+?@|<|>|\?|\!|@|#|\$|%|\^|&|\*|\))\K\S+?(?=\))/' "$1")
 
  if [[ -v inline_link_matches ]]; then
     for match in "${inline_link_matches[@]}"; do
@@ -136,7 +136,7 @@ process_content() {
   fi
 
   mapfile -t ref_link_matches < \
-    <(grep -o -i -P '^\[.+\]:\s*(?!mailto|\S+?@|<|>|\?|\!|@|#|\$|%|\^|&|\*)\K\S+$' "$1")
+    <(grep -o -i -P '/^\[.+\]:\s*(?!mailto|\S+?@|<|>|\?|\!|@|#|\$|%|\^|&|\*)\K\S+$/' "$1")
 
   if [[ -v ref_link_matches ]]; then
     for match in "${ref_link_matches[@]}"; do
@@ -176,7 +176,7 @@ expand_path() {
   filename="$(basename "$2")"
   [[ "$dirpath" == '.' || "$dirpath" == "/" ]] && dirpath=""
   expanded_path="$dirpath/$filename"
-  if echo "$2" | grep -q -P "^\.?\/?$expanded_path"; then
+  if echo "$2" | grep -q -P "/^\.?\/?$expanded_path/"; then
     echo "$expanded_path"
   else
     echo "${expanded_path##"$3"}"
@@ -202,7 +202,7 @@ gen_link() {
   # appended for generation of correct url rewrites. It may need to be further
   # updated if the external org/repo uses their own domain shortener similar to
   # git.k8s.io.
-  if echo "$generated_link" | grep -q -i -E "https?:\/\/((sigs|git)\.k8s\.io|(www\.)?github\.com\/(kubernetes(-(client|csi|incubator|sigs))?|cncf))"; then
+  if echo "$generated_link" | grep -q -i -E "/https?:\/\/((sigs|git)\.k8s\.io|(www\.)?github\.com\/(kubernetes(-(client|csi|incubator|sigs))?|cncf))/"; then
     local i; i=0
     while (( i < ${#glsrcs[@]} )); do
       local repo=""

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,8 +1,9 @@
 baseURL = "https://www.kubernetes.dev/"
 title = "Kubernetes Contributors"
-theme = ["docsy"]
 enableRobotsTXT = true
 enableGitInfo = false
+theme = ["github.com/google/docsy", "github.com/google/docsy/dependencies"]
+
 
 # Language settings
 contentDir = "content/en"
@@ -10,7 +11,7 @@ defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 enableMissingTranslationPlaceholders = true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy"]
 
 # Highlighting config
 pygmentsCodeFences = true
@@ -157,3 +158,10 @@ enable = true
 	url = "https://slack.k8s.io"
 	icon = "fab fa-slack"
         desc = "Chat with other project developers"
+
+[module]
+        proxy = "direct"
+        [[module.imports]]
+                path = "github.com/google/docsy"
+        [[module.imports]]
+                path = "github.com/google/docsy/dependencies"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.117.0"
+HUGO_VERSION = "0.120.4"
 HUGO_ENV = "production"
 
 [context.deploy-preview]


### PR DESCRIPTION
- Upgrades Hugo to 0.120.3
- Upgrades Docsy to 0.7.2
- Swaps to using `hugo mod` 
- Dockerfile workaround for https://github.com/gohugoio/hugo/issues/10839
- Updates `hack/gen-content.sh` to suppress `grep` warnings (see https://github.com/koalaman/shellcheck/issues/2573 for example)
- Content pulled in from a `gen-content` run. 