### PR TITLE
Security: Hardening GitHub Actions workflows and configuration

### DIFF
--- a/.github/workflows/netlify-periodic-build.yml
+++ b/.github/workflows/netlify-periodic-build.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: none
     steps:
     - name: Trigger webhook on netlify
       run: curl -s -X POST "https://api.netlify.com/build_hooks/${TOKEN}"


### PR DESCRIPTION
Added an explicit `permissions: contents: none` block to the `build` job. Since this job only triggers a webhook via `curl`, it does not require access to the repository's source code or other resources.

/sig contributor-experience