### PR TITLE
Include tech leads on community group cards and individual group pages

### DIFF
--- a/layouts/community/content.html
+++ b/layouts/community/content.html
@@ -39,7 +39,10 @@
   {{ if .Params.leadership }}
   <div class="mt-5">
     <h3 class="h4 fw-bold border-bottom pb-2 mb-4">Leadership</h3>
-    <div class="row g-4">
+    
+    {{ if .Params.leadership.chairs }}
+    <h4 class="h5 fw-semibold mb-3">Chairs</h4>
+    <div class="row g-4 mb-4">
       {{ range .Params.leadership.chairs }}
       <div class="col-md-6 col-lg-4">
         <div class="card h-100 border-0 shadow-sm bg-light">
@@ -58,6 +61,30 @@
       </div>
       {{ end }}
     </div>
+    {{ end }}
+
+    {{ if .Params.leadership.tech_leads }}
+    <h4 class="h5 fw-semibold mb-3">Tech Leads</h4>
+    <div class="row g-4 mb-4">
+      {{ range .Params.leadership.tech_leads }}
+      <div class="col-md-6 col-lg-4">
+        <div class="card h-100 border-0 shadow-sm bg-light">
+          <div class="card-body p-3 d-flex align-items-center">
+            <div class="flex-shrink-0 me-3">
+              <img src="https://github.com/{{ .github }}.png?size=48" class="rounded-circle shadow-sm" alt="{{ .github }}" width="48" height="48">
+            </div>
+            <div>
+              <h5 class="mb-0 h6 fw-bold text-dark">{{ .name }}</h5>
+              <a href="https://github.com/{{ .github }}" target="_blank" class="text-primary small text-decoration-none">
+                <i class="fab fa-github me-1"></i>@{{ .github }}
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      {{ end }}
+    </div>
+    {{ end }}
   </div>
   {{ end }}
 

--- a/layouts/shortcodes/sigs-list.html
+++ b/layouts/shortcodes/sigs-list.html
@@ -129,13 +129,32 @@
                     {{ if .leadership }}
                     <div class="mb-3">
                       <h6 class="fw-bold small text-uppercase text-muted border-bottom pb-1 mb-2">Leadership</h6>
-                      <div class="d-flex flex-wrap gap-1">
-                        {{ range .leadership.chairs }}
-                        <a href="https://github.com/{{ .github }}" class="badge bg-primary bg-opacity-10 text-primary border-0 text-decoration-none py-1 px-2">
-                          <span class="small">@{{ .github }}</span>
-                        </a>
-                        {{ end }}
+                      
+                      {{ if .leadership.chairs }}
+                      <div class="mb-2">
+                        <div class="small fw-semibold text-dark mb-1">Chairs</div>
+                        <div class="d-flex flex-wrap gap-1">
+                          {{ range .leadership.chairs }}
+                          <a href="https://github.com/{{ .github }}" class="badge bg-primary bg-opacity-10 text-primary border-0 text-decoration-none py-1 px-2">
+                            <span class="small">@{{ .github }}</span>
+                          </a>
+                          {{ end }}
+                        </div>
                       </div>
+                      {{ end }}
+
+                      {{ if .leadership.tech_leads }}
+                      <div>
+                        <div class="small fw-semibold text-dark mb-1">Tech Leads</div>
+                        <div class="d-flex flex-wrap gap-1">
+                          {{ range .leadership.tech_leads }}
+                          <a href="https://github.com/{{ .github }}" class="badge bg-secondary bg-opacity-10 text-secondary border-0 text-decoration-none py-1 px-2">
+                            <span class="small">@{{ .github }}</span>
+                          </a>
+                          {{ end }}
+                        </div>
+                      </div>
+                      {{ end }}
                     </div>
                     {{ end }}
 
@@ -225,6 +244,38 @@
                   
                   <!-- Collapsible Details -->
                   <div class="collapse mt-auto" id="collapse-{{ .dir | urlize }}">
