### PR TITLE
Improve image versioning and add commit traceability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ STAGING_IMAGE_REGISTRY	:= us-central1-docker.pkg.dev/k8s-staging-images
 IMAGE_REGISTRY			?= ${STAGING_IMAGE_REGISTRY}/contributor-site
 IMAGE_NAME				:= k8s-contrib-site-hugo
 IMAGE_REPO				:= $(IMAGE_REGISTRY)/$(IMAGE_NAME)
-IMAGE_VERSION			:= $(shell git rev-parse --short HEAD)
+IMAGE_VERSION			:= $(shell scripts/hash-files.sh Dockerfile Makefile netlify.toml .dockerignore cloudbuild.yaml package.json package-lock.json | cut -c 1-12)
+COMMIT					:= $(shell git rev-parse --short HEAD)
 CONTAINER_RUN			:= $(CONTAINER_ENGINE) run --rm -it -v "$(CURDIR):/src"
 CONTAINER_RUN_TTY		:= $(CONTAINER_ENGINE) run --rm -it
 HUGO_VERSION			:= $(shell grep ^HUGO_VERSION netlify.toml | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
@@ -73,7 +74,7 @@ docker-image:
 	$(MAKE) container-image
 
 container-image: ## Build container image for use with container-* targets.
-	$(CONTAINER_ENGINE) build . -t $(CONTAINER_IMAGE) --build-arg HUGO_VERSION=$(HUGO_VERSION)
+	$(CONTAINER_ENGINE) build . -t $(CONTAINER_IMAGE) --label git_commit=$(COMMIT) --build-arg HUGO_VERSION=$(HUGO_VERSION)
 
 container-push: container-image ## Push container image for the preview of the website
 	$(CONTAINER_ENGINE) push $(CONTAINER_IMAGE)

--- a/scripts/hash-files.sh
+++ b/scripts/hash-files.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# this script emits as hash for the files listed in $@
+if command -v shasum >/dev/null 2>&1; then
+  cat "$@" | shasum -a 256 | cut -d' ' -f1
+elif command -v sha256sum >/dev/null 2>&1; then
+  cat "$@" | sha256sum | cut -d' ' -f1
+else
+  echo "missing shasum tool" 1>&2
+  exit 1
+fi


### PR DESCRIPTION
- Switch image versioning to use a hash of build-relevant files
- Ensure container images are rebuilt only when the build environment changes, reducing unnecessary builds (https://github.com/kubernetes/test-infra/pull/35983)
- Add Git commit SHA as an image label to improve traceability without forcing new image tags
- Prevent image rebuilds on pure content changes (Markdown, templates, docs)
- Keep reproducibility: image labels now map each image to the exact commit that produced it