### PR TITLE
Add contributor website container image build automation

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,28 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+    # It's fine to bump the tag to a recent version, as needed
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079"
+    entrypoint: 'bash'
+    env:
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - TAG=$_GIT_TAG
+      - BASE_REF=$_PULL_BASE_REF
+    args:
+      - -c
+      - |
+        gcloud auth configure-docker \
+        && make container-push
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: "12345"
+  # _PULL_BASE_REF will contain the ref that was pushed to trigger this build -
+  # a branch like 'main' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: "master"


### PR DESCRIPTION
- Add automated build for the contributor website container image.
- Publish an official prebuilt image to simplify local setup.

(Note - Can be merged after PR ~[#8775](https://github.com/kubernetes/k8s.io/pull/8775)~ [#35958](https://github.com/kubernetes/test-infra/pull/35958) is merged.)

Fixes #565 