### PR TITLE
SIG Architecture API Gov. Spotlight: update publication date

### DIFF
--- a/content/en/blog/2026/sig-arch-api-spotlight.md
+++ b/content/en/blog/2026/sig-arch-api-spotlight.md
@@ -2,8 +2,8 @@
 layout: blog
 title: "Spotlight on SIG Architecture: API Governance"
 slug: sig-architecture-api
-date: 2026-12-31 # placeholder
-draft: true
+date: 2026-02-12
+draft: false
 author: "Frederico Muñoz (SAS Institute)"
 ---
 


### PR DESCRIPTION
Removed draft status and update publication date for Feb 12 on already reviewed & merged spotlight.

A similar PR update will be made for the `website` , which is already merged as well.