### PR TITLE
refactor: remove pygments and other properties that are already default

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,43 +1,31 @@
 baseURL: 'https://www.kubernetes.dev/'
-title: Kubernetes Contributors
+title: &title Kubernetes Contributors # Create a reference to use later
 theme:
   - docsy
 themesDir: node_modules
 enableRobotsTXT: true
-enableGitInfo: false
 
 # Language settings
 contentDir: content/en
-defaultContentLanguage: en
-defaultContentLanguageInSubdir: false
-enableMissingTranslationPlaceholders: true
 
+enableMissingTranslationPlaceholders: true
 disableKinds:
   - taxonomy
-
-# Highlighting config
-pygmentsCodeFences: true
-pygmentsUseClasses: false
-pygmentsUseClassic: false
-pygmentsStyle: tango
 
 # Configure how URLs look like per section.
 permalinks:
   blog: '/:section/:year/:month/:day/:slug/'
 
-
 # Image processing configuration.
 imaging:
   resampleFilter: CatmullRom
-  quality: 75
-  anchor: smart
 
 services:
   googleAnalytics:
-# Fake ID in support of [params.ui.feedback]. The real GA ID is set in the Netlify config.
+    # Fake ID in support of [params.ui.feedback]. The real GA ID is set in the Netlify config.
     id: UA-00000000-0
 
-# Hugo internal cacheing
+# Hugo internal caching
 caches:
   assets:
     dir: ':cacheDir/_gen'
@@ -56,16 +44,18 @@ caches:
     maxAge: -1
 
 # Language configuration
-
 languages:
   en:
-    title: Kubernetes Contributors
+    title: *title # Use the YAML reference instead of repeating
     languageName: English
 
 markup:
   goldmark:
     renderer:
       unsafe: true
+  # Default highlight is tango for Docsy but the website uses emacs (for now)
+  highlight:
+    style: emacs
 
 frontmatter:
   date:
@@ -76,73 +66,30 @@ frontmatter:
 
 # Everything below this are Site Params
 params:
+  # This is used instead of the built-in top level `copyright` to utilize
+  # Docsy's partial which adds the copyright year automatically
   copyright: The Kubernetes Authors
-  privacy_policy: ''
-
-# First one is picked as the Twitter card image if not set on page.
-  # images:
-  #   - "images/project-illustration.png"
-
-# Menu title if your navbar has a versions selector to access old versions of your site.
-# This menu appears only if you have at least one [params.versions] set.
-  version_menu: Releases
-
-# Flag used in the "version-banner" partial to decide whether to display a
-# banner on every page indicating that this is an archived version of the docs.
-# Set this flag to "true" if you want to display the banner.
-  archived_version: false
-
-# The version number for the version of the docs represented in this doc set.
-# Used in the "version-banner" partial to display a version number for the
-# current doc set.
-  version: '0.0'
-
-# A link to latest version of the docs. Used in the "version-banner" partial to
-# point people to the main doc site.
-  # url_latest_version: "https://example.com"
-
-# Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-  # mgithub_repo: "https://github.com/kubernetes-sigs/contributor-site"
-# An optional link to a related project repo. For example, the sibling repository where your product code lives.
-  # github_project_repo: "https://github.com/google/docsy"
-
-# Specify a value here if your content directory is not in your repo's root directory
-  # github_subdir: ""
-
-# Google Custom Search Engine ID. Remove or comment out to disable search.
   gcs_engine_id: 8ad0f1b8442fece81
 
-# Enable Algolia DocSearch
-  algolia_docsearch: false
-
-# Enable Lunr.js offline search
-  offlineSearch: false
-
-# User interface configuration
+  # User interface configuration
   ui:
-# Enable to show the side bar menu in its compact state.
+    # Enable to show the sidebar menu in its compact state.
     sidebar_menu_compact: true
-#  Set to true to disable breadcrumb navigation.
-    breadcrumb_disable: false
-#  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-    sidebar_search_disable: false
-#  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
-    navbar_logo: true
-# Set to true to disable the About link in the site footer
+    # Set to true to disable the About link in the site footer
     footer_about_disable: false
 
-# Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
-# This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.
-# If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
-# add "hide_feedback: true" to the page's front matter.
+    # Adds an H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
+    # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.
+    # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
+    # add "hide_feedback: true" to the page's front matter.
     feedback:
       enable: true
-# The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-# yes = 'Glad to hear it! Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
-# no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
+    # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
+    # yes = 'Glad to hear it! Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
+    # no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
 
   links:
-# End user relevant links. These will show up on left side of footer and in the community page if you have one.
+    # End user relevant links. These will show up on left side of footer and in the community page if you have one.
     user:
       - name: Kubernetes Dev Mailing List
         url: 'https://groups.google.com/a/kubernetes.io/group/dev'
@@ -152,7 +99,7 @@ params:
         url: 'https://twitter.com/K8sContributors'
         icon: fab fa-twitter
         desc: Follow us on Twitter to get the latest news!
-# Developer relevant links. These will show up on right side of footer and in the community page if you have one.
+    # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: GitHub
         url: 'https://github.com/kubernetes/community'


### PR DESCRIPTION
Updated `hugo.yaml` removing some properties which are deprecated and or the same as the defaults.
- Remove pygments in config which closes #560 which includes `pygmentsCodeFences`, `pygmentsUseClasses`, `pygmentsUseClassic`, `pygmentsStyle`.
- Remove `enableGitInfo` as `false` is the default, see https://gohugo.io/getting-started/configuration/#enablegitinfo
- Remove `defaultContentLanguage` as `en` is the default, see https://gohugo.io/getting-started/configuration/#defaultcontentlanguage
- Remove `defaultContentLanguageInSubdir` as `false` is the default, see https://gohugo.io/getting-started/configuration/#defaultcontentlanguageinsubdir
- Remove `imaging.quality` as `75` is the default, see https://gohugo.io/content-management/image-processing/#quality
- Remove `imagine.anchor` as `smart` is the default, see https://gohugo.io/content-management/image-processing/#anchor
- Remove `privacy_policy` as an empty string does the same thing as not having the property
- Remove `version_menu`, `archived_version`, `version` as the site is not versioned.
- Remove `algolia_docsearch` and `offlineSearch` as only 1 method of searching can be enabled and Algolia search and offline search is disabled by default. See https://github.com/google/docsy/blob/e6d94771f3376c1f5f96c3be3f01759b529cdc8d/layouts/partials/head.html#L60 and https://www.docsy.dev/docs/adding-content/search/
- Remove `breadcrumb_disable` as `false` is the default. Breadcrumbs are enabled by default see https://www.docsy.dev/docs/adding-content/navigation/#breadcrumb-navigation
- Remove `sidebar_search_disable` as `false` is the default. Sidebar search is enabled by default see https://www.docsy.dev/docs/adding-content/search/#disabling-the-sidebar-search-box
- Remove `navbar_logo` as `true` is the default. Navbar logo is enabled by default see https://www.docsy.dev/docs/adding-content/iconsimages/#add-your-logo
- Use YAML references in `languages.en.title` as its already defined in `title`.
- Add `markup.highlight.style` as `emacs` to make the style the same as k8s.io. Although nothing is using highlight shortcode in the site right now.