### PR TITLE
Add sig/contributor-experience label to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+labels:
+  - sig/contributor-experience
+
 filters:
   ".*":
     approvers:

--- a/OWNERS
+++ b/OWNERS
@@ -3,20 +3,23 @@
 labels:
   - sig/contributor-experience
 
+approvers:
+  - jberkus
+  - jeefy
+  - lmktfy
+  - mrbobbytables
+  - natalisucks
+  - nimbinatus
+  - reylejano
+  - stmcginnis
+  - TineoC
+  - tokt
+  - sig-contributor-experience-leads
+
+reviewers:
+  - sig-contributor-experience-leads
+
 filters:
-  ".*":
-    approvers:
-      - jberkus
-      - jeefy
-      - lmktfy
-      - mrbobbytables
-      - natalisucks
-      - nimbinatus
-      - reylejano
-      - stmcginnis
-      - TineoC
-      - tokt
-      - sig-contributor-experience-leads
   # files/directories related to static site generator
   "^(assets|layouts|static|package-lock\\.json|package\\.json|netlify\\.toml|hugo\\.yaml)$":
     reviewers:


### PR DESCRIPTION
Use the description I provided earlier about enabling Prow auto-labeling for DevStats.