### PR TITLE
Add placeholder page for the New Contributor Orientation.

### DIFF
--- a/content/en/docs/orientation/_index.md
+++ b/content/en/docs/orientation/_index.md
@@ -13,13 +13,8 @@ on Zoom.
 
 **Meeting Time**: every 3rd Tuesday of the month for 1 hour
 
-<a href="https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NXVpdGhoMWRyMGhpMDZjd[…]afef04s12ra0gkqql6fchjc%40group.calendar.google.com&scp=ALL" >EMEA/APAC-friendly: 1:30 PT / 8:30 UTC / 10:30 CET / 14:00 IST</a>
+For more information, including how to join, [visit the NCO Details page](https://github.com/kubernetes/community/tree/master/mentoring/new-contributor-orientation) in Github.
 
-<a href="https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MnZqMXVmazZhNWJ2aTNld[…]afef04s12ra0gkqql6fchjc%40group.calendar.google.com&scp=ALL" >AMER-friendly: 8:30 PT / 15:30 UTC / 17:30 CET / 21:00 IST</a>
-
-**[Zoom Link](https://zoom.us/j/94335417770)**
-This meeting will give you an Overview of the Kubernetes Project, and it's different working parts. There will be an explanation
-about the <a href="https://github.com/kubernetes/community/blob/master/community-membership.md">Contribution Ladder</a> and inner workings of the project.
 Also, please check out these resources:
 
 * [New contributors slack channel](https://kubernetes.slack.com/archives/C09R23FHP)

--- a/content/en/docs/orientation/_index.md
+++ b/content/en/docs/orientation/_index.md
@@ -1,0 +1,26 @@
+---
+title: "New Contributor Orientation Sessions"
+weight: 3
+description: |
+  The community conducts monthly online sessions to orient new Kubernetes
+  contributors.
+---
+
+If you're new to the Kubernetes community and looking for a place to contribute,
+it can be challenging to figure out how to get started.  New contributors should
+join us for one of the New Contributor Orientation sessions, held once a month
+on Zoom.
+
+**Meeting Time**: every 3rd Tuesday of the month for 1 hour
+
+**EMEA/APAC-friendly**: 1:30 PT / 8:30 UTC / 10:30 CET / 14:00 IST
+
+**AMER-friendly**: 8:30 PT / 15:30 UTC / 17:30 CET / 21:00 IST
+
+**[Zoom Link](https://zoom.us/j/94335417770)**
+
+Also, please check out these resources:
+
+* [New contributors slack channel](https://kubernetes.slack.com/archives/C09R23FHP)
+* [Kubernetes Dev Google group](https://groups.google.com/a/kubernetes.io/g/dev)
+* [New Contributor Course](https://k8s.dev/course)

--- a/content/en/docs/orientation/_index.md
+++ b/content/en/docs/orientation/_index.md
@@ -13,12 +13,13 @@ on Zoom.
 
 **Meeting Time**: every 3rd Tuesday of the month for 1 hour
 
-**EMEA/APAC-friendly**: 1:30 PT / 8:30 UTC / 10:30 CET / 14:00 IST
+<a href="https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NXVpdGhoMWRyMGhpMDZjd[…]afef04s12ra0gkqql6fchjc%40group.calendar.google.com&scp=ALL" >EMEA/APAC-friendly: 1:30 PT / 8:30 UTC / 10:30 CET / 14:00 IST</a>
 
-**AMER-friendly**: 8:30 PT / 15:30 UTC / 17:30 CET / 21:00 IST
+<a href="https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MnZqMXVmazZhNWJ2aTNld[…]afef04s12ra0gkqql6fchjc%40group.calendar.google.com&scp=ALL" >AMER-friendly: 8:30 PT / 15:30 UTC / 17:30 CET / 21:00 IST</a>
 
 **[Zoom Link](https://zoom.us/j/94335417770)**
-
+This meeting will give you an Overview of the Kubernetes Project, and it's different working parts. There will be an explanation
+about the <a href="https://github.com/kubernetes/community/blob/master/community-membership.md">Contribution Ladder</a> and inner workings of the project.
 Also, please check out these resources:
 
 * [New contributors slack channel](https://kubernetes.slack.com/archives/C09R23FHP)


### PR DESCRIPTION
Add a placeholder page so we have something to link to.

I dropped it in Documentation because that's where the New Contributor Course is.   It could also be in Events or Resources.

@kaslin @mfahlandt please review!