### PR TITLE
hack/gen-content.sh: fix bogus reference link mangling

### DIFF
--- a/hack/gen-content.sh
+++ b/hack/gen-content.sh
@@ -172,7 +172,7 @@ process_content() {
       replacement_link=$(gen_link "$replacement_link" "$2" "$3" "$4")
       if [[ "$match" != "$replacement_link" ]]; then
         echo "Update link: File: $1 Original: $match Updated: $replacement_link"
-        $SED -i -e "s|]:\s*$match|]: $replacement_link|g" "$1"
+        $SED -i -e "s|]:\s*$match\$|]: $replacement_link|g" "$1"
       fi
     done
   fi


### PR DESCRIPTION
Some pages downloaded by `gen-content.sh`  contain links to other pages. Some of these links are similar to each other--they can be subpages or even anchor links. [For example](https://github.com/kubernetes/community/blob/208d7a966c8a23b405baaa7c742c042b2ea3c377/communication/slack-guidelines.md?plain=1#L391C1-L406C123):

```
[slack-config]: ./slack-config/
[Channel Documentation]: ./slack-config/README.md
[Slack Config Documentation]: ./slack-config/README.md
[usergroups.yaml]: ./slack-config/usergroups.yaml
[User Group Documentation]: ./slack-config/README.md#usergroups
```

There's a corner case in gen-content.sh that [produces bogus links under these conditions](https://github.com/kubernetes/contributor-site/issues/509). This commit fixes it.

Here's a diff with the before an after for `content/`:

```
> diff -r ~/tmp/site-no-fix/ ~/tmp/site-with-fix/
diff -r /home/rul/tmp/site-no-fix/en/docs/comms/slack.md /home/rul/tmp/site-with-fix/en/docs/comms/slack.md
398c398
< [Channel Documentation]: https://github.com/kubernetes/community/blob/master/communication/slack-configREADME.md
---
> [Channel Documentation]: https://github.com/kubernetes/community/blob/master/communication/slack-config/README.md
400c400
< [Slack Config Documentation]: https://github.com/kubernetes/community/blob/master/communication/slack-configREADME.md
---
> [Slack Config Documentation]: https://github.com/kubernetes/community/blob/master/communication/slack-config/README.md
402,403c402,403
< [usergroups.yaml]: https://github.com/kubernetes/community/blob/master/communication/slack-configusergroups.yaml
< [User Group Documentation]: https://github.com/kubernetes/community/blob/master/communication/slack-configREADME.md#usergroups
---
> [usergroups.yaml]: https://github.com/kubernetes/community/blob/master/communication/slack-config/usergroups.yaml
> [User Group Documentation]: https://github.com/kubernetes/community/blob/master/communication/slack-config/README.md#usergroups
```

Fixes #509.