### PR TITLE
Publish introducing-checkpoint-restore-wg blog article

### DIFF
--- a/content/en/blog/2026/announcing-checkpoint-restore-wg.md
+++ b/content/en/blog/2026/announcing-checkpoint-restore-wg.md
@@ -1,7 +1,6 @@
 ---
 title: "Announcing the Checkpoint/Restore Working Group"
-date: 2026-XX-XX
-draft: true
+date: 2026-01-21
 slug: introducing-checkpoint-restore-wg
 author: >
   [Radostin Stoyanov](https://github.com/rst0git),


### PR DESCRIPTION
Set publication date to 2026-01-21 for blog post ["Announcing the Checkpoint/Restore Working Group"](https://github.com/kubernetes/contributor-site/blob/master/content/en/blog/2026/announcing-checkpoint-restore-wg.md).

[Preview](https://deploy-preview-620--kubernetes-contributor.netlify.app/blog/2026/01/21/introducing-checkpoint-restore-wg/)

Reference: https://github.com/kubernetes/website/pull/54015