### PR TITLE
feat(events): add 2024 maintainer summit india website

### DIFF
--- a/content/en/events/2024/kcsin/_index.md
+++ b/content/en/events/2024/kcsin/_index.md
@@ -1,0 +1,37 @@
+---
+title: "Maintainer Summit India 2024"
+type: docs
+weight: 1
+description: >
+  CNCF Maintainer Summit India, hosted in Delhi, India.
+---
+
+### Event Summary
+
+The Indian edition of the Maintainer Summit took place on December 10th, 2024, in Delhi, India, alongside 
+<a href="https://events.linuxfoundation.org/archive/2024/kubecon-cloudnativecon-india/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon India 2024</a>.
+
+The Summit featured a mix of technical sessions, including:
+
+* **Unconference Tracks:** Several hours of spontaneous, peer-led deep dives into contributor experience and technical bottlenecks.
+* **SIG & WG Meetings:** In-person sessions for Special Interest Groups and Working Groups to align on 2025 roadmaps.
+
+---
+
+### Recordings & Presentations
+
+* **Watch Sessions:** Recordings from the summit are available on the [CNCF YouTube Channel](https://youtube.com/playlist?list=PLj6h78yzYM2O5UYrc70fDqwAPJciCVDkE&si=bhuMtjWGaon0BAFx).
+* **Event Schedule:** The full list of sessions and speakers is hosted on [Sched](https://maintainersummitindia2024.sched.com/).
+* **Slide Decks:** Presentation materials were uploaded by speakers to their respective session pages on the schedule.
+
+---
+
+### Call for Session Proposals
+
+The Call for Papers (CFP) for this event is closed. For historical reference, you can review the original session tracks and descriptions on the [event schedule](https://maintainersummitindia2024.sched.com/list/descriptions).
+
+### Code of Conduct
+
+Attendees participated under the Kubernetes [Code of Conduct].
+
+[Code of Conduct]: /community/code-of-conduct


### PR DESCRIPTION
Add 2024 Maintainer Summit website for India.

Relates to https://github.com/kubernetes/contributor-site/issues/590

/cc @TineoC @jberkus @Priyankasaggu11929 