### PR TITLE
Fix typo in name in SIG Architecture: Code Organization blog post

### DIFF
--- a/content/en/blog/2024/sig-arch-code-spotlight.md
+++ b/content/en/blog/2024/sig-arch-code-spotlight.md
@@ -9,7 +9,7 @@ author: "Frederico Muñoz (SAS Institute)"
 _This is the third interview of a SIG Architecture Spotlight series that will cover the different
 subprojects. We will cover [SIG Architecture: Code Organization](https://github.com/kubernetes/community/blob/e44c2c9d0d3023e7111d8b01ac93d54c8624ee91/sig-architecture/README.md#code-organization)._
 
-In this SIG Architecture spotlight I talked with [Madhav Jivrajan](https://github.com/MadhavJivrajani)
+In this SIG Architecture spotlight I talked with [Madhav Jivrajani](https://github.com/MadhavJivrajani)
 (VMware), a member of the Code Organization subproject.
 
 ## Introducing the Code Organization subproject


### PR DESCRIPTION
This fix syncs the  `contributor-site` content added here https://github.com/kubernetes/contributor-site/pull/493 with the `website` content added here https://github.com/kubernetes/website/pull/45725 and fixed here https://github.com/kubernetes/website/pull/45853 by @dims 