### PR TITLE
[FIX]: Social venue walking direction image not displaying on website (KCSNA24)

### DIFF
--- a/content/en/events/2024/kcsna/social.md
+++ b/content/en/events/2024/kcsna/social.md
@@ -20,7 +20,7 @@ There will be food, live music, activities, and more!
 6 N Rio Grande St Suite 35<br/>
 Salt Lake City, UT, 84101<br/>
 
-![Walking directions from Salt Palace to Flanker](/content/en/events/2024/kcsna/kcs_na_social_walking_directions.png)
+![Walking directions from Salt Palace to Flanker](../kcs_na_social_walking_directions.png)
 
 ## Bringing A Guest
 


### PR DESCRIPTION
The last change in PR https://github.com/kubernetes/contributor-site/pull/540 did not correctly display the Social Venue Walking Direction image on the [socials page](https://www.kubernetes.dev/events/2024/kcsna/social/). This PR aims to resolve that.

cc @salaxander @stmcginnis @mfahlandt 

Screenshot:
![image](https://github.com/user-attachments/assets/a739c5aa-4c1f-4f03-b74b-9b68f2a1614d)
