### PR TITLE
feat(events): add 2025 maintainer summit websites

### DIFF
--- a/content/en/events/2025/_index.md
+++ b/content/en/events/2025/_index.md
@@ -1,0 +1,6 @@
+---
+title: 2025
+description: Events and community wide activities held during 2025
+type: docs
+weight: 1
+---

--- a/content/en/events/2025/kcseu/_index.md
+++ b/content/en/events/2025/kcseu/_index.md
@@ -1,0 +1,37 @@
+---
+title: "Maintainer Summit Europe 2025"
+type: docs
+weight: 1
+description: >
+  Kubernetes Maintainer Summit Europe, hosted in London, United Kingdom.
+---
+
+### Event Summary
+
+The European edition of the Maintainer Summit took place on March 31st, 2025, in London, United Kingdom, alongside 
+<a href="https://events.linuxfoundation.org/archive/2025/kubecon-cloudnativecon-europe/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon Europe 2025</a>.
+
+The Summit featured a mix of technical sessions, including:
+
+* **Unconference Tracks:** Several hours of spontaneous, peer-led deep dives into contributor experience and technical bottlenecks.
+* **SIG & WG Meetings:** In-person sessions for Special Interest Groups and Working Groups to align on 2026 roadmaps.
+
+---
+
+### Recordings & Presentations
+
+* **Watch Sessions:** Recordings from the summit are available on the [CNCF YouTube Channel](https://www.youtube.com/playlist?list=PLj6h78yzYM2PfvoC5c0702tr4rk-W6KS4).
+* **Event Schedule:** The full list of sessions and speakers is hosted on [Sched](https://maintainersummiteu2025.sched.com/).
+* **Slide Decks:** Presentation materials were uploaded by speakers to their respective session pages on the schedule.
+
+---
+
+### Call for Session Proposals
+
+The Call for Papers (CFP) for this event is closed. For historical reference, you can review the original session tracks and descriptions on the [event schedule](https://maintainersummitna2025.sched.com/list/descriptions).
+
+### Code of Conduct
+
+Attendees participated under the Kubernetes [Code of Conduct].
+
+[Code of Conduct]: /community/code-of-conduct

--- a/content/en/events/2025/kcsna/_index.md
+++ b/content/en/events/2025/kcsna/_index.md
@@ -1,0 +1,37 @@
+---
+title: "Maintainer Summit North America 2025"
+type: docs
+weight: 1
+description: >
+  Kubernetes Maintainer Summit North America, hosted in Atlanta, Georgia.
+---
+
+### Event Summary
+
+The North America edition of the Maintainer Summit took place on **November 10th, 2025**, in Atlanta, Georgia. The event was co-located with 
+<a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon North America 2025</a>.
+
+The Summit provided a dedicated space for the maintainer community to collaborate through:
+
+* **Unconference Tracks:** Several hours of spontaneous, peer-led deep dives into contributor experience and technical bottlenecks.
+* **SIG & WG Meetings:** In-person sessions for Special Interest Groups and Working Groups to align on 2026 roadmaps.
+
+---
+
+### Recordings & Presentations
+
+* **Watch Sessions:** Recordings from the summit are available on the [CNCF YouTube Channel](https://www.youtube.com/playlist?list=PLj6h78yzYM2OPbGEIqJk2AT25wGu9mY8V).
+* **Event Schedule:** The full list of sessions and speakers is hosted on [Sched](https://maintainersummitna2025.sched.com/).
+* **Slide Decks:** Slide decks and presentation PDFs are available via the individual session links on the schedule.
+
+---
+
+### Call for Session Proposals
+
+The Call for Papers (CFP) for this event is closed. For historical reference, you can review the original session tracks and descriptions on the [event schedule](https://maintainersummitna2025.sched.com/list/descriptions).
+
+### Code of Conduct
+
+Attendees participated under the Kubernetes [Code of Conduct].
+
+[Code of Conduct]: /community/code-of-conduct


### PR DESCRIPTION
Add 2025 Maintainer Summit websites for EU and NA.

Relates to #590