### PR TITLE
[Blog] Revise blog "Spotlight on Kubernetes Upstream Training in Japan"

### DIFF
--- a/content/en/blog/2024/k8s-upstream-training-japan-spotlight/k8s-upstream-training-japan-spotlight.md
+++ b/content/en/blog/2024/k8s-upstream-training-japan-spotlight/k8s-upstream-training-japan-spotlight.md
@@ -4,11 +4,9 @@ title: "Spotlight on Kubernetes Upstream Training in Japan"
 slug: k8s-upstream-training-japan-spotlight
 date: 2024-10-28
 author: >
-  [Junya Okabe](https://github.com/Okabe-Junya) (University of Tsukuba)
+  [Junya Okabe](https://github.com/Okabe-Junya) (University of Tsukuba) / 
   Organizing team of Kubernetes Upstream Training in Japan
 ---
-
-## About our team
 
 We are organizers of [Kubernetes Upstream Training in Japan](https://github.com/kubernetes-sigs/contributor-playground/tree/master/japan).
 Our team is composed of members who actively contribute to Kubernetes, including individuals who hold roles such as member, reviewer, approver, and chair.


### PR DESCRIPTION
following up #541

Revise blog article based on feedbacks

/assign sftim 
for approval

Deploy preview: https://deploy-preview-546--kubernetes-contributor.netlify.app/blog/2024/10/28/k8s-upstream-training-japan-spotlight/