### PR TITLE
Improve KEP layout: hyperlink to internal SIG pages

### DIFF
--- a/layouts/keps/single.html
+++ b/layouts/keps/single.html
@@ -35,17 +35,28 @@
   <div class="kep-sigs mt-4">
     <h2 id="sigs">SIGs</h2>
       <p class="kep-sigs-owner">Owning SIG:</p>
-      <a href="https://github.com/kubernetes/community/tree/master/{{ .Params.owningSig }}">
-        SIG {{ strings.TrimPrefix "sig-" .Params.owningSig | humanize | title }}
-      </a>
+      {{- $owningSigSlug := strings.TrimPrefix "sig-" .Params.owningSig -}}
+      {{- with .Site.GetPage (printf "community/community-groups/sigs/%s" $owningSigSlug) -}}
+        <a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Title }}</a>
+      {{- else -}}
+        <a href="https://github.com/kubernetes/community/tree/master/{{ $.Params.owningSig }}">
+          SIG {{ $owningSigSlug | humanize | title }}
+        </a>
+      {{- end -}}
+
     {{ with .Params.participatingSigs }}
     <p>
       <strong>Participating SIGs:</strong>
       {{ range $i, $sig := . }}
         {{- if $i }}, {{ end -}}
-        <a href="https://github.com/kubernetes/community/tree/master/{{ $sig }}">
-          SIG {{ strings.TrimPrefix "sig-" $sig | humanize | title }}
-        </a>
+        {{- $sigSlug := strings.TrimPrefix "sig-" $sig -}}
+        {{- with $.Site.GetPage (printf "community/community-groups/sigs/%s" $sigSlug) -}}
+          <a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Title }}</a>
+        {{- else -}}
+          <a href="https://github.com/kubernetes/community/tree/master/{{ $sig }}">
+            SIG {{ $sigSlug | humanize | title }}
+          </a>
+        {{- end -}}
       {{ end }}
     </p>
     {{ end }}

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -72,9 +72,14 @@
               {{- end -}}
             </td>
             <td>
-              <a href=" https://github.com/kubernetes/community/tree/master/{{ $data.owningSig }}">
-                {{ strings.TrimPrefix "sig-" $data.owningSig | humanize | title }}
-              </a>
+              {{- $sigSlug := strings.TrimPrefix "sig-" $data.owningSig -}}
+              {{- with site.GetPage (printf "community/community-groups/sigs/%s" $sigSlug) -}}
+                <a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Title }}</a>
+              {{- else -}}
+                <a href="https://github.com/kubernetes/community/tree/master/{{ $data.owningSig }}">
+                  SIG {{ $sigSlug | humanize | title }}
+                </a>
+              {{- end -}}
             </td>
             <td>
               {{ range $index, $author := $data.authors }}


### PR DESCRIPTION
Currently, the SIG names on KEP pages link to external GitHub repositories. This PR updates the KEP layout and data table to hyperlink to the relevant internal SIG sub-page if it exists, falling back to the GitHub link if not found.

### Changes:
- Updated `layouts/keps/single.html` to use `.Site.GetPage` for internal SIG linking.
- Updated `layouts/shortcodes/keps-data.html` to use `site.GetPage` for internal SIG linking.
- Handles both `owningSig` and `participatingSigs`.

Closes #690