### PR TITLE
Updated hugo version to 0.133.0

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -3,13 +3,13 @@
     {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
         {{ partial "reading-time.html" . }}
-    {{ end }}       
+    {{ end }}
 	{{ .Content }}
-	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.Params.DisqusShortname) }}
+	{{ if (.Site.Config.Services.Disqus.Shortname) }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}

--- a/layouts/_internal/google_analytics_gtag.html
+++ b/layouts/_internal/google_analytics_gtag.html
@@ -1,0 +1,47 @@
+{{/*
+  This is a temporary customisation to override docsy's use of deprecated Site.GoogleAnalytics and Site.DisqusShortname.
+  This file needs to be removed once Docsy has been updated to 0.10.0.
+*/}}
+
+{{/*
+
+  This is a modified copy of
+
+  https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/google_analytics.html,
+
+  specifically this version:
+
+  https://github.com/gohugoio/hugo/blob/f7e00c039ff3cea5f991b05c1e325666004cf129/tpl/tplimpl/embedded/templates/google_analytics.html
+
+  The only differences between this copy and the original are that we've dropped:
+
+  - The `{{ if hasPrefix . "G-"}}` condition
+  - The `{{ else }}` block
+  - The `anonymize_ip` argument to the `gtag()` call, since it is superfluous.
+    For details, see https://github.com/gohugoio/hugo/issues/10093.
+
+*/}}
+
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.Disable }}{{ with .Site.Config.Services.GoogleAnalytics.ID -}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script>
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+	gtag('config', '{{ . }}');
+}
+</script>
+{{- end }}{{ end -}}
+
+{{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.RespectDoNotTrack -}}
+var doNotTrack = false;
+{{- else -}}
+var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
+var doNotTrack = (dnt == "1" || dnt == "yes");
+{{- end -}}
+{{- end -}}

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -10,11 +10,11 @@
 	</header>
 	{{ .Content }}
         {{ partial "section-index.html" . }}
-	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.DisqusShortname) }}
+	{{ if (.Site.Config.Services.Disqus.Shortname) }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,18 +1,14 @@
+{{/*
+This is a temporary customisation to override docsy's use of deprecated Site.GoogleAnalytics and Site.DisqusShortname.
+This file needs to be removed once Docsy has been updated to 0.10.0.
+*/}}
+
 {{ define "main" }}
 <div class="td-content">
 	<h1>{{ .Title }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
-		{{ $context := . }}
-		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-			{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ else }}
-			{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ end }}
+		{{ partial "taxonomy_terms_article_wrapper.html" . }}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
 			{{ partial "reading-time.html" . }}
 		{{ end }}

--- a/layouts/partials/disqus-comment.html
+++ b/layouts/partials/disqus-comment.html
@@ -1,0 +1,28 @@
+{{/*
+This is a temporary customisation to override docsy's use of deprecated Site.GoogleAnalytics and Site.DisqusShortname.
+This file needs to be removed once Docsy has been updated to 0.10.0.
+*/}}
+
+<div class="page-blank">
+
+<div id="disqus_thread"></div>
+<script>
+
+/**
+*  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+*  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables*/
+/*
+var disqus_config = function () {
+this.page.url = PAGE_URL;  // Replace PAGE_URL with your page's canonical URL variable
+this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+};
+*/
+(function() { // DON'T EDIT BELOW THIS LINE
+var d = document, s = d.createElement('script');
+s.src = 'https://' + {{ .Site.Config.Services.Disqus.Shortname }} + '.disqus.com/embed.js';
+s.setAttribute('data-timestamp', +new Date());
+(d.head || d.body).appendChild(s);
+})();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+</div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,61 @@
+{{/*
+This is a temporary customisation to override docsy's use of deprecated Site.GoogleAnalytics and Site.DisqusShortname.
+It also includes use of "_internal/google_analytics.html" instead of "_internal/google_analytics_async.html" which is
+no longer present in Hugo.
+This file needs to be removed once Docsy has been updated to 0.10.0.
+*/}}
+
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+{{ hugo.Generator }}
+{{ range .AlternativeOutputFormats -}}
+<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+{{ end -}}
+
+{{ $outputFormat := partial "outputformat.html" . -}}
+{{ if and hugo.IsProduction (ne $outputFormat "print") -}}
+<meta name="robots" content="index, follow">
+{{ else -}}
+<meta name="robots" content="noindex, nofollow">
+{{ end -}}
+
+{{ partialCached "favicons.html" . }}
+<title>
+  {{- if .IsHome -}}
+    {{ .Site.Title -}}
+  {{ else -}}
+    {{ with .Title }}{{ . }} | {{ end -}}
+    {{ .Site.Title -}}
+  {{ end -}}
+</title>
+<meta name="description" content="{{ template "partials/page-description.html" . }}">
+{{ template "_internal/opengraph.html" . -}}
+{{ template "_internal/schema.html" . -}}
+{{ template "_internal/twitter_cards.html" . -}}
+{{ partialCached "head-css.html" . "asdf" -}}
+<script
+  src="https://code.jquery.com/jquery-3.6.0.min.js"
+  integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK"
+  crossorigin="anonymous"></script>
+{{ if .Site.Params.offlineSearch -}}
+<script defer
+  src="https://unpkg.com/lunr@2.3.9/lunr.min.js"
+  integrity="sha384-203J0SNzyqHby3iU6hzvzltrWi/M41wOP5Gu+BiJMz5nwKykbkUx8Kp7iti0Lpli"
+  crossorigin="anonymous"></script>
+{{ end -}}
+
+{{ if .Site.Params.prism_syntax_highlighting -}}
+<link rel="stylesheet" href="{{ "css/prism.css" | relURL }}"/>
+{{ end -}}
+
+{{ partial "hooks/head-end.html" . -}}
+
+{{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}
+{{ if hugo.IsProduction -}}
+  {{ $enableGtagForUniversalAnalytics := not .Site.Params.disableGtagForUniversalAnalytics -}}
+  {{ if (or $enableGtagForUniversalAnalytics (hasPrefix .Site.Config.Services.GoogleAnalytics.ID "G-")) -}}
+    {{ template "_internal/google_analytics_gtag.html" . -}}
+  {{ else -}}
+    {{ template "_internal/google_analytics.html" . -}}
+  {{ end -}}
+{{ end -}}

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -10,11 +10,11 @@
 	</header>
 	{{ .Content }}
         {{ partial "section-index.html" . }}
-	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.DisqusShortname) }}
+	{{ if (.Site.Config.Services.Disqus.Shortname) }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}

--- a/layouts/swagger/list.html
+++ b/layouts/swagger/list.html
@@ -1,18 +1,14 @@
+{{/*
+This is a temporary customisation to override docsy's use of deprecated Site.GoogleAnalytics and Site.DisqusShortname.
+This file needs to be removed once Docsy has been updated to 0.10.0.
+*/}}
+
 {{ define "main" }}
 <div class="td-content">
 	<h1>{{ .Title }}</h1>
-  {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
-		{{ $context := . }}
-		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-			{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ else }}
-			{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ end }}
+		{{ partial "taxonomy_terms_article_wrapper.html" . }}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
 			{{ partial "reading-time.html" . }}
 		{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.124.0"
+HUGO_VERSION = "0.133.0"
 NODE_VERSION = "20.16.0"
 HUGO_ENV = "production"
 


### PR DESCRIPTION
This update brings the hugo version in line with the k8s website. The current docsy version of 0.5.1 should support Hugo 0.133.0.