### PR TITLE
feat(content): add mastodon link to footer

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -103,6 +103,10 @@ params:
         url: 'https://www.linkedin.com/company/kubernetes'
         icon: fab fa-linkedin
         desc: "Kubernetes on LinkedIn"
+      - name: Mastodon
+        url: 'https://hachyderm.io/@K8sContributors'
+        icon: fab fa-mastodon
+        desc: Follow us on Mastodon
     # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: GitHub


### PR DESCRIPTION
**Description:**
Adds the Mastodon link to the footer navigation.

**Changes:**
- Adds Mastodon link to `hugo.yaml`
- Reorders footer links: Mailing List, LinkedIn, Mastodon, X

**Related Issue:**
Closes #636
