### PR TITLE
Add Award Recipients for 2025 to k8s.dev

### DIFF
--- a/content/en/community/awards/2025/index.md
+++ b/content/en/community/awards/2025/index.md
@@ -67,7 +67,7 @@ For his excellent work in aligning the Kubernetes website with upstream Docsy, w
 *Graziano Casto, [@graz-dev](https://github.com/graz-dev)*  
 For his helpful work on the Kubernetes Blog, which has led him to become a co-maintainer of our blog in a helpful, efficient, and kind manner. Graziano's reviews for authors are well-received, and he has generally mastered our blog guidelines to become a definitive authority within our small SIG Docs Blog team, which was sorely needed. We're incredibly grateful for Graziano's step-up into blog maintainer for the SIG.
 
-#### etcd
+#### SIG etcd
 
 *Joshua James, [@joshjms](https://github.com/joshjms)*  
 Joshua documented the process for bumping etcd versions in Kubernetes, has been working toward unifying etcd image management in Kubernetes, and has contributed to various project chores such as release and dependency updates.


### PR DESCRIPTION
This PR implements the changes requested in #599 by adding a new Awards subpage for 2025 and populating it with the official award recipients.

📄 What's included

- Created a new page `content/en/community/awards/2025/index.md`
- Added the full list of 2025 Award Recipients based on the official source (Google Slides reference provided in #599)
- Matched formatting and structure from the 2024 Awards

🔗 Fixes #599