### PR TITLE
feat(content): normalize event dates to ensure build visibility

### DIFF
--- a/content/en/events/2020/_index.md
+++ b/content/en/events/2020/_index.md
@@ -1,5 +1,6 @@
 ---
 title: 2020
+eventDate: 2020-01-01
 description: Events and community wide activities held during 2020
 type: docs
 weight: 5

--- a/content/en/events/2021/_index.md
+++ b/content/en/events/2021/_index.md
@@ -1,5 +1,6 @@
 ---
 title: 2021
+eventDate: 2021-01-01
 description: Events and community wide activities held during 2021
 type: docs
 weight: 4

--- a/content/en/events/2021/kcsna/_index.md
+++ b/content/en/events/2021/kcsna/_index.md
@@ -2,6 +2,7 @@
 title: "Contributor Summit North America 2021"
 type: docs
 weight: 1
+eventDate: 2021-10-11
 date: 2021-10-11
 description: >
   The Kubernetes Contributor Summits are returning for 2021!

--- a/content/en/events/2022/_index.md
+++ b/content/en/events/2022/_index.md
@@ -1,5 +1,6 @@
 ---
 title: 2022
+eventDate: 2022-01-01
 description: Events and community wide activities held during 2022
 type: docs
 weight: 3

--- a/content/en/events/2022/kcseu/_index.md
+++ b/content/en/events/2022/kcseu/_index.md
@@ -2,6 +2,7 @@
 title: "Contributor Summit Europe 2022"
 type: docs
 weight: 1
+eventDate: 2022-05-16
 date: 2022-05-16
 description: >
   Kubernetes Contributor Summit Europe, hosted in Valencia Spain.

--- a/content/en/events/2022/kcsna/_index.md
+++ b/content/en/events/2022/kcsna/_index.md
@@ -2,6 +2,7 @@
 title: "Contributor Summit North America 2022"
 type: docs
 weight: 1
+eventDate: 2022-10-24
 date: 2022-10-24
 description: >
   Kubernetes Contributor Summit North America, hosted in Detroit Michigan.

--- a/content/en/events/2023/_index.md
+++ b/content/en/events/2023/_index.md
@@ -1,5 +1,6 @@
 ---
 title: 2023
+eventDate: 2023-01-01
 description: Events and community wide activities held during 2023
 type: docs
 weight: 2

--- a/content/en/events/2023/kcscn/_index.md
+++ b/content/en/events/2023/kcscn/_index.md
@@ -2,6 +2,7 @@
 title: "Contributor Summit China 2023"
 type: docs
 weight: 1
+eventDate: 2023-09-26
 date: 2023-09-26
 description: >
   Kubernetes Contributor Summit China, hosted in Shanghai.

--- a/content/en/events/2023/kcseu/_index.md
+++ b/content/en/events/2023/kcseu/_index.md
@@ -2,6 +2,7 @@
 title: "Contributor Summit Europe 2023"
 type: docs
 weight: 1
+eventDate: 2023-04-18
 date: 2023-04-18
 description: >
   Kubernetes Contributor Summit Europe, hosted in Amsterdam Netherlands.

--- a/content/en/events/2023/kcsna/_index.md
+++ b/content/en/events/2023/kcsna/_index.md
@@ -2,6 +2,7 @@
 title: "Contributor Summit North America 2023"
 type: docs
 weight: 1
+eventDate: 2023-11-06
 date: 2023-11-06
 description: >
   Kubernetes Contributor Summit North America, hosted in Chicago, Illinois.

--- a/content/en/events/2024/_index.md
+++ b/content/en/events/2024/_index.md
@@ -1,5 +1,6 @@
 ---
 title: 2024
+eventDate: 2024-01-01
 description: Events and community wide activities held during 2024
 type: docs
 weight: 1

--- a/content/en/events/2024/kcseu/_index.md
+++ b/content/en/events/2024/kcseu/_index.md
@@ -2,6 +2,7 @@
 title: "Contributor Summit Europe 2024"
 type: docs
 weight: 1
+eventDate: 2024-03-19
 date: 2024-03-19
 description: >
   Kubernetes Contributor Summit Europe, hosted in Paris, France.

