### PR TITLE
feat(content): add youtube link to footer

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -91,6 +91,10 @@ params:
   links:
     # End user relevant links. These will show up on left side of footer and in the community page if you have one.
     user:
+      - name: YouTube
+        url: 'https://youtube.com/kubernetescommunity'
+        icon: fab fa-youtube
+        desc: Kubernetes Community on YouTube
       - name: Kubernetes Dev Mailing List
         url: 'https://groups.google.com/a/kubernetes.io/group/dev'
         icon: fa fa-envelope


### PR DESCRIPTION
**Description:**
Adds the YouTube link to the footer navigation, ordered before the Mailing List.

**Changes:**
- Adds YouTube link to `hugo.yaml`
- Reorders footer links: YouTube, Mailing List, LinkedIn, X

**Related Issue:**
Closes #635
