### PR TITLE
Bump release information page to v1.36

### DIFF
--- a/external-sources/kubernetes/sig-release
+++ b/external-sources/kubernetes/sig-release
@@ -1,1 +1,1 @@
-"/releases/release-1.35/README.md","/resources/release/index.md"
+"/releases/release-1.36/README.md","/resources/release/index.md"


### PR DESCRIPTION
Following the [official information](https://groups.google.com/g/kubernetes-sig-release/c/73ZKJ3lbQBw/m/OiZMBUKJCwAJ) and https://github.com/kubernetes/sig-release/tree/master/releases/release-1.36.

/assign @Priyankasaggu11929 