### PR TITLE
Update cloudbuild.yaml to use main branch

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,4 +27,4 @@ substitutions:
   _GIT_TAG: "12345"
   # _PULL_BASE_REF will contain the ref that was pushed to trigger this build -
   # a branch like 'main' or 'release-0.2', or a tag like 'v0.2'.
-  _PULL_BASE_REF: "master"
+  _PULL_BASE_REF: "main"


### PR DESCRIPTION
This updates the PULL_BASE_REF to main ahead of the branch rename.

Part of https://github.com/kubernetes/contributor-site/issues/686