### PR TITLE
[codex] Fix k8s.dev footer GitHub link

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -121,9 +121,9 @@ params:
     # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: GitHub
-        url: 'https://github.com/kubernetes/community'
+        url: 'https://github.com/kubernetes/contributor-site'
         icon: fab fa-github
-        desc: Home of the Kubernetes Community!
+        desc: Source for the Kubernetes Contributor Site
       - name: Slack
         url: 'https://slack.k8s.io'
         icon: fab fa-slack


### PR DESCRIPTION
## Summary
- update the footer GitHub link on k8s.dev to point to `kubernetes/contributor-site`
- align the link description with the contributor-site destination

## Why
Fixes #687. The footer GitHub icon currently links to `kubernetes/community` instead of this repository.

## Validation
- attempted `make container-image container-render`
- blocked locally because the Docker daemon was not running (`Cannot connect to the Docker daemon at unix:///Users/abhaychaurasiya/.docker/run/docker.sock`)