--- a/content/en/events/2024/kcsin/_index.md
+++ b/content/en/events/2024/kcsin/_index.md
@@ -2,6 +2,7 @@
 title: "Maintainer Summit India 2024"
 type: docs
 weight: 1
+eventDate: 2024-12-10
 date: 2024-12-10
 description: >
   CNCF Maintainer Summit India, hosted in Delhi, India.

--- a/content/en/events/2024/kcsna/_index.md
+++ b/content/en/events/2024/kcsna/_index.md
@@ -2,6 +2,7 @@
 title: "Contributor Summit North America 2024"
 type: docs
 weight: 1
+eventDate: 2024-11-11
 date: 2024-11-11
 description: >
   Kubernetes Contributor Summit North America, hosted in Salt Lake City, Utah.

--- a/content/en/events/2025/_index.md
+++ b/content/en/events/2025/_index.md
@@ -3,5 +3,6 @@ title: 2025
 description: Events and community wide activities held during 2025
 type: docs
 weight: 1
+eventDate: 2025-11-09
 date: 2025-11-09
 ---

--- a/content/en/events/2025/kcseu/_index.md
+++ b/content/en/events/2025/kcseu/_index.md
@@ -2,6 +2,7 @@
 title: "Maintainer Summit Europe 2025"
 type: docs
 weight: 1
+eventDate: 2025-03-31
 date: 2025-03-31
 description: >
   CNCF Maintainer Summit Europe, hosted in London, United Kingdom.

--- a/content/en/events/2026/_index.md
+++ b/content/en/events/2026/_index.md
@@ -1,5 +1,6 @@
 ---
 title: 2026
+eventDate: 2026-01-01
 description: Events and community wide activities held during 2026
 type: docs
 weight: 1

--- a/content/en/events/2026/kcseu/maintainer-summit-eu.md
+++ b/content/en/events/2026/kcseu/maintainer-summit-eu.md
@@ -2,6 +2,7 @@
 title: "Maintainer Summit Europe 2026"
 type: docs
 weight: 1
+eventDate: 2026-03-22
 date: 2026-03-22
 description: >
   CNCF Maintainer Summit Europe, hosted in Amsterdam, Netherlands.

--- a/content/en/events/2026/kcseu/meet-and-greet.md
+++ b/content/en/events/2026/kcseu/meet-and-greet.md
@@ -4,6 +4,7 @@ type: docs
 weight: 1
 description: >
   Kubernetes Meet and Greet at KubeCon EU
+eventDate: 2026-03-25
 date: 2026-03-25
 ---
 

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,0 +1,40 @@
+<div class="section-index">
+    {{ $parent := .Page }}
+    {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
+    
+    {{/* Sort events by eventDate descending */}}
+    {{ if eq .Section "events" }}
+        {{ $pages = sort $pages "Params.eventdate" "desc" }}
+    {{ end }}
+
+    {{ $pages = (where $pages "Type" "!=" "search") }}
+    {{ $pages = (where $pages ".Params.hide_summary" "!=" true) }}
+    {{ $pages = (where $pages ".Parent" "!=" nil) }}
+    {{ if $parent.File }}
+        {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
+    {{ end }}
+    
+    {{ if or $parent.Params.no_list (eq (len $pages) 0) }}
+    {{/* If no_list is true or we don't have subpages we don't show a list of subpages */}}
+    {{ else if $parent.Params.simple_list }}
+    {{/* If simple_list is true we show a bulleted list of subpages */}}
+        <ul>
+            {{ range $pages }}
+                {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
+                <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></li>
+            {{ end }}
+        </ul>
+    {{ else }}
+    {{/* Otherwise we show a nice formatted list of subpages with page descriptions */}}
+    <hr class="panel-line">
+        {{ range $pages }}
+            {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
+            <div class="entry">
+                <h5>
+                    <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a>
+                </h5>
+                <p>{{ .Description | markdownify }}</p>
+            </div>
+        {{ end }}
+    {{ end }}
+</div>


### PR DESCRIPTION
This PR ensures that future event pages remain visible and correctly sorted after the global `buildFuture` configuration is reverted in #671. 

### Changes
- Introduces a custom `eventDate` field for events to ensure visibility in non-future builds.
- Adds a custom `section-index.html` partial to maintain correct chronological sorting by the new `eventDate` property.

Depends on: #671
cc @lmktfy