### PR TITLE
Update CNCF links to use 'main' branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://github.com/kubernetes/community)! The Kubernetes community abides by the CNCF [code of conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Here is an excerpt:
+Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://github.com/kubernetes/community)! The Kubernetes community abides by the CNCF [code of conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Here is an excerpt:
 
 _As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ original location. A list of sources and their locations within the
 
 - **Source:** https://git.k8s.io/community/contributors/guide <br>
   **Destination:** `/guide`
-- **Source:** https://github.com/cncf/foundation/blob/master/code-of-conduct.md <br>
+- **Source:** https://github.com/cncf/foundation/blob/main/code-of-conduct.md <br>
   **Destination:** `/code-of-conduct.md`
 - **Source:** https://git.k8s.io/sig-release/releases/release-1.18/README.md <br>
   **Destination:** `/release.md`

--- a/content/en/blog/2021/peeyush-contributor-story.md
+++ b/content/en/blog/2021/peeyush-contributor-story.md
@@ -24,8 +24,8 @@ If you're mourning that loss,
 know you're not alone.
 Whatever you do to honor him,
 may it be with as much kindness as he brought to others every day.
-We have started to collect some of our <a href="https://github.com/cncf/memorials/blob/master/peeyush-gupta.md" target="_blank" rel="noreferrer">thoughts and memories of Peeyush</a> as a memorial to him and what he brought to the community.
-If you would like to share some of your own, please <a href="https://github.com/cncf/memorials/blob/master/peeyush-gupta.md" target="_blank" rel="noreferrer">open a PR adding your own memories of him.</a>
+We have started to collect some of our <a href="https://github.com/cncf/memorials/blob/main/peeyush-gupta.md" target="_blank" rel="noreferrer">thoughts and memories of Peeyush</a> as a memorial to him and what he brought to the community.
+If you would like to share some of your own, please <a href="https://github.com/cncf/memorials/blob/main/peeyush-gupta.md" target="_blank" rel="noreferrer">open a PR adding your own memories of him.</a>
 
 {{% /alert %}}
 


### PR DESCRIPTION
This PR updates links to the CNCF Foundation (Code of Conduct) and CNCF Memorials repositories to use the `main` branch.

These repositories have already migrated their default branch from `master` to `main`.

Part of #686.
Addressing feedback from #713 review to split changes by repository.