### PR TITLE
Update KCS faq and KCS registration page that KubeCon registration is required

### DIFF
--- a/content/en/events/2024/kcsna/faq.md
+++ b/content/en/events/2024/kcsna/faq.md
@@ -10,6 +10,7 @@ weight: 7
 - [What are the Health and Safety protocols](#what-are-the-health-and-safety-protocols)
 - [Why do I need to be a Kubernetes Org member to attend in-person?](#why-do-i-need-to-be-a-kubernetes-org-member-to-attend-in-person)
 - [What is a sponsored attendee?](#what-is-a-sponsored-attendee)
+- [Do I need to be registered for KubeCon to attend the Contributor Summit](#do-i-need-to-registered-for-kubecon-to-attend-the-contributor-summit)
 - [I have an idea for a session](#i-have-an-idea-for-a-session)
 - [My SIG wants to meet at the Summit](#my-sig-wants-to-meet-at-the-summit)
 - [Will there be a doc sprint?](#will-there-be-a-doc-sprint)
@@ -75,6 +76,10 @@ If you are a SIG lead or subproject lead and there is someone that is not yet
 an org member or from another project that might take part in a panel,
 SIG face-to-face meeting etc, you can sponsor them to attend the summit.
 Please [email us] to make arrangements.
+
+### Do I need to be registered for KubeCon to attend the Contributor Summit
+
+KubeCon registration is required for Contributor Summit attendees.
 
 ### I have an idea for a session
 

--- a/content/en/events/2024/kcsna/registration.md
+++ b/content/en/events/2024/kcsna/registration.md
@@ -16,6 +16,8 @@ If you are sponsored by a SIG Lead please fill in the SIG in the registration fo
 
 **NOTE:** The summit adheres to KubeCon’s [Health & Safety Guidelines]
 
+KubeCon registration is required for Contributor Summit attendees.
+
 If you acknowledge the above, please go ahead and click below to register:
 
 <h3>


### PR DESCRIPTION
This PR adds 2 additions about KubeCon registration requirements:
- an FAQ entry that KubeCon registration is required
- a line on the Registration page that KubeCon registration is required