### PR TITLE
feat(content): add 2026 maintainer summit EU 2026

### DIFF
--- a/content/en/events/2026/_index.md
+++ b/content/en/events/2026/_index.md
@@ -1,0 +1,6 @@
+---
+title: 2026
+description: Events and community wide activities held during 2026
+type: docs
+weight: 1
+---

--- a/content/en/events/2026/kcseu/_index.md
+++ b/content/en/events/2026/kcseu/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Maintainer Summit Europe 2026"
+type: docs
+weight: 1
+description: >
+  Kubernetes Maintainer Summit Europe, hosted in Amsterdam, Netherlands.
+---
+
+### About
+
+The European edition of the Maintainer Summit will take place on **March 23, 2026**, in Amsterdam, Netherlands, alongside 
+<a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon Europe 2026</a>.
+
+The Summit is a dedicated day for Kubernetes maintainers to collaborate in person. The event will feature:
+
+* **Submitted Talks:** Technical deep dives and project health updates.
+* **Unconference Sessions:** Open-space discussions for spontaneous problem-solving and SIG alignment.
+* **Documentation Sprint:** A collaborative session focused on improving project resources.
+* **Contributor Social:** An evening of games and networking following the technical tracks.
+
+### 📅 Schedule & Participation
+
+- **Call for Proposals (CFP):** Check the [event schedule](https://maintainersummiteu2026.sched.com/) for submission deadlines.
+- **Registration:** [Register here](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/features-add-ons/maintainer-summit/#registration).
+
+### Eligibility
+
+Who can attend Maintainer Summit?
+
+* Sandbox Project Maintainers
+* Incubating Project Org Members
+* Graduated Project Org Members
+* CNCF TOC Members
+* CNCF TAG Chairs, Technical Leads and Working Group Leads
+
+For more information, please visit the [official event page](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/features-add-ons/maintainer-summit/).
+
+### 🤝 Code of Conduct
+
+Attendees agree to abide by the Kubernetes [Code of Conduct](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/code-of-conduct/). To report an incident, please reach out to the [CNCF event staff](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/code-of-conduct/).

--- a/content/en/events/2026/kcsna/_index.md
+++ b/content/en/events/2026/kcsna/_index.md
@@ -1,0 +1,34 @@
+---
+title: "Maintainer Summit North America 2026"
+type: docs
+weight: 1
+description: >
+  Kubernetes Maintainer Summit North America, hosted in Salt Lake City, Utah.
+---
+
+### About
+
+The North America edition of the Maintainer Summit will take place on **October 26, 2026**, in Salt Lake City, Utah, alongside 
+<a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon North America 2026</a>.
+
+This summit provides a space for the North American contributor community to synchronize on the final releases of the year and plan for 2027.
+
+The day's agenda includes:
+* **Roadmap Deep Dives:** Dedicated sessions for SIGs and Working Groups.
+* **Contributor Experience Tracks:** Focused on mentoring and project sustainability.
+* **The "Hallway Track":** Ample time for peer-to-peer networking and collaboration.
+
+### 📅 Key Dates
+
+- **CFP Opening:** Expected mid-2026. 
+- **Event Date:** Monday, October 26, 2026.
+
+### 🤝 Code of Conduct
+
+Attendees agree to abide by the Kubernetes [Code of Conduct]. The CNCF is committed to providing a safe and welcoming experience for all participants.
+
+[location]: /events/2026/kcsna/location/
+[Code of Conduct]: /community/code-of-conduct
+[CNCF event staff]: https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/attend/code-of-conduct/
+
+[email us]: mailto:summit-team@kubernetes.io


### PR DESCRIPTION
Adds 2026 maintainer summits content for North America and Europe.

Closes #590