### PR TITLE
Improve fetch for KEP data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ container-server: ## Run Hugo locally within a container, available at http://lo
 	bash -c 'cd /src && hack/gen-content.sh --in-container && \
 		 cd /tmp/src && \
 		hugo server \
+		--environment preview \
 		--verbose \
 		--noBuildLock \
 		--bind 0.0.0.0 \
@@ -131,6 +132,7 @@ production-build: ## Builds the production site (this command used only by Netli
 	git submodule update --init --recursive --depth 1
 	hack/gen-content.sh
 	hugo \
+		--environment production \
 		--verbose \
 		--ignoreCache \
 		--minify
@@ -140,6 +142,7 @@ preview-build: ## Builds a deploy preview of the site (this command used only by
 	git submodule update --init --recursive --depth 1
 	hack/gen-content.sh
 	hugo \
+		--environment preview \
 		--verbose \
 		--baseURL $(DEPLOY_PRIME_URL) \
 		--buildDrafts \

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,3 +1,4 @@
+{{- $kepDataSourceUrl := "https://storage.googleapis.com/k8s-keps/keps.json" -}}
 {{/*
   Datatables is used in the page to enrich the list of KEPs.
   The stylesheets and scripts required are in `partials/hooks/head-end.html`
@@ -7,6 +8,24 @@
   the `DataTable` initialization in `partials/hooks/body-end.html`
 
 */}}
+{{- $kepData := "" -}}
+{{- with resources.GetRemote $kepDataSourceUrl -}}
+  {{- with .Err -}}
+    {{- if eq hugo.Environment "production" }}
+      {{ errorf "Unable to load CVE Feed: %s" }}
+    {{- else -}}
+      {{- warnf "Cannot load CVE Feed: %s" -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $kepData = .Content | transform.Unmarshal -}}
+  {{- end -}}
+{{- else -}}
+  {{- if eq hugo.Environment "production" }}
+    {{- errorf "Unable to load CVE Feed: %s (source URL was %q)" $kepDataSourceUrl -}}
+  {{- else -}}
+    {{- warnf "Cannot load CVE Feed: %s" -}}
+  {{- end -}}
+{{- end -}}
 
 <div>
   <table id="keps-table" class="table table-hover mt-2 col-md-12 table-sm">
@@ -22,7 +41,7 @@
       </tr>
     </thead>
     <tbody>
-      {{range $index, $data := getJSON "https://storage.googleapis.com/k8s-keps/keps.json" }}
+      {{range $index, $data := $kepData}}
           <tr>
             <td>
               <a href="https://features.k8s.io/{{ $data.kepNumber }}">


### PR DESCRIPTION
- Use the supported method for fetching KEP data (`GetJSON` is deprecated)
- In support of that, let Hugo know what environment a build is targeting.

[_preview_](https://deploy-preview-490--kubernetes-contributor.netlify.app/resources/keps/) of the revised page / [original](https://k8s.dev/resources/keps/)
