### PR TITLE
bump release v1.35

### DIFF
--- a/external-sources/kubernetes/sig-release
+++ b/external-sources/kubernetes/sig-release
@@ -1,1 +1,1 @@
-"/releases/release-1.34/README.md","/resources/release/index.md"
+"/releases/release-1.35/README.md","/resources/release/index.md"


### PR DESCRIPTION
https://groups.google.com/a/kubernetes.io/d/msgid/dev/CAPVdP5otPmwzhN%3D3oue1zXzebBjt0ARLoi4QgW-0RneEUQsNkA%40mail.gmail.com 

v1.35 Release Cycle timeline:
- Release Cycle begins – Monday 15th September 2025


https://github.com/kubernetes/sig-release/tree/master/releases/release-1.35