### PR TITLE
feat(content): add bluesky link to footer

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -103,6 +103,10 @@ params:
         url: 'https://www.linkedin.com/company/kubernetes'
         icon: fab fa-linkedin
         desc: "Kubernetes on LinkedIn"
+      - name: BlueSky
+        url: 'https://bsky.app/profile/k8sContributors.bsky.social'
+        icon: fab fa-bluesky
+        desc: Follow us on BlueSky
     # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: GitHub


### PR DESCRIPTION
**Description:**
Adds the BlueSky link to the footer navigation.

**Changes:**
- Adds BlueSky link to `hugo.yaml`
- Reorders footer links: Mailing List, LinkedIn, BlueSky, X

**Related Issue:**
Closes #637
