### PR TITLE
fix: support main as default branch in gen-content.sh

### DIFF
--- a/hack/gen-content.sh
+++ b/hack/gen-content.sh
@@ -82,7 +82,7 @@ fi
 
 # init_src
 # Intializes source repositores by pulling the latest content. If the repo
-# is already present, fetch the latest content from the master branch.
+# is already present, fetch the latest content.
 # Args:
 # $1 - git repo to be cloned/fetched
 # $2 - path to destination directory for cloned repo
@@ -91,7 +91,7 @@ init_src() {
     echo "Cloning $1" 1>&2
     git clone --depth=1 "$1" "$2"
   elif [[ $(git -C "$2" rev-parse --show-toplevel) == "$2" ]]; then
-    echo "Syncing with latest content from master." 1>&2
+    echo "Syncing with latest content from upstream." 1>&2
     git -C "$2" checkout .
     git -C "$2" pull
   else
@@ -126,8 +126,8 @@ find_md_files() {
 #   Links:
 #   ./bug-bounty.md -> /guide/bug-bounty
 #   contributor-cheatsheet/README.md -> /guide/contributor-cheatsheet
-#   ../../sig-list.md -> https://github.com/kubernetes/community/blob/master/sig-list.md
-#   /contributors/devel/README.md -> https://github.com/kubernetes/community/blob/master/contributors/devel/README.md
+#   ../../sig-list.md -> https://github.com/kubernetes/community/blob/<default-branch>/sig-list.md
+#   /contributors/devel/README.md -> https://github.com/kubernetes/community/blob/<default-branch>/contributors/devel/README.md
 #   http://git.k8s.io/cotributors/guide/collab.md -> /guide/collab
 # 
 # Args:
@@ -232,7 +232,7 @@ gen_link() {
       local src=""
       repo="$(echo "${glsrcs[i]}" | cut -d '/' -f2)/$(echo "${glsrcs[i]}" | cut -d '/' -f3)"
       src="${glsrcs[i]#/${repo}}"
-      if echo "$generated_link" | $GREP -q -i -E "/${repo}(/(blob|tree)/master)?${src}"; then
+      if echo "$generated_link" | $GREP -q -i -E "/${repo}(/(blob|tree)/(master|main))?${src}"; then
         generated_link="$src"
         break
       fi
@@ -288,7 +288,9 @@ gen_link() {
     if [[ "$internal_link" == "false" ]]; then
       local org
       org="$(echo "$2" | rev | cut -d '/' -f2 | rev)" # reverse the string to trim from the "right"
-      generated_link="https://github.com/$org/$(basename "$2")/blob/master${generated_link}"
+      local default_branch
+      default_branch="$(git -C "$2" rev-parse --abbrev-ref HEAD)"
+      generated_link="https://github.com/$org/$(basename "$2")/blob/${default_branch}${generated_link}"
     fi
   fi
 


### PR DESCRIPTION
## Summary

- Detect the default branch dynamically from the cloned repo's HEAD when generating external GitHub links, instead of hardcoding `master`
- Match both `master` and `main` in the URL regex that detects internal content links
- Update comments and log messages to be branch-agnostic

This is a prerequisite for kubernetes/community#6290 (renaming the default branch from `master` to `main`) and is non-disruptive: it works correctly both before and after the rename.

## Details

`hack/gen-content.sh` had two functional code paths that hardcoded `master`:

1. **Link detection regex** (`gen_link`, line 235): When checking if a GitHub URL points to content being synced, the regex only matched `/blob/master/` and `/tree/master/`. URLs with `/blob/main/` would not be recognized as internal, causing them to be left as external links instead of being rewritten to local paths. Fixed by matching `(master|main)`.

2. **External link generation** (`gen_link`, line 291): When generating GitHub URLs for content not being synced, `blob/master` was hardcoded. For repos whose default branch is `main`, this produces broken links. Fixed by detecting the default branch dynamically via `git rev-parse --abbrev-ref HEAD` on the already-cloned repo (which always has the default branch checked out since `init_src` uses `git clone --depth=1`).

Note: `init_src()` itself needed no changes — `git clone --depth=1` and `git pull` are already branch-agnostic.

## Test plan

- [ ] Run `hack/gen-content.sh` and confirm it completes without errors
- [ ] Spot-check generated links in `content/en/` for correct rewriting
