### PR TITLE
Add CFP info for KCSNA

### DIFF
--- a/content/en/events/2024/kcsna/_index.md
+++ b/content/en/events/2024/kcsna/_index.md
@@ -31,7 +31,9 @@ slack channel.
 
 ### Call for Session Proposals
 
-A CFP for sessions will be opened at a later point in time.
+A [CFP](https://forms.gle/5RJBiKtuYsBDYAsVA) for sessions will be open through Sunday, September 15th.
+
+[CFP]: (https://forms.gle/5RJBiKtuYsBDYAsVA)
 
 ### Code of Conduct
 

--- a/content/en/events/2024/kcsna/_index.md
+++ b/content/en/events/2024/kcsna/_index.md
@@ -31,9 +31,9 @@ slack channel.
 
 ### Call for Session Proposals
 
-A [CFP](https://forms.gle/5RJBiKtuYsBDYAsVA) for sessions will be open through Sunday, September 15th.
+A [CFP] for sessions will be open through Sunday, September 15th.
 
-[CFP]: (https://forms.gle/5RJBiKtuYsBDYAsVA)
+[CFP]: https://forms.gle/5RJBiKtuYsBDYAsVA
 
 ### Code of Conduct
 


### PR DESCRIPTION
This PR adds a link and deadline for the CFP for KCSNA 2024.

