### PR TITLE
feat: move from a toml hugo config to a yaml one

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,159 +1,164 @@
-baseURL = "https://www.kubernetes.dev/"
-title = "Kubernetes Contributors"
-theme = ["docsy"]
-enableRobotsTXT = true
-enableGitInfo = false
+baseURL: 'https://www.kubernetes.dev/'
+title: Kubernetes Contributors
+theme:
+  - docsy
+enableRobotsTXT: true
+enableGitInfo: false
 
 # Language settings
-contentDir = "content/en"
-defaultContentLanguage = "en"
-defaultContentLanguageInSubdir = false
-enableMissingTranslationPlaceholders = true
+contentDir: content/en
+defaultContentLanguage: en
+defaultContentLanguageInSubdir: false
+enableMissingTranslationPlaceholders: true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds:
+  - taxonomy
+  - taxonomyTerm
 
 # Highlighting config
-pygmentsCodeFences = true
-pygmentsUseClasses = false
-pygmentsUseClassic = false
-pygmentsStyle = "tango"
+pygmentsCodeFences: true
+pygmentsUseClasses: false
+pygmentsUseClassic: false
+pygmentsStyle: tango
 
 # Configure how URLs look like per section.
-[permalinks]
-blog = "/:section/:year/:month/:day/:slug/"
+permalinks:
+  blog: '/:section/:year/:month/:day/:slug/'
 
 
 # Image processing configuration.
-[imaging]
-resampleFilter = "CatmullRom"
-quality = 75
-anchor = "smart"
+imaging:
+  resampleFilter: CatmullRom
+  quality: 75
+  anchor: smart
 
-[services]
-[services.googleAnalytics]
+services:
+  googleAnalytics:
 # Fake ID in support of [params.ui.feedback]. The real GA ID is set in the Netlify config.
-id = "UA-00000000-0"
+    id: UA-00000000-0
 
 # Hugo internal cacheing
-[caches]
- [caches.assets]
-  dir = ":cacheDir/_gen"
-  maxAge = -1
- [caches.getcsv]
-  dir = ":cacheDir/:project"
-  maxAge = "60s"
- [caches.getjson]
-  dir = ":cacheDir/:project"
-  maxAge = "60s"
- [caches.images]
-  dir = ":cacheDir/_images"
-  maxAge = -1
- [caches.modules]
-  dir = ":cacheDir/modules"
-  maxAge = -1
+caches:
+  assets:
+    dir: ':cacheDir/_gen'
+    maxAge: -1
+  getcsv:
+    dir: ':cacheDir/:project'
+    maxAge: 60s
+  getjson:
+    dir: ':cacheDir/:project'
+    maxAge: 60s
+  images:
+    dir: ':cacheDir/_images'
+    maxAge: -1
+  modules:
+    dir: ':cacheDir/modules'
+    maxAge: -1
 
 # Language configuration
 
-[languages]
-[languages.en]
-title = "Kubernetes Contributors"
-languageName ="English"
+languages:
+  en:
+    title: Kubernetes Contributors
+    languageName: English
 
-[markup]
-  [markup.goldmark]
-    [markup.goldmark.renderer]
-      unsafe = true
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
 
-
-[frontmatter]
-date = ["date", ":filename", "publishDate", "lastmod"]
+frontmatter:
+  date:
+    - date
+    - ':filename'
+    - publishDate
+    - lastmod
 
 # Everything below this are Site Params
-[params]
-copyright = "The Kubernetes Authors"
-privacy_policy = ""
+params:
+  copyright: The Kubernetes Authors
+  privacy_policy: ''
 
 # First one is picked as the Twitter card image if not set on page.
-# images = ["images/project-illustration.png"]
+  # images:
+  #   - "images/project-illustration.png"
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.
-version_menu = "Releases"
+  version_menu: Releases
 
 # Flag used in the "version-banner" partial to decide whether to display a
 # banner on every page indicating that this is an archived version of the docs.
 # Set this flag to "true" if you want to display the banner.
-archived_version = false
+  archived_version: false
 
 # The version number for the version of the docs represented in this doc set.
 # Used in the "version-banner" partial to display a version number for the
 # current doc set.
-version = "0.0"
+  version: '0.0'
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-# url_latest_version = "https://example.com"
+  # url_latest_version: "https://example.com"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-# mgithub_repo = "https://github.com/kubernetes-sigs/contributor-site"
+  # mgithub_repo: "https://github.com/kubernetes-sigs/contributor-site"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
-#github_project_repo = "https://github.com/google/docsy"
+  # github_project_repo: "https://github.com/google/docsy"
 
 # Specify a value here if your content directory is not in your repo's root directory
-# github_subdir = ""
+  # github_subdir: ""
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "8ad0f1b8442fece81"
+  gcs_engine_id: 8ad0f1b8442fece81
 
 # Enable Algolia DocSearch
-algolia_docsearch = false
+  algolia_docsearch: false
 
 # Enable Lunr.js offline search
-offlineSearch = false
+  offlineSearch: false
 
 # User interface configuration
-[params.ui]
+  ui:
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = true
+    sidebar_menu_compact: true
 #  Set to true to disable breadcrumb navigation.
-breadcrumb_disable = false
+    breadcrumb_disable: false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-sidebar_search_disable = false
+    sidebar_search_disable: false
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
-navbar_logo = true
+    navbar_logo: true
 # Set to true to disable the About link in the site footer
-footer_about_disable = false
+    footer_about_disable: false
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.
 # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
 # add "hide_feedback: true" to the page's front matter.
-[params.ui.feedback]
-enable = true
+    feedback:
+      enable: true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
 # yes = 'Glad to hear it! Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
-#no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
-
-[params.links]
+# no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
+  
+  links:
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
-[[params.links.user]]
-	name = "Kubernetes Dev Mailing List"
-	url = "https://groups.google.com/a/kubernetes.io/group/dev"
-	icon = "fa fa-envelope"
-        desc = "Discussion and help from your fellow users"
-[[params.links.user]]
-	name ="Twitter"
-	url = "https://twitter.com/K8sContributors"
-	icon = "fab fa-twitter"
-        desc = "Follow us on Twitter to get the latest news!"
+    user:
+      - name: Kubernetes Dev Mailing List
+        url: 'https://groups.google.com/a/kubernetes.io/group/dev'
+        icon: fa fa-envelope
+        desc: Discussion and help from your fellow users
+      - name: Twitter
+        url: 'https://twitter.com/K8sContributors'
+        icon: fab fa-twitter
+        desc: Follow us on Twitter to get the latest news!
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
-[[params.links.developer]]
-	name = "GitHub"
-	url = "https://github.com/kubernetes/community"
-	icon = "fab fa-github"
-        desc = "Home of the Kubernetes Community!"
-[[params.links.developer]]
-	name = "Slack"
-	url = "https://slack.k8s.io"
-	icon = "fab fa-slack"
-        desc = "Chat with other project developers"
+    developer:
+      - name: GitHub
+        url: 'https://github.com/kubernetes/community'
+        icon: fab fa-github
+        desc: Home of the Kubernetes Community!
+      - name: Slack
+        url: 'https://slack.k8s.io'
+        icon: fab fa-slack
+        desc: Chat with other project developers


### PR DESCRIPTION
Moving to YAML config for Hugo instead of TOML as Docsy itself has moved. This PR will also be a blocker for #531 as this change will be removed from that PR and rebased.
Reference [comment](https://github.com/kubernetes/contributor-site/pull/531?new_mergebox=true#discussion_r1827532753) by @sftim 
> I would make the move to YAML be its own separate PR.