### PR TITLE
feat(content): update maintainer summit 2026 description and scope

### DIFF
--- a/content/en/events/2026/kcseu/_index.md
+++ b/content/en/events/2026/kcseu/_index.md
@@ -11,7 +11,7 @@ description: >
 The European edition of the Maintainer Summit will take place on **Sunday, March 22, 2026**, in Amsterdam, Netherlands, alongside 
 <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon Europe 2026</a>.
 
-The Summit is a dedicated day for Kubernetes maintainers to collaborate in person. The event will feature:
+The Summit is a dedicated day for CNCF maintainers to collaborate in person. The event will feature:
 
 * **Submitted Talks:** Technical deep dives and project health updates.
 * **Unconference Sessions:** Open-space discussions for spontaneous problem-solving and SIG alignment.


### PR DESCRIPTION
Update the Maintainer Summit Europe 2026 description to match the CNCF naming convention used for 2025 events (referencing PR #659).

Relates to: https://github.com/kubernetes/contributor-site/issues/590