### PR TITLE
fix: revert global buildFuture to fix future blog post publication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ gen-content: ## Generates content from external sources.
 	hack/gen-content.sh
 
 render: dependencies ## Build the site using Hugo on the host.
-	hugo --logLevel info --ignoreCache --minify --buildFuture
+	hugo --logLevel info --ignoreCache --minify
 
 server: dependencies ## Run Hugo locally (if Hugo "extended" is installed locally)
 	hugo server \
@@ -175,8 +175,7 @@ production-build: ## Builds the production site (this command used only by Netli
 		--environment production \
 		--logLevel info \
 		--ignoreCache \
-		--minify \
-		--buildFuture
+		--minify
 
 preview-build: ## Builds a deploy preview of the site (this command used only by Netlify).
 	$(BLOCK_STDOUT_CMD)

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -4,7 +4,6 @@ theme:
   - docsy
 themesDir: node_modules
 enableRobotsTXT: true
-buildFuture: true
 
 # Language settings
 contentDir: content/en


### PR DESCRIPTION
This PR reverts the changes introduced in #666 to address #669.

### Description
PR #666 correctly enabled building of future events, but it did so by setting `buildFuture: true` globally in `hugo.yaml` and adding the flag to production build targets in the `Makefile`. This caused future-dated blog posts to be published immediately in production, breaking the scheduled publication mechanism.

Fixes #669