### PR TITLE
Don't default Hugo version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:latest
-ARG HUGO_VERSION=0.69.2
+
+# Specify HUGO_VERSION, or work it out automatically by using
+# "make container-image"
+ARG HUGO_VERSION
 
 RUN apk add --no-cache \
     bash \


### PR DESCRIPTION
For a container build, expect that this is happening wrapped in `make` (but still allow a local container image build where you specify the version of Hugo by hand)

/cc @JamesLaverack