### PR TITLE
fix: add backdrop blur to sticky header for better readability

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -7,7 +7,8 @@
 }
 
 .td-navbar.scrolled {
-  background-color: rgba($primary, 0.95) !important;
+  background-color: rgba($primary, 0.9) !important;
+  backdrop-filter: blur(10px);
 }
 
 /* KEP page styles */


### PR DESCRIPTION
This PR adds backdrop-filter: blur(10px) and adjusts the background opacity of the sticky navbar when scrolled to ensure header text remains readable against underlying content.
