### PR TITLE
feat(content): add social media links to footer

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -103,6 +103,18 @@ params:
         url: 'https://www.linkedin.com/company/kubernetes'
         icon: fab fa-linkedin
         desc: "Kubernetes on LinkedIn"
+      - name: YouTube
+        url: 'https://youtube.com/kubernetescommunity'
+        icon: fab fa-youtube
+        desc: Kubernetes Community on YouTube
+      - name: Mastodon
+        url: 'https://hachyderm.io/@K8sContributors'
+        icon: fab fa-mastodon
+        desc: Follow us on Mastodon
+      - name: BlueSky
+        url: 'https://bsky.app/profile/k8sContributors.bsky.social'
+        icon: fab fa-bluesky
+        desc: Follow us on BlueSky
     # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: GitHub


### PR DESCRIPTION
Adds YouTube, Mastodon, and BlueSky links to the footer.

Closes https://github.com/kubernetes/contributor-site/issues/641