### PR TITLE
[Fix/build]: Handling of CURDIR with spaces and resolve regex warnings in make container- commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 CONTAINER_ENGINE	?= docker
-CONTAINER_RUN		:= $(CONTAINER_ENGINE) run --user : --rm -it -v $(CURDIR):/src
+CONTAINER_RUN		:= $(CONTAINER_ENGINE) run --user : --rm -it -v "$(CURDIR):/src"
 HUGO_VERSION		:= $(shell grep ^HUGO_VERSION netlify.toml | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
 CONTAINER_IMAGE		:= k8s-contrib-site-hugo
 REPO_ROOT	:=${CURDIR}

--- a/hack/gen-content.sh
+++ b/hack/gen-content.sh
@@ -225,7 +225,7 @@ gen_link() {
   # appended for generation of correct url rewrites. It may need to be further
   # updated if the external org/repo uses their own domain shortener similar to
   # git.k8s.io.
-  if echo "$generated_link" | $GREP -q -i -E "https?:\/\/((sigs|git)\.k8s\.io|(www\.)?github\.com\/(kubernetes(-(client|csi|incubator|sigs))?|cncf))"; then
+  if echo "$generated_link" | $GREP -q -i -E "https?://((sigs|git)\.k8s\.io|(www\.)?github\.com/(kubernetes(-(client|csi|incubator|sigs))?|cncf))"; then
     local i; i=0
     while (( i < ${#glsrcs[@]} )); do
       local repo=""


### PR DESCRIPTION
### What this PR does:

- Fixes an issue where `make container-` commands fail when the CURDIR variable contains spaces. This is resolved by enclosing CURDIR in double quotes.
- Addresses warnings like "stray \ before /" during the execution of `make container-gen-content` and `make-container-server` commands. The issue was caused by unnecessary escaping of `/` in the regex, which has been removed.

### Screenshots: 
1.
 ![image](https://github.com/user-attachments/assets/3d32fbbb-fb8a-47a2-9a3d-a595c552b098)
2.
![image](https://github.com/user-attachments/assets/417d9066-f869-4fa8-9ca9-306dce194fc4)

