### PR TITLE
fix: update the primary colour to align with the k8s branding

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -17,7 +17,7 @@ $td-enable-google-fonts: true;
 
 // Theme colors
 
-$primary: #30638E;
+$primary: #326CE5;
 $primary-light: lighten($primary, 75%);
 $secondary: #303030;
 $success: #3772FF;


### PR DESCRIPTION
Updated the primary colour of the site based on the k8s branding as discussed below.    
    
    Well, I would expect `$primary` to be `#326ce5`; can we do the small fix first and rebase this big one?

_Originally posted by @sftim in https://github.com/kubernetes/contributor-site/pull/531#discussion_r1827532103_