+                    {{ if .leadership }}
+                    <div class="mb-3">
+                      <h6 class="fw-bold small text-uppercase text-muted border-bottom pb-1 mb-2">Leadership</h6>
+                      
+                      {{ if .leadership.chairs }}
+                      <div class="mb-2">
+                        <div class="small fw-semibold text-dark mb-1">Chairs</div>
+                        <div class="d-flex flex-wrap gap-1">
+                          {{ range .leadership.chairs }}
+                          <a href="https://github.com/{{ .github }}" class="badge bg-primary bg-opacity-10 text-primary border-0 text-decoration-none py-1 px-2">
+                            <span class="small">@{{ .github }}</span>
+                          </a>
+                          {{ end }}
+                        </div>
+                      </div>
+                      {{ end }}
+
+                      {{ if .leadership.tech_leads }}
+                      <div>
+                        <div class="small fw-semibold text-dark mb-1">Tech Leads</div>
+                        <div class="d-flex flex-wrap gap-1">
+                          {{ range .leadership.tech_leads }}
+                          <a href="https://github.com/{{ .github }}" class="badge bg-secondary bg-opacity-10 text-secondary border-0 text-decoration-none py-1 px-2">
+                            <span class="small">@{{ .github }}</span>
+                          </a>
+                          {{ end }}
+                        </div>
+                      </div>
+                      {{ end }}
+                    </div>
+                    {{ end }}
+
                     {{ if gt (len $allMeetings) 0 }}
                     <div class="bg-primary bg-opacity-10 p-2 rounded-3 mb-3">
                       <h6 class="fw-bold small text-uppercase text-primary mb-2"><i class="far fa-clock me-1"></i> Meetings ({{ len $allMeetings }})</h6>
@@ -332,13 +383,32 @@
                     {{ if .leadership }}
                     <div class="mb-3">
                       <h6 class="fw-bold small text-uppercase text-muted border-bottom pb-1 mb-2">Leadership</h6>
-                      <div class="d-flex flex-wrap gap-1">
-                        {{ range .leadership.chairs }}
-                        <a href="https://github.com/{{ .github }}" class="badge bg-primary bg-opacity-10 text-primary border-0 text-decoration-none py-1 px-2">
-                          <span class="small">@{{ .github }}</span>
-                        </a>
-                        {{ end }}
+                      
+                      {{ if .leadership.chairs }}
+                      <div class="mb-2">
+                        <div class="small fw-semibold text-dark mb-1">Chairs</div>
+                        <div class="d-flex flex-wrap gap-1">
+                          {{ range .leadership.chairs }}
+                          <a href="https://github.com/{{ .github }}" class="badge bg-primary bg-opacity-10 text-primary border-0 text-decoration-none py-1 px-2">
+                            <span class="small">@{{ .github }}</span>
+                          </a>
+                          {{ end }}
+                        </div>
                       </div>
+                      {{ end }}
+
+                      {{ if .leadership.tech_leads }}
+                      <div>
+                        <div class="small fw-semibold text-dark mb-1">Tech Leads</div>
+                        <div class="d-flex flex-wrap gap-1">
+                          {{ range .leadership.tech_leads }}
+                          <a href="https://github.com/{{ .github }}" class="badge bg-secondary bg-opacity-10 text-secondary border-0 text-decoration-none py-1 px-2">
+                            <span class="small">@{{ .github }}</span>
+                          </a>
+                          {{ end }}
+                        </div>
+                      </div>
+                      {{ end }}
                     </div>
                     {{ end }}
                   </div>


### PR DESCRIPTION
Currently, the community group cards on the overview page and the individual community group pages only display the **Chairs** of each group. 

In the `sigs.yaml` from `kubernetes/community`, many groups also have **Tech Leads** listed under `leadership.tech_leads`. This PR includes them to give a more complete picture of the group's leadership.

### Changes:
- **Community Groups Overview**: Updated `layouts/shortcodes/sigs-list.html` to range over `.leadership.tech_leads` in addition to `.leadership.chairs`.
- **Individual Community Group Pages**: Updated `layouts/community/content.html` to display `.Params.leadership.tech_leads`.
- Distinct sections are used to distinguish between Chairs and Tech Leads.

Closes #695

/sig contributor-experience
/area contributor-site
/kind feature