### PR TITLE
Fix buildx flow

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,6 @@ steps:
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - DOCKER_BUILDKIT=1
-      - DOCKER_BUILDX=/root/.docker/cli-plugins/docker-buildx
       - TAG=$_GIT_TAG
       - BASE_REF=$_PULL_BASE_REF
     args:


### PR DESCRIPTION
- Fix buildx flow (drop explicit docker-buildx path)

Prow job [post-contributor-site-push-image-k8s-contrib-site-hugo #2018605512349716480](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-contributor-site-push-image-k8s-contrib-site-hugo/2018605512349716480) failure - `make: /root/.docker/cli-plugins/docker-buildx: No such file or directory`