### PR TITLE
Fix: Update footer GitHub link to point to contributor-site

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -118,9 +118,9 @@ params:
     # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: GitHub
-        url: 'https://github.com/kubernetes/community'
+        url: 'https://github.com/kubernetes/contributor-site'
         icon: fab fa-github
-        desc: Home of the Kubernetes Community!
+        desc: Source code for the Kubernetes Contributor Site!
       - name: Slack
         url: 'https://slack.k8s.io'
         icon: fab fa-slack

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kubernetes-sigs/contributor-site.git"
+    "url": "git+https://github.com/kubernetes/contributor-site.git"
   },
   "author": "The Kubernetes Authors",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/kubernetes-sigs/contributor-site/issues"
+    "url": "https://github.com/kubernetes/contributor-site/issues"
   },
-  "homepage": "https://github.com/kubernetes-sigs/contributor-site#readme",
+  "homepage": "https://github.com/kubernetes/contributor-site#readme",
   "overrides": {
     "@fortawesome/fontawesome-free": "^6.6.0"
   }


### PR DESCRIPTION
The GitHub icon in the footer of the k8s.dev website is currently pointing to the `kubernetes/community` repository. This PR updates the link to point to the `kubernetes/contributor-site` repository instead.

References: https://github.com/kubernetes/contributor-site/issues/687#issuecomment-4129450614

Changes:
- Updated `hugo.yaml` footer link and description.
- Updated `package.json` repository, bugs, and homepage URLs.