### PR TITLE
Use kep.k8s.io instead of features.k8s.io

### DIFF
--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -44,7 +44,7 @@
       {{range $index, $data := $kepData}}
           <tr>
             <td>
-              <a href="https://features.k8s.io/{{ $data.kepNumber }}">
+              <a href="https://kep.k8s.io/{{ $data.kepNumber }}">
                 {{ printf "%s" $data.kepNumber }}
               </a>
             </td>


### PR DESCRIPTION
This PR fixes to use `kep.k8s.io` instead of old short URL `features.k8s.io` to reduce unnecessary redirection.

Previously, `features.k8s.io` was used as a short URL for each enhancement proposal. However, it has since changed to `kep.k8s.io`, likely because the repository was renamed from `kubernetes/features` to `kubernetes/enhancements` at some point. This results in one additional unnecessary redirection when initially accessing `features.k8s.io` compared to `kep.k8s.io`:

- `https://features.k8s.io/555` -> `https://github.com/kubernetes/features/issues/555` -> `https://github.com/kubernetes/enhancements/issues/555`
- `https://kep.k8s.io/555` -> `https://github.com/kubernetes/enhancements/issues/555`