### PR TITLE
fix: enable future date pages in contributor-site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ gen-content: ## Generates content from external sources.
 	hack/gen-content.sh
 
 render: dependencies ## Build the site using Hugo on the host.
-	hugo --logLevel info --ignoreCache --minify
+	hugo --logLevel info --ignoreCache --minify --buildFuture
 
 server: dependencies ## Run Hugo locally (if Hugo "extended" is installed locally)
 	hugo server \
@@ -175,7 +175,8 @@ production-build: ## Builds the production site (this command used only by Netli
 		--environment production \
 		--logLevel info \
 		--ignoreCache \
-		--minify
+		--minify \
+		--buildFuture
 
 preview-build: ## Builds a deploy preview of the site (this command used only by Netlify).
 	$(BLOCK_STDOUT_CMD)

--- a/content/en/events/2026/kcseu/meet-and-greet.md
+++ b/content/en/events/2026/kcseu/meet-and-greet.md
@@ -4,6 +4,7 @@ type: docs
 weight: 1
 description: >
   Kubernetes Meet and Greet at KubeCon EU
+date: 2026-03-25
 ---
 
 ### About

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -4,6 +4,7 @@ theme:
   - docsy
 themesDir: node_modules
 enableRobotsTXT: true
+buildFuture: true
 
 # Language settings
 contentDir: content/en


### PR DESCRIPTION
Future builds aren't available, so it is ignoring future date pages.

Currently, is showing the meet & greet as it doesn't have a date on its page.

<img width="812" height="262" alt="image" src="https://github.com/user-attachments/assets/f2e76bb5-9a7a-463f-b373-7f94816475df" />

https://www.kubernetes.dev/events/2026/kcseu/

Relates to https://github.com/kubernetes/contributor-site/issues/590

CC @kaslin @stmcginnis 