### PR TITLE
Render KEP README content on k8s.dev

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -28,34 +28,234 @@ body.td-home div.lead p {
 
 /* KEP page styles */
 .kep-page {
-  .kep-stage-badge {
-    margin-bottom: 1rem;
+  padding: 1rem 0;
 
-    .badge {
-      font-size: 0.9rem;
-      padding: 0.5em 1em;
-      border-radius: 4px;
+  .kep-banner-container {
+    background-color: #fff;
+    border: 1px solid #e0e4e8;
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03);
+  }
+
+  .kep-banner-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    
+    @media (max-width: 991px) {
+      grid-template-columns: 1fr;
     }
   }
 
-  .kep-stage-alpha .badge {
-    background-color: #ffc107;
-    color: #000;
+  .kep-banner-col {
+    padding: 2rem;
+    position: relative;
+
+    &.border-start-refined {
+      border-left: 1px solid #e0e4e8;
+      
+      @media (max-width: 991px) {
+        border-left: none;
+        border-top: 1px solid #e0e4e8;
+      }
+    }
   }
 
-  .kep-stage-beta .badge {
-    background-color: #17a2b8;
-    color: #fff;
+  .kep-banner-label {
+    font-family: var(--bs-font-monospace);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: #8a94a6;
+    margin-bottom: 2rem;
+    display: block;
+    font-weight: 600;
   }
 
-  .kep-stage-stable .badge {
-    background-color: #28a745;
-    color: #fff;
+  .kep-banner-sublabel {
+    font-family: var(--bs-font-monospace);
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #a0aec0;
+    margin-bottom: 0.75rem;
+    font-weight: 600;
   }
 
-  .kep-stage-deprecated .badge {
-    background-color: #6c757d;
-    color: #fff;
+  /* Refined Badges */
+  .kep-badge-refined {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    border-radius: 4px;
+    letter-spacing: 0.05em;
+
+    &.kep-stage-alpha {
+      background-color: #fff8e1;
+      color: #b45309;
+      border: 1px solid #fef3c7;
+    }
+
+    &.kep-stage-beta {
+      background-color: #e0f2fe;
+      color: #0369a1;
+      border: 1px solid #bae6fd;
+    }
+
+    &.kep-stage-stable {
+      background-color: #ecfdf5;
+      color: #15803d;
+      border: 1px solid #d1fae5;
+    }
+
+    &.kep-stage-deprecated {
+      background-color: #f3f4f6;
+      color: #4b5563;
+      border: 1px solid #e5e7eb;
+    }
+
+    &.kep-status-generic {
+      background-color: #f8fafc;
+      color: #475569;
+      border: 1px solid #e2e8f0;
+    }
+  }
+
+  /* Data Grid for Timeline/Milestones */
+  .kep-data-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .kep-data-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.9rem;
+    padding: 0.25rem 0;
+
+    .kep-data-label {
+      color: #64748b;
+      display: flex;
+      align-items: center;
+
+      .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        margin-right: 8px;
+        display: inline-block;
+
+        &.alpha { background-color: #fbbf24; box-shadow: 0 0 8px rgba(251, 191, 36, 0.4); }
+        &.beta { background-color: #38bdf8; box-shadow: 0 0 8px rgba(56, 189, 248, 0.4); }
+        &.stable { background-color: #34d399; box-shadow: 0 0 8px rgba(52, 211, 153, 0.4); }
+        &.deprecated { background-color: #94a3b8; }
+      }
+    }
+
+    .kep-data-value {
+      font-weight: 500;
+      color: #1e293b;
+      
+      code {
+        background: #f1f5f9;
+        padding: 0.1rem 0.4rem;
+        border-radius: 3px;
+        color: #475569;
+      }
+    }
+  }
+
+  /* Ownership Links */
+  .kep-main-link {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #0f172a;
+    text-decoration: none;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: var(--bs-primary);
+    }
+  }
+
+  .kep-tag-link {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    background-color: #64748b;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #ffffff;
+    text-decoration: none;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: #475569;
+      color: #ffffff;
+      transform: translateY(-1px);
+    }
+  }
+
+  .kep-people-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .kep-person-link {
+    font-size: 0.85rem;
+    color: #475569;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    transition: all 0.2s ease;
+
+    i { color: #94a3b8; }
+
+    &:hover {
+      color: var(--bs-primary);
+      transform: translateX(4px);
+      i { color: var(--bs-primary); }
+    }
+  }
+
+  .kep-link-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    li {
+      margin-bottom: 0.5rem;
+      
+      a {
+        font-size: 0.85rem;
+        color: #334155;
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        transition: all 0.2s ease;
+
+        i { 
+          font-size: 0.7rem;
+          color: #94a3b8; 
+          line-height: 1;
+        }
+
+        &:hover {
+          color: var(--bs-primary);
+          transform: translateX(4px);
+          i { color: var(--bs-primary); }
+        }
+
+        strong { font-weight: 500; }
+      }
+    }
   }
 
   h2 {
@@ -65,13 +265,131 @@ body.td-home div.lead p {
     margin-top: 1.5rem;
   }
 
-  .kep-sigs-owner {
-    font-weight: bold;
-    margin-bottom: 0.25rem;
+  .kep-content {
+    background-color: transparent;
+    padding: 0;
+    margin-bottom: 3rem;
+    line-height: 1.7;
+
+    // Hide duplicate KEP title from README if present
+    h1:first-of-type {
+      display: none;
+    }
+
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin-top: 2.5rem;
+      margin-bottom: 1.25rem;
+      font-weight: 700;
+    }
+
+    h2 {
+      font-size: 1.5rem;
+      color: #1a1a1a;
+    }
+
+    p {
+      margin-bottom: 1.5rem;
+      color: #3a3a3a;
+    }
+
+    // Ensure images don't overflow
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 8px;
+      margin: 2rem 0;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    }
+
+    // Handle tables in markdown
+    table {
+      width: 100%;
+      margin: 2rem 0;
+      border-collapse: separate;
+      border-spacing: 0;
+      border: 1px solid #dee2e6;
+      border-radius: 8px;
+      overflow: hidden;
+
+      th,
+      td {
+        padding: 1rem;
+        border: 1px solid #dee2e6;
+      }
+
+      th {
+        background-color: #f8f9fa;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.8rem;
+        letter-spacing: 0.05em;
+      }
+    }
+
+    // Blockquotes
+    blockquote {
+      padding: 1.5rem 2rem;
+      margin: 2rem 0;
+      background: #fdfdfe;
+      border-left: 4px solid #dee2e6;
+      font-style: italic;
+      color: #4a4a4a;
+
+      p:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    // Code blocks
+    pre {
+      background-color: #1e1e1e;
+      color: #d4d4d4;
+      padding: 1.5rem;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      margin: 2rem 0;
+    }
   }
 
-  .table {
-    max-width: 600px;
+  // Status-specific content borders
+
+  .kep-metadata-container {
+    background: #f8f9fa;
+    padding: 2rem;
+    border-radius: 8px;
+    margin-top: 4rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+
+    h2 {
+      margin-top: 0;
+      font-size: 1.25rem;
+      border-bottom: 2px solid #dee2e6;
+      padding-bottom: 0.5rem;
+      margin-bottom: 1.5rem;
+      display: block;
+      color: #6c757d;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+
+    div {
+      margin-top: 0 !important;
+    }
+
+    ul {
+      padding-left: 1.25rem;
+    }
+
+    p {
+      margin-bottom: 0.75rem;
+      font-size: 0.95rem;
+    }
   }
 }
 
@@ -80,7 +398,7 @@ body.td-home div.lead p {
   background-color: rgba(var(--bs-primary-rgb), 0.1);
   color: var(--bs-primary);
   transition: all 0.2s ease;
-  
+
   &.active {
     background-color: var(--bs-primary);
     color: #fff;

--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -1,8 +1,16 @@
 {{- $kepDataSourceUrl := "https://storage.googleapis.com/k8s-keps/keps.json" -}}
+{{- $rawBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/keps/" -}}
 {{- $kepData := slice -}}
 
+{{/* Global Options for GetRemote */}}
+{{- $globalOpts := dict -}}
+{{- with os.Getenv "HUGO_GITHUB_TOKEN" -}}
+  {{- $globalOpts = dict "headers" (dict "Authorization" (printf "Bearer %s" .)) -}}
+{{- end -}}
+
 {{/* Fetch remote KEP data */}}
-{{- with resources.GetRemote $kepDataSourceUrl -}}
+{{- $kepDataOpts := merge $globalOpts (dict "key" "keps-json-data") -}}
+{{- with resources.GetRemote $kepDataSourceUrl $kepDataOpts -}}
   {{- with .Err -}}
     {{- if eq hugo.Environment "production" -}}
       {{- errorf "Unable to load KEP data: %s" . -}}
@@ -55,6 +63,51 @@
       "toc_hide" true
     -}}
 
+    {{/* Fetch README Content */}}
+    {{- $readmeUrl := printf "%s%s/%s/README.md" $rawBaseUrl $kep.owningSig $kep.name -}}
+    {{- $readmeContent := "" -}}
+    {{- $readmeOpts := merge $globalOpts (dict "key" (printf "kep-readme-%s" $kep.kepNumber)) -}}
+    
+    {{- $resource := resources.GetRemote $readmeUrl $readmeOpts -}}
+    
+    {{- /* Fallback to README.MD if README.md fails or is nil */ -}}
+    {{- $needsFallback := false -}}
+    {{- if not $resource -}}
+      {{- $needsFallback = true -}}
+    {{- else if $resource.Err -}}
+      {{- $needsFallback = true -}}
+    {{- end -}}
+
+    {{- if $needsFallback -}}
+      {{- $readmeUrlUpper := printf "%s%s/%s/README.MD" $rawBaseUrl $kep.owningSig $kep.name -}}
+      {{- $readmeOptsUpper := merge $globalOpts (dict "key" (printf "kep-readme-%s-upper" $kep.kepNumber)) -}}
+      {{- $resource = resources.GetRemote $readmeUrlUpper $readmeOptsUpper -}}
+    {{- end -}}
+
+    {{- if $resource -}}
+      {{- if $resource.Err -}}
+        {{- warnf "Unable to load README for KEP %s (tried .md and .MD): %s" $kep.kepNumber $resource.Err -}}
+      {{- else -}}
+        {{- /* Fix common markdown link errors in KEP READMEs to avoid build failures */ -}}
+        {{- $readmeContent = replace $resource.Content "]((http" "](http" -}}
+        {{- $readmeContent = replace $readmeContent "/))" "/)" -}}
+        {{- $readmeContent = replace $readmeContent "((http" "(http" -}}
+        
+        {{- /* Fix relative image and link paths to point to GitHub */ -}}
+        {{- $repoBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
+        {{- $kepDirUrl := printf "%skeps/%s/%s/" $repoBaseUrl $kep.owningSig $kep.name -}}
+        
+        {{- /* 1. Fix absolute-looking paths (starting with /) */ -}}
+        {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
+        
+        {{- /* 2. Fix relative paths (not starting with http, #, or / and not containing :) */ -}}
+        {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
+      {{- end -}}
+    {{- end -}}
+
     {{/* Build page path: /resources/keps/{kepNumber}/ */}}
     {{- $pagePath := $kep.kepNumber -}}
 
@@ -65,6 +118,10 @@
       "kind" "page"
       "type" "keps"
       "params" $params
+      "content" (dict
+        "mediaType" "text/markdown"
+        "value" $readmeContent
+      )
     -}}
 
     {{- $.AddPage $page -}}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,12 @@
+{{- $u := .Destination -}}
+{{- /* 
+  Robustly handle URLs with parentheses or extra spaces from external sources (e.g. KEP READMEs).
+  This prevents build failures like "first path segment in URL cannot contain colon" when 
+  a link destination is wrapped in extra parentheses.
+*/ -}}
+{{- $u = trim $u " ()" -}}
+<a href="{{ $u | safeURL }}"
+  {{ with .Title }} title="{{ . }}"{{ end }}
+  {{ if strings.HasPrefix $u "http" }} target="_blank" rel="noopener"{{ end }}>
+  {{- .Text | safeHTML -}}
+</a>

--- a/layouts/keps/single.html
+++ b/layouts/keps/single.html
@@ -2,179 +2,156 @@
 <div class="td-content kep-page">
   <h1>KEP-{{ .Params.kepNumber }}: {{ .Title }}</h1>
 
-  {{/* Stage badge */}}
-  {{ with .Params.stage }}
-  <div class="kep-stage-badge kep-stage-{{ . }}">
-    <span class="badge">{{ . | upper }}</span>
-  </div>
-  {{ end }}
-
-  {{/* Status info */}}
-  {{ with .Params.status }}
-  <p class="kep-status"><strong>Status:</strong> {{ . | humanize | title }}</p>
-  {{ end }}
-
-  {{/* External links section */}}
-  <div class="kep-links mt-4">
-    <h2 id="links">Links</h2>
-    <ul>
-      <li>
-        <a href="https://kep.k8s.io/{{ .Params.kepNumber }}" target="_blank" rel="noopener">
-          Enhancement Issue #{{ .Params.kepNumber }}
-        </a>
-      </li>
-      <li>
-        <a href="https://github.com/kubernetes/enhancements/tree/master/keps/{{ .Params.owningSig }}/{{ .Params.name }}" target="_blank" rel="noopener">
-          KEP Documentation
-        </a>
-      </li>
-    </ul>
-  </div>
-
-  {{/* SIG information */}}
-  <div class="kep-sigs mt-4">
-    <h2 id="sigs">SIGs</h2>
-      <p class="kep-sigs-owner">Owning SIG:</p>
-      {{- $owningSigSlug := strings.TrimPrefix "sig-" .Params.owningSig -}}
-      {{- with .Site.GetPage (printf "community/community-groups/sigs/%s" $owningSigSlug) -}}
-        <a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Title }}</a>
-      {{- else -}}
-        <a href="https://github.com/kubernetes/community/tree/master/{{ $.Params.owningSig }}">
-          SIG {{ $owningSigSlug | humanize | title }}
-        </a>
-      {{- end -}}
-
-    {{ with .Params.participatingSigs }}
-    <p>
-      <strong>Participating SIGs:</strong>
-      {{ range $i, $sig := . }}
-        {{- if $i }}, {{ end -}}
-        {{- $sigSlug := strings.TrimPrefix "sig-" $sig -}}
-        {{- with $.Site.GetPage (printf "community/community-groups/sigs/%s" $sigSlug) -}}
-          <a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Title }}</a>
-        {{- else -}}
-          <a href="https://github.com/kubernetes/community/tree/master/{{ $sig }}">
-            SIG {{ $sigSlug | humanize | title }}
-          </a>
-        {{- end -}}
-      {{ end }}
-    </p>
-    {{ end }}
-  </div>
-
-  {{/* Milestone information */}}
-  {{ with .Params.milestone }}
-  <div class="kep-milestones mt-4">
-    <h2 id="milestones">Milestones</h2>
-    <table class="table table-sm">
-      <tbody>
-        {{ with .alpha }}<tr><td>Alpha</td><td>{{ . }}</td></tr>{{ end }}
-        {{ with .beta }}<tr><td>Beta</td><td>{{ . }}</td></tr>{{ end }}
-        {{ with .stable }}<tr><td>Stable</td><td>{{ . }}</td></tr>{{ end }}
-        {{ with .deprecated }}<tr><td>Deprecated</td><td>{{ . }}</td></tr>{{ end }}
-      </tbody>
-    </table>
-  </div>
-  {{ end }}
-
-  {{/* Feature gates */}}
-  {{ with .Params.featureGates }}
-  <div class="kep-feature-gates mt-4">
-    <h2 id="feature-gates">Feature Gates</h2>
-    <p>This enhancement was designed with opt-in or opt-out at the feature level;
-       there are <a href="https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/">feature gates</a> associated with it.</p>
-    <table class="table table-sm">
-      <caption>Feature gates for this KEP</caption>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Components</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{ range . }}
-        <tr>
-          <td><code>{{ .name }}</code></td>
-          <td>
-            {{ range $i, $comp := .components }}
-              {{- if $i }}, {{ end -}}
-              <code>{{ $comp }}</code>
+  {{/* Technical Editorial Metadata Banner */}}
+  <div class="kep-banner-container mb-5">
+    <div class="kep-banner-grid">
+      
+      {{/* Column 1: Implementation & History */}}
+      <div class="kep-banner-col">
+        <div class="kep-banner-label">Implementation History</div>
+        
+        <div class="kep-status-group mb-4">
+          <div class="d-flex flex-wrap gap-2">
+            {{ with .Params.stage }}
+            <span class="kep-badge-refined kep-stage-{{ . }}">{{ . | upper }}</span>
             {{ end }}
-          </td>
-        </tr>
+            {{ with .Params.status }}
+            <span class="kep-badge-refined kep-status-generic">{{ . | humanize | title }}</span>
+            {{ end }}
+          </div>
+        </div>
+
+        <div class="kep-data-grid mb-4">
+          {{ with .Params.creationDate }}
+          <div class="kep-data-row">
+            <span class="kep-data-label">Created</span>
+            <span class="kep-data-value">{{ . }}</span>
+          </div>
+          {{ end }}
+          {{ with .Params.lastUpdated }}
+          <div class="kep-data-row">
+            <span class="kep-data-label">Updated</span>
+            <span class="kep-data-value">{{ . }}</span>
+          </div>
+          {{ end }}
+          {{ with .Params.latestMilestone }}
+          <div class="kep-data-row">
+            <span class="kep-data-label">Latest</span>
+            <span class="kep-data-value">{{ . }}</span>
+          </div>
+          {{ end }}
+        </div>
+
+        {{ with .Params.milestone }}
+        {{ if or .alpha .beta .stable .deprecated }}
+        <div class="kep-milestones-refined pt-3 border-top">
+          <div class="kep-banner-sublabel">Milestones</div>
+          <div class="kep-data-grid">
+            {{ with .alpha }}
+            <div class="kep-data-row">
+              <span class="kep-data-label"><span class="dot alpha"></span> Alpha</span>
+              <span class="kep-data-value"><code>{{ . }}</code></span>
+            </div>
+            {{ end }}
+            {{ with .beta }}
+            <div class="kep-data-row">
+              <span class="kep-data-label"><span class="dot beta"></span> Beta</span>
+              <span class="kep-data-value"><code>{{ . }}</code></span>
+            </div>
+            {{ end }}
+            {{ with .stable }}
+            <div class="kep-data-row">
+              <span class="kep-data-label"><span class="dot stable"></span> Stable</span>
+              <span class="kep-data-value"><code>{{ . }}</code></span>
+            </div>
+            {{ end }}
+            {{ with .deprecated }}
+            <div class="kep-data-row">
+              <span class="kep-data-label"><span class="dot deprecated"></span> Depr.</span>
+              <span class="kep-data-value"><code>{{ . }}</code></span>
+            </div>
+            {{ end }}
+          </div>
+        </div>
         {{ end }}
-      </tbody>
-    </table>
+        {{ end }}
+
+        {{ with .Params.seeAlso }}
+        <div class="kep-related-refined pt-3 border-top mt-3">
+          <div class="kep-banner-sublabel">Related Enhancements</div>
+          <ul class="kep-link-list">
+            {{ range . }}
+            <li>
+              {{- if and (strings.HasPrefix . "http") (not (strings.Contains . "[")) -}}
+                <a href="{{ . }}" target="_blank" rel="noopener"><i class="fas fa-external-link-alt"></i> {{ . }}</a>
+              {{- else if and (strings.HasPrefix . "/") (not (strings.Contains . "[")) -}}
+                <a href="https://github.com/kubernetes/enhancements/tree/master{{ . }}" target="_blank" rel="noopener"><i class="fab fa-github"></i> {{ . }}</a>
+              {{- else -}}
+                {{ . | markdownify }}
+              {{- end -}}
+            </li>
+            {{ end }}
+          </ul>
+        </div>
+        {{ end }}
+      </div>
+
+      {{/* Column 2: Ownership & People */}}
+      <div class="kep-banner-col border-start-refined">
+        <div class="kep-banner-label">Ownership</div>
+        
+        <div class="kep-sig-section mb-4">
+          <div class="kep-banner-sublabel">Owning SIG</div>
+          {{- $owningSigSlug := strings.TrimPrefix "sig-" .Params.owningSig -}}
+          {{- with .Site.GetPage (printf "community/community-groups/sigs/%s" $owningSigSlug) -}}
+            <a href="{{ .RelPermalink }}" class="kep-main-link">{{ .LinkTitle | default .Title }}</a>
+          {{- else -}}
+            <a href="https://github.com/kubernetes/community/tree/master/{{ $.Params.owningSig }}" class="kep-main-link">
+              SIG {{ $owningSigSlug | humanize | title }}
+            </a>
+          {{- end -}}
+        </div>
+
+        {{ with .Params.participatingSigs }}
+        <div class="kep-sig-section mb-4 pt-3 border-top">
+          <div class="kep-banner-sublabel">Participating SIGs</div>
+          <div class="d-flex flex-wrap gap-2">
+            {{ range $i, $sig := . }}
+              {{- $sigSlug := strings.TrimPrefix "sig-" $sig -}}
+              {{- with $.Site.GetPage (printf "community/community-groups/sigs/%s" $sigSlug) -}}
+                <a href="{{ .RelPermalink }}" class="kep-tag-link">{{ .LinkTitle | default .Title }}</a>
+              {{- else -}}
+                <a href="https://github.com/kubernetes/community/tree/master/{{ $sig }}" class="kep-tag-link">
+                  {{ $sigSlug | humanize | title }}
+                </a>
+              {{- end -}}
+            {{ end }}
+          </div>
+        </div>
+        {{ end }}
+
+        {{ with .Params.authors }}
+        <div class="kep-people-section pt-3 border-top">
+          <div class="kep-banner-sublabel">Primary Authors</div>
+          <div class="kep-people-grid">
+            {{ range . }}
+            <a href="https://github.com/{{ trim . "@" }}" target="_blank" rel="noopener" class="kep-person-link">
+              <i class="fab fa-github"></i> {{ . }}
+            </a>
+            {{ end }}
+          </div>
+        </div>
+        {{ end }}
+      </div>
+
+    </div>
   </div>
-  {{ end }}
 
-  {{/* Authors and contributors */}}
-  <div class="kep-people mt-4">
-    <h2 id="people">People</h2>
-
-    {{ with .Params.authors }}
-    <p>
-      <strong>Authors:</strong>
-      {{ range $i, $author := . }}
-        {{- if $i }}, {{ end -}}
-        <a href="https://github.com/{{ trim $author "@" }}">{{ $author }}</a>
-      {{ end }}
-    </p>
-    {{ end }}
-
-    {{ with .Params.reviewers }}
-    <p>
-      <strong>Reviewers:</strong>
-      {{ range $i, $reviewer := . }}
-        {{- if $i }}, {{ end -}}
-        <a href="https://github.com/{{ trim $reviewer "@" }}">{{ $reviewer }}</a>
-      {{ end }}
-    </p>
-    {{ end }}
-
-    {{ with .Params.approvers }}
-    <p>
-      <strong>Approvers:</strong>
-      {{ range $i, $approver := . }}
-        {{- if $i }}, {{ end -}}
-        <a href="https://github.com/{{ trim $approver "@" }}">{{ $approver }}</a>
-      {{ end }}
-    </p>
-    {{ end }}
-  </div>
-
-  {{/* Dates */}}
-  <div class="kep-dates mt-4">
-    <h2 id="timeline">Timeline</h2>
-    {{ with .Params.creationDate }}
-    <p><strong>Created:</strong> <time datetime="{{ . }}">{{ . }}</time></p>
-    {{ end }}
-    {{ with .Params.lastUpdated }}
-    <p><strong>Last Updated:</strong> <time datetime="{{ . }}">{{ . }}</time></p>
-    {{ end }}
-    {{ with $.Params.latestMilestone }}
-    <p><strong>Latest Milestone:</strong> {{ . }}</p>
-    {{ end }}
-  </div>
-
-  {{/* See Also */}}
-  {{ with .Params.seeAlso }}
-  <div class="kep-see-also mt-4">
-    <h2 id="related-keps">Related KEPs</h2>
-    <ul>
-      {{ range . }}
-      <li>{{ . }}</li>
-      {{ end }}
-    </ul>
-  </div>
-  {{ end }}
-
-  {{/* Manual content placeholder - for markdown overrides */}}
+  {{/* Main content (README) */}}
   {{ if .Content }}
-  <div class="kep-custom-content mt-4">
+  <div class="kep-content mt-4">
     {{ .Content }}
   </div>
   {{ end }}
-
 </div>
 {{ end }}


### PR DESCRIPTION
This PR implements the rendering of full KEP README content directly on k8s.dev.

Currently, KEP pages only show metadata and redirect users to GitHub. This change fetches the README content during the build process and displays it prominently on the page.

Fixes https://github.com/kubernetes/contributor-site/issues/698

Special notes: This PR was prepared with the help of Antigravity.