### PR TITLE
fix: only enable analytics for production builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,8 @@ command = "make production-build"
 [build.environment]
 HUGO_VERSION = "0.133.0"
 NODE_VERSION = "20.16.0"
+
+[context.production.environment]
 HUGO_ENV = "production"
 
 [context.deploy-preview]


### PR DESCRIPTION
## Problem

Currently, analytics are enabled for all builds including deploy previews and branch deploys. This is because `HUGO_ENV = "production"` is set in the global `[build.environment]` section of `netlify.toml`, which applies to all build contexts.

## Solution

Move `HUGO_ENV = "production"` from the global `[build.environment]` section to `[context.production.environment]` so it only applies to production builds.

## Changes

- Removed `HUGO_ENV = "production"` from `[build.environment]`
- Added `[context.production.environment]` section with `HUGO_ENV = "production"`

## Result

- **Production builds**: `HUGO_ENV = "production"` → `hugo.IsProduction` is true → analytics enabled ✅
- **Preview builds**: `HUGO_ENV` not set → `hugo.IsProduction` is false → analytics disabled ✅

The Makefile already passes `--environment preview` for preview builds, so without the global override, Hugo will correctly use the preview environment.

Closes #357