### PR TITLE
Update kubernetes/steering links to use 'main' branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,62 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 - [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](http://git.k8s.io/community/contributors/guide#contributing)
 - [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet) - Common resources for existing developers
 
+## Localization (i18n)
+
+We welcome contributions to localize `kubernetes.dev`. Our localization efforts are conducted in partnership with the **SIG Docs Localization subproject**.
+
+### Governance and Review
+To ensure translation accuracy and consistency across the Kubernetes project:
+- **Delegated Approval**: Approval for localized content is delegated to the established SIG Docs Language Teams. 
+- **Ownership**: Each language directory (e.g., `content/ko/`) should contain an `OWNERS` file that references the corresponding SIG Docs GitHub team (e.g., `@kubernetes/sig-docs-ko-owners`).
+- **Process**: Localization contributors should follow the [SIG Docs Localization guide](https://kubernetes.io/docs/contribute/localization/) for best practices, but all PRs should be opened against the `kubernetes/contributor-site` repository.
+
+### Adding a New Language
+To bootstrap support for a new language on the contributor site:
+
+1. **Update `hugo.yaml`**:
+   Add a new language block under `languages` in the site configuration.
+   ```yaml
+   languages:
+     # ... existing languages
+     ko:
+       contentDir: content/ko
+       title: Kubernetes Contributors
+       languageName: 한국어
+       languageNameLatinScript: Korean
+       weight: 2
+       languagedirection: ltr
+       params:
+         languageNameLatinScript: Korean
+   ```
+
+2. **Create the Content Directory**:
+   Create the base directory for the new language (e.g., `content/ko/`) and copy the `_index.md` from `content/en/` to start.
+
+3. **Set Up the `OWNERS` File**:
+   Add an `OWNERS` file in the root of the new language directory (`content/<lang>/OWNERS`) to properly delegate reviews and approvals to the SIG Docs language team.
+   ```yaml
+   # content/ko/OWNERS
+   # This is the localization project for Korean.
+   # Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+   
+   reviewers:
+   - sig-docs-ko-reviews
+   
+   approvers:
+   - sig-docs-ko-owners
+   
+   labels:
+   - area/localization
+   - language/ko
+   ```
+
+4. **Translate UI Strings**:
+   Create a new translation file in `i18n/<lang>/<lang>.toml` (e.g., `i18n/ko/ko.toml`) and translate the English site strings used in the layouts.
+
+5. **Update README.md**:
+   Add a link to the new localized `README-<lang>.md` file in the root `README.md` under the Localization section.
+
 ## Mentorship
 
 - [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a diverse set of mentorship programs available that are always looking for volunteers!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://github.com/kubernetes/community)! The Kubernetes community abides by the CNCF [code of conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Here is an excerpt:
+Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://github.com/kubernetes/community)! The Kubernetes community abides by the CNCF [code of conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Here is an excerpt:
 
 _As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
 

--- a/OWNERS
+++ b/OWNERS
@@ -14,7 +14,8 @@ filters:
       - TineoC
       - tokt
       - sig-contributor-experience-leads
-  # files/directories related to static site generator
-  "^(assets|layouts|static|package-lock\\.json|package\\.json|netlify\\.toml|hugo\\.yaml)$":
+  # files/directories related to static site generator and localization framework
+  "^(assets|layouts|static|package-lock\\.json|package\\.json|netlify\\.toml|hugo\\.yaml|content/)$":
     reviewers:
       - SayakMukhopadhyay
+      - sig-contribex-website-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,3 +9,32 @@ aliases:
     - mfahlandt
     - palnabarun
     - Priyankasaggu11929
+  sig-contribex-i18n-leads:
+    - kaslin
+    - MadhavJivrajani
+    - mfahlandt
+    - palnabarun
+    - Priyankasaggu11929
+    - dipesh-rawat
+    - divya-mohan0209
+    - katcosgrove
+    - natalisucks
+    - reylejano
+    - salaxander
+    - Tengqm
+    - seokho-son
+  sig-contribex-i18n-tech-leads:
+    - TineoC
+    - lmktfy
+  sig-contribex-website-owners:
+    - TineoC
+  sig-contribex-website-reviewers:
+    - lmktfy
+    - jberkus
+    - reylejano
+  sig-contribex-en-owners:
+    - fsmunoz
+    - TineoC
+    - jberkus
+  sig-contribex-en-reviewers:
+    - lmktfy

--- a/README-en.md
+++ b/README-en.md
@@ -1,0 +1,12 @@
+# Kubernetes Contributor Site - English (en)
+
+This directory contains the English localization of the Kubernetes Contributor Site.
+
+## Contact
+- **Slack**: [#sig-contribex](https://kubernetes.slack.com/messages/sig-contribex)
+- **Mailing List**: [kubernetes-dev](https://groups.google.com/a/kubernetes.io/group/dev)
+
+## Code of Conduct
+All contributors must follow the [Kubernetes Code of Conduct](https://github.com/kubernetes/community/blob/master/code-of-conduct.md).
+
+For more information on contributing to this site, please see the main [README.md](../README.md).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ original location. A list of sources and their locations within the
 
 - **Source:** https://git.k8s.io/community/contributors/guide <br>
   **Destination:** `/guide`
-- **Source:** https://github.com/cncf/foundation/blob/master/code-of-conduct.md <br>
+- **Source:** https://github.com/cncf/foundation/blob/main/code-of-conduct.md <br>
   **Destination:** `/code-of-conduct.md`
 - **Source:** https://git.k8s.io/sig-release/releases/release-1.18/README.md <br>
   **Destination:** `/release.md`

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains the [Hugo][hugo] site and generator scripts for the
 Kubernetes Contributor site. The published website is available at
 https://kubernetes.dev/ (served via Netlify).
 
+## Localization
+
+- [English (en)](README-en.md)
+
 ## Site content
 
 The content for the Contributor Site is sourced from multiple locations.
@@ -18,12 +22,12 @@ original location. A list of sources and their locations within the
 
 ### External sources
 
-- **Source:** https://git.k8s.io/community/contributors/guide <br>
-  **Destination:** `/guide`
-- **Source:** https://github.com/cncf/foundation/blob/main/code-of-conduct.md <br>
-  **Destination:** `/code-of-conduct.md`
-- **Source:** https://git.k8s.io/sig-release/releases/release-1.18/README.md <br>
-  **Destination:** `/release.md`
+- **Source:** [kubernetes/community/contributors/guide](https://git.k8s.io/community/contributors/guide) <br>
+  **Destination:** `/en/docs/guide/`
+- **Source:** [cncf/foundation/code-of-conduct.md](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) <br>
+  **Destination:** `/en/includes/cncf-code-of-conduct.md`
+- **Source:** [kubernetes/sig-release/releases/release-1.36/README.md](https://git.k8s.io/sig-release/releases/release-1.36/README.md) <br>
+  **Destination:** `/en/resources/release/`
 
 ## Running the site locally
 

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -407,26 +407,17 @@ body.td-home div.lead p {
 
 // ===== KEP Listing Full Width =====
 body.kep-listing {
-  overflow-x: hidden;
 
   .td-sidebar-toc {
     display: none !important;
   }
 
-  // Desktop: expand main to fill hidden TOC space, add right padding and border
+  // Desktop & Tablet: expand main to fill hidden TOC space
   main.col-xl-8 {
-    @media (min-width: 1200px) {
+    @media (min-width: 768px) {
       flex: 0 0 83.333333% !important;
       max-width: 83.333333% !important;
       width: 83.333333% !important;
-      padding-right: 3rem !important;
-      border-right: 1px solid #e2e8f0;
-    }
-
-    // Tablet: add right padding and border
-    @media (min-width: 768px) and (max-width: 1199px) {
-      padding-right: 2rem !important;
-      border-right: 1px solid #e2e8f0;
     }
   }
 
@@ -691,7 +682,7 @@ body.kep-listing {
 
 // ===== KEP Table Wrapper =====
 .kep-table-wrapper {
-  overflow-x: hidden;
+  overflow-x: auto;
   width: 100%;
 }
 
@@ -1060,7 +1051,6 @@ body.kep-listing {
   .kep-table-wrapper {
     margin: 0;
     padding: 0;
-    overflow-x: hidden;
   }
 
   #keps-table {

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -28,7 +28,7 @@ body.td-home div.lead p {
 
 /* KEP page styles */
 .kep-page {
-  padding: 1rem 0;
+  padding: 0;
 
   .kep-banner-container {
     background-color: #fff;
@@ -986,7 +986,7 @@ body.kep-listing {
 // ===== Responsive: Phone =====
 @media (max-width: 768px) {
   .kep-page {
-    padding: 0.5rem 0;
+    padding: 0;
   }
 
   .kep-filter-bar {

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -413,18 +413,20 @@ body.kep-listing {
     display: none !important;
   }
 
-  // Desktop: expand main to fill hidden TOC space, add right padding
+  // Desktop: expand main to fill hidden TOC space, add right padding and border
   main.col-xl-8 {
     @media (min-width: 1200px) {
       flex: 0 0 100% !important;
       max-width: 100% !important;
       width: 100% !important;
       padding-right: 3rem !important;
+      border-right: 1px solid #e2e8f0;
     }
 
-    // Tablet: add right padding
+    // Tablet: add right padding and border
     @media (min-width: 768px) and (max-width: 1199px) {
       padding-right: 2rem !important;
+      border-right: 1px solid #e2e8f0;
     }
   }
 

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -404,3 +404,774 @@ body.td-home div.lead p {
     color: #fff;
   }
 }
+
+// ===== KEP Listing Full Width =====
+body.kep-listing {
+  .td-sidebar-toc {
+    display: none !important;
+  }
+
+  // Tablet+: expand main to fill hidden TOC space
+  main.col-xl-8 {
+    @media (min-width: 1200px) {
+      flex: 0 0 100% !important;
+      max-width: 100% !important;
+      width: 100% !important;
+    }
+  }
+
+  // Mobile: hide left sidebar and go full-width
+  @media (max-width: 767px) {
+    .td-sidebar {
+      display: none !important;
+    }
+    main.col-md-9,
+    main.col-xl-8 {
+      flex: 0 0 100% !important;
+      max-width: 100% !important;
+      width: 100% !important;
+      padding-left: 1rem !important;
+      padding-right: 1rem !important;
+    }
+  }
+}
+
+// ===== KEP Filter Bar =====
+.kep-filter-bar {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+
+  .kep-filter-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .kep-filter-selects {
+    gap: 1rem;
+  }
+
+  .kep-filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    flex: 1;
+
+    label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #64748b;
+    }
+
+    select {
+      font-size: 0.85rem;
+      padding: 0.4rem 0.6rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      background: #f8fafc;
+      color: #0f172a;
+      cursor: pointer;
+      min-height: 36px;
+      width: 100%;
+      transition: border-color 0.15s ease;
+
+      &:hover {
+        border-color: #cbd5e1;
+      }
+
+      &:focus-visible {
+        outline: 2px solid #326ce5;
+        outline-offset: 1px;
+        border-color: transparent;
+      }
+    }
+  }
+
+  .kep-stage-toggles {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+
+    legend {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #64748b;
+      margin-bottom: 0.25rem;
+      width: 100%;
+      float: none;
+      padding: 0;
+    }
+  }
+
+  .kep-stage-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 0.3rem 0.65rem;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    border: 1.5px solid transparent;
+    min-height: 32px;
+    font-family: inherit;
+
+    &[aria-checked="true"] {
+      border-color: currentColor;
+      box-shadow: 0 0 0 2px rgba(50, 108, 229, 0.15);
+      font-weight: 700;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #326ce5;
+      outline-offset: 2px;
+    }
+
+    &.kep-stage-alpha {
+      background: #fff8e1;
+      color: #b45309;
+      &[aria-checked="true"] {
+        background: #fef3c7;
+        border-color: #f59e0b;
+      }
+    }
+
+    &.kep-stage-beta {
+      background: #e0f2fe;
+      color: #0369a1;
+      &[aria-checked="true"] {
+        background: #bae6fd;
+        border-color: #0ea5e9;
+      }
+    }
+
+    &.kep-stage-stable {
+      background: #ecfdf5;
+      color: #15803d;
+      &[aria-checked="true"] {
+        background: #d1fae5;
+        border-color: #10b981;
+      }
+    }
+
+    &.kep-stage-deprecated {
+      background: #f3f4f6;
+      color: #4b5563;
+      &[aria-checked="true"] {
+        background: #e5e7eb;
+        border-color: #94a3b8;
+      }
+    }
+
+    &.kep-stage-other {
+      background: #eef2ff;
+      color: #4338ca;
+      &[aria-checked="true"] {
+        background: #e0e7ff;
+        border-color: #6366f1;
+      }
+    }
+  }
+
+  .kep-filter-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .kep-search-group {
+    position: relative;
+    flex: 1;
+    max-width: 400px;
+
+    .kep-search-icon {
+      position: absolute;
+      left: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+      color: #94a3b8;
+      pointer-events: none;
+    }
+
+    .kep-search-input {
+      width: 100%;
+      padding: 0.45rem 0.75rem 0.45rem 2rem;
+      font-size: 0.85rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      background: #f8fafc;
+      color: #0f172a;
+      min-height: 36px;
+      transition: border-color 0.15s ease;
+
+      &::placeholder {
+        color: #94a3b8;
+      }
+
+      &:hover {
+        border-color: #cbd5e1;
+      }
+
+      &:focus-visible {
+        outline: 2px solid #326ce5;
+        outline-offset: 1px;
+        border-color: transparent;
+      }
+    }
+  }
+
+  .kep-results-count {
+    font-size: 0.82rem;
+    color: #64748b;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}
+
+// ===== Filter Toggle (Mobile) =====
+.kep-filter-toggle {
+  display: none;
+  margin-bottom: 1rem;
+}
+
+.kep-filter-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #326ce5;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-family: inherit;
+
+  &:hover {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #326ce5;
+    outline-offset: 2px;
+  }
+}
+
+// ===== KEP Table Wrapper =====
+.kep-table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+// ===== KEP Table Styles =====
+#keps-table {
+  font-size: 0.85rem;
+  width: 100%;
+
+  thead th {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #64748b;
+    background: #f8fafc;
+    white-space: nowrap;
+    padding: 0.65rem 0.5rem;
+    border-bottom: 2px solid #e2e8f0;
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.1s ease;
+    position: relative;
+
+    &:hover {
+      background: #f1f5f9;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #326ce5;
+      outline-offset: -2px;
+    }
+  }
+
+  tbody td {
+    padding: 0.5rem;
+    vertical-align: middle;
+  }
+
+  tbody tr {
+    transition: opacity 0.15s ease;
+
+    &:hover {
+      background: #f8fafc;
+    }
+
+    &:focus-within {
+      outline: 2px solid #326ce5;
+      outline-offset: -2px;
+    }
+  }
+
+  td:first-child {
+    font-family: "JetBrains Mono", "SF Mono", "Fira Code", "Cascadia Code", monospace;
+    font-weight: 600;
+    font-size: 0.78rem;
+  }
+
+  .kep-number-link,
+  .kep-title-link,
+  .kep-sig-link {
+    text-decoration: none;
+    color: #0f172a;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: #326ce5;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #326ce5;
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
+  }
+
+  .kep-title-link {
+    color: #1e293b;
+  }
+
+  .kep-sig-link {
+    color: #475569;
+    font-size: 0.82rem;
+  }
+
+  .kep-author-link {
+    text-decoration: none;
+    color: #64748b;
+    font-size: 0.82rem;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: #326ce5;
+    }
+  }
+
+  .kep-author-etal {
+    color: #94a3b8;
+    font-size: 0.78rem;
+    font-style: italic;
+  }
+}
+
+// ===== Stage Badges in Table =====
+.kep-stage-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  border: 1px solid transparent;
+
+  &.kep-stage-alpha {
+    background: #fff8e1;
+    color: #b45309;
+    border-color: #fef3c7;
+  }
+
+  &.kep-stage-beta {
+    background: #e0f2fe;
+    color: #0369a1;
+    border-color: #bae6fd;
+  }
+
+  &.kep-stage-stable {
+    background: #ecfdf5;
+    color: #15803d;
+    border-color: #d1fae5;
+  }
+
+  &.kep-stage-deprecated {
+    background: #f3f4f6;
+    color: #4b5563;
+    border-color: #e5e7eb;
+  }
+
+  &.kep-stage-other,
+  &.kep-stage-implementable,
+  &.kep-stage-implemented,
+  &.kep-stage-provisional {
+    background: #eef2ff;
+    color: #4338ca;
+    border-color: #e0e7ff;
+  }
+}
+
+// ===== Latest Version Styles =====
+.kep-latest-cell {
+  .kep-latest-version {
+    font-family: "JetBrains Mono", "SF Mono", "Fira Code", "Cascadia Code", monospace;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  .kep-latest-alpha {
+    color: #b45309;
+  }
+
+  .kep-latest-beta {
+    color: #0369a1;
+  }
+
+  .kep-latest-stable {
+    color: #15803d;
+  }
+
+  .kep-latest-deprecated {
+    color: #64748b;
+  }
+}
+
+// ===== No Data Fallback =====
+.kep-no-data {
+  color: #cbd5e1;
+  font-size: 0.78rem;
+}
+
+// ===== DataTable Overrides =====
+.dataTables_wrapper {
+  .dataTables_length {
+    font-size: 0.82rem;
+    color: #64748b;
+    margin-bottom: 0.75rem;
+
+    select {
+      font-size: 0.82rem;
+      padding: 0.2rem 0.4rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 4px;
+      background: #fff;
+      color: #0f172a;
+    }
+  }
+
+  .dataTables_info {
+    font-size: 0.82rem;
+    color: #64748b;
+    padding-top: 0.75rem;
+  }
+
+  .dataTables_paginate {
+    font-size: 0.82rem;
+    padding-top: 0.75rem;
+
+    .paginate_button {
+      padding: 0.3rem 0.6rem;
+      margin: 0 0.1rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 4px;
+      background: #fff;
+      color: #475569 !important;
+      cursor: pointer;
+      transition: all 0.1s ease;
+
+      &:hover {
+        background: #f1f5f9;
+        border-color: #cbd5e1;
+      }
+
+      &.current {
+        background: #326ce5;
+        color: #fff !important;
+        border-color: #326ce5;
+      }
+
+      &.disabled {
+        opacity: 0.4;
+        cursor: default;
+        pointer-events: none;
+      }
+    }
+  }
+
+  .dataTables_filter {
+    display: none;
+  }
+}
+
+// ===== Responsive: Tablet =====
+@media (max-width: 991px) {
+  .kep-filter-bar .kep-filter-selects {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  #keps-table {
+    // Hide Author on tablet
+    th:nth-child(7),
+    td:nth-child(7) {
+      display: none;
+    }
+
+    th, td {
+      padding: 0.45rem 0.4rem;
+    }
+
+    .kep-title-link {
+      font-size: 0.82rem;
+    }
+
+    .kep-stage-badge {
+      font-size: 0.65rem;
+      padding: 0.1rem 0.4rem;
+    }
+  }
+}
+
+// ===== Responsive: Phone =====
+@media (max-width: 768px) {
+  .kep-page {
+    padding: 0.5rem 0;
+  }
+
+  .kep-filter-bar {
+    display: none;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    margin: 0 -1rem 1rem;
+    padding: 0.75rem 1rem;
+
+    &.visible {
+      display: block;
+    }
+
+    .kep-filter-row {
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .kep-filter-actions {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.5rem;
+    }
+
+    .kep-search-group {
+      max-width: none;
+
+      .kep-search-input {
+        font-size: 1rem; // prevent iOS zoom
+        min-height: 40px;
+      }
+    }
+
+    .kep-stage-toggles {
+      gap: 0.3rem;
+      flex-wrap: wrap;
+
+      legend {
+        margin-bottom: 0.15rem;
+      }
+
+      .kep-stage-btn {
+        font-size: 0.7rem;
+        padding: 0.25rem 0.5rem;
+        min-height: 32px;
+      }
+    }
+
+    .kep-results-count {
+      text-align: center;
+      font-size: 0.78rem;
+    }
+  }
+
+  .kep-filter-toggle {
+    display: block;
+    margin-bottom: 0.75rem;
+  }
+
+  .kep-filter-toggle-btn {
+    width: 100%;
+    justify-content: center;
+    padding: 0.6rem 1rem;
+    font-size: 0.9rem;
+    min-height: 44px; // touch target
+  }
+
+  .kep-table-wrapper {
+    margin: 0 -1rem;
+    padding: 0 1rem;
+  }
+
+  #keps-table {
+    font-size: 0.8rem;
+
+    // Hide Created and Author on phone
+    th:nth-child(6),
+    td:nth-child(6),
+    th:nth-child(7),
+    td:nth-child(7) {
+      display: none;
+    }
+
+    // Hide Latest Milestone on small phones
+    th:nth-child(5),
+    td:nth-child(5) {
+      display: none;
+    }
+
+    th, td {
+      padding: 0.35rem 0.3rem;
+    }
+
+    th {
+      font-size: 0.65rem;
+      letter-spacing: 0.04em;
+    }
+
+    td:first-child {
+      font-size: 0.72rem;
+    }
+
+    .kep-title-link {
+      font-size: 0.78rem;
+      line-height: 1.3;
+      display: block;
+      max-width: 180px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .kep-sig-link {
+      font-size: 0.72rem;
+    }
+
+    .kep-stage-badge {
+      font-size: 0.6rem;
+      padding: 0.08rem 0.35rem;
+      letter-spacing: 0;
+    }
+  }
+
+  .dataTables_wrapper {
+    .dataTables_length {
+      display: none;
+    }
+
+    .dataTables_info {
+      font-size: 0.75rem;
+      text-align: center;
+      padding-top: 0.5rem;
+    }
+
+    .dataTables_paginate {
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      padding-top: 0.5rem;
+
+      .paginate_button {
+        padding: 0.4rem 0.6rem;
+        font-size: 0.8rem;
+        min-height: 36px;
+        min-width: 36px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+
+        &.current {
+          min-height: 36px;
+        }
+      }
+    }
+  }
+}
+
+// ===== Responsive: Small Phone =====
+@media (max-width: 480px) {
+  #keps-table {
+    // Hide SIG on very small screens
+    th:nth-child(3),
+    td:nth-child(3) {
+      display: none;
+    }
+
+    // Hide Stage too — only show Number + Title
+    th:nth-child(4),
+    td:nth-child(4) {
+      display: none;
+    }
+
+    .kep-title-link {
+      max-width: 200px;
+      font-size: 0.75rem;
+    }
+  }
+
+  .kep-filter-toggle-btn {
+    font-size: 0.82rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .dataTables_wrapper .dataTables_paginate .paginate_button {
+    padding: 0.35rem 0.5rem;
+    font-size: 0.75rem;
+    min-height: 32px;
+    min-width: 32px;
+  }
+}
+
+// ===== Reduced Motion =====
+@media (prefers-reduced-motion: reduce) {
+  .kep-stage-btn,
+  #keps-table tbody tr,
+  .kep-filter-bar select,
+  .kep-filter-bar .kep-search-input,
+  .kep-filter-toggle-btn,
+  #keps-table a,
+  #keps-table thead th {
+    transition: none;
+  }
+}
+
+// ===== Visually Hidden =====
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  padding: 0;
+  margin: -1px;
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -416,9 +416,9 @@ body.kep-listing {
   // Desktop: expand main to fill hidden TOC space, add right padding and border
   main.col-xl-8 {
     @media (min-width: 1200px) {
-      flex: 0 0 100% !important;
-      max-width: 100% !important;
-      width: 100% !important;
+      flex: 0 0 83.333333% !important;
+      max-width: 83.333333% !important;
+      width: 83.333333% !important;
       padding-right: 3rem !important;
       border-right: 1px solid #e2e8f0;
     }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -413,12 +413,18 @@ body.kep-listing {
     display: none !important;
   }
 
-  // Tablet+: expand main to fill hidden TOC space
+  // Desktop: expand main to fill hidden TOC space, add right padding
   main.col-xl-8 {
     @media (min-width: 1200px) {
       flex: 0 0 100% !important;
       max-width: 100% !important;
       width: 100% !important;
+      padding-right: 3rem !important;
+    }
+
+    // Tablet: add right padding
+    @media (min-width: 768px) and (max-width: 1199px) {
+      padding-right: 2rem !important;
     }
   }
 

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -407,6 +407,8 @@ body.td-home div.lead p {
 
 // ===== KEP Listing Full Width =====
 body.kep-listing {
+  overflow-x: hidden;
+
   .td-sidebar-toc {
     display: none !important;
   }
@@ -681,14 +683,24 @@ body.kep-listing {
 
 // ===== KEP Table Wrapper =====
 .kep-table-wrapper {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
+  overflow-x: hidden;
+  width: 100%;
 }
 
 // ===== KEP Table Styles =====
 #keps-table {
   font-size: 0.85rem;
   width: 100%;
+  table-layout: fixed;
+
+  // Column widths — title gets remaining space
+  .kep-col-number { width: 9%; }
+  .kep-col-title { width: auto; }
+  .kep-col-sig { width: 11%; }
+  .kep-col-stage { width: 10%; }
+  .kep-col-latest { width: 10%; }
+  .kep-col-created { width: 10%; }
+  .kep-col-author { width: 15%; }
 
   thead th {
     font-size: 0.7rem;
@@ -718,6 +730,9 @@ body.kep-listing {
   tbody td {
     padding: 0.5rem;
     vertical-align: middle;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   tbody tr {
@@ -759,6 +774,10 @@ body.kep-listing {
 
   .kep-title-link {
     color: #1e293b;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .kep-sig-link {
@@ -933,14 +952,19 @@ body.kep-listing {
 
   #keps-table {
     // Hide Author on tablet
-    th:nth-child(7),
-    td:nth-child(7) {
+    .kep-col-author {
       display: none;
     }
 
     th, td {
       padding: 0.45rem 0.4rem;
     }
+
+    .kep-col-number { width: 11%; }
+    .kep-col-sig { width: 13%; }
+    .kep-col-stage { width: 12%; }
+    .kep-col-latest { width: 12%; }
+    .kep-col-created { width: 12%; }
 
     .kep-title-link {
       font-size: 0.82rem;
@@ -964,7 +988,7 @@ body.kep-listing {
     border-radius: 0;
     border-left: none;
     border-right: none;
-    margin: 0 -1rem 1rem;
+    margin: 0 0 1rem;
     padding: 0.75rem 1rem;
 
     &.visible {
@@ -1026,24 +1050,18 @@ body.kep-listing {
   }
 
   .kep-table-wrapper {
-    margin: 0 -1rem;
-    padding: 0 1rem;
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
   }
 
   #keps-table {
     font-size: 0.8rem;
 
-    // Hide Created and Author on phone
-    th:nth-child(6),
-    td:nth-child(6),
-    th:nth-child(7),
-    td:nth-child(7) {
-      display: none;
-    }
-
-    // Hide Latest Milestone on small phones
-    th:nth-child(5),
-    td:nth-child(5) {
+    // Hide Created, Author, Latest Milestone on phone
+    .kep-col-created,
+    .kep-col-author,
+    .kep-col-latest {
       display: none;
     }
 
@@ -1060,14 +1078,13 @@ body.kep-listing {
       font-size: 0.72rem;
     }
 
+    .kep-col-number { width: 14%; }
+    .kep-col-sig { width: 20%; }
+    .kep-col-stage { width: 16%; }
+
     .kep-title-link {
       font-size: 0.78rem;
       line-height: 1.3;
-      display: block;
-      max-width: 180px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
     }
 
     .kep-sig-link {
@@ -1119,20 +1136,15 @@ body.kep-listing {
 // ===== Responsive: Small Phone =====
 @media (max-width: 480px) {
   #keps-table {
-    // Hide SIG on very small screens
-    th:nth-child(3),
-    td:nth-child(3) {
+    // Hide SIG and Stage — only Number + Title
+    .kep-col-sig,
+    .kep-col-stage {
       display: none;
     }
 
-    // Hide Stage too — only show Number + Title
-    th:nth-child(4),
-    td:nth-child(4) {
-      display: none;
-    }
+    .kep-col-number { width: 18%; }
 
     .kep-title-link {
-      max-width: 200px;
       font-size: 0.75rem;
     }
   }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -418,6 +418,7 @@ body.kep-listing {
       flex: 0 0 83.333333% !important;
       max-width: 83.333333% !important;
       width: 83.333333% !important;
+      padding: 0 3rem;
     }
   }
 

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -840,10 +840,7 @@ body.kep-listing {
     border-color: #e5e7eb;
   }
 
-  &.kep-stage-other,
-  &.kep-stage-implementable,
-  &.kep-stage-implemented,
-  &.kep-stage-provisional {
+  &.kep-stage-other {
     background: #eef2ff;
     color: #4338ca;
     border-color: #e0e7ff;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -41,7 +41,7 @@ body.td-home div.lead p {
   .kep-banner-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    
+
     @media (max-width: 991px) {
       grid-template-columns: 1fr;
     }
@@ -53,7 +53,7 @@ body.td-home div.lead p {
 
     &.border-start-refined {
       border-left: 1px solid #e0e4e8;
-      
+
       @media (max-width: 991px) {
         border-left: none;
         border-top: 1px solid #e0e4e8;
@@ -149,17 +149,31 @@ body.td-home div.lead p {
         margin-right: 8px;
         display: inline-block;
 
-        &.alpha { background-color: #fbbf24; box-shadow: 0 0 8px rgba(251, 191, 36, 0.4); }
-        &.beta { background-color: #38bdf8; box-shadow: 0 0 8px rgba(56, 189, 248, 0.4); }
-        &.stable { background-color: #34d399; box-shadow: 0 0 8px rgba(52, 211, 153, 0.4); }
-        &.deprecated { background-color: #94a3b8; }
+        &.alpha {
+          background-color: #fbbf24;
+          box-shadow: 0 0 8px rgba(251, 191, 36, 0.4);
+        }
+
+        &.beta {
+          background-color: #38bdf8;
+          box-shadow: 0 0 8px rgba(56, 189, 248, 0.4);
+        }
+
+        &.stable {
+          background-color: #34d399;
+          box-shadow: 0 0 8px rgba(52, 211, 153, 0.4);
+        }
+
+        &.deprecated {
+          background-color: #94a3b8;
+        }
       }
     }
 
     .kep-data-value {
       font-weight: 500;
       color: #1e293b;
-      
+
       code {
         background: #f1f5f9;
         padding: 0.1rem 0.4rem;
@@ -215,12 +229,17 @@ body.td-home div.lead p {
     gap: 6px;
     transition: all 0.2s ease;
 
-    i { color: #94a3b8; }
+    i {
+      color: #94a3b8;
+    }
 
     &:hover {
       color: var(--bs-primary);
       transform: translateX(4px);
-      i { color: var(--bs-primary); }
+
+      i {
+        color: var(--bs-primary);
+      }
     }
   }
 
@@ -231,7 +250,7 @@ body.td-home div.lead p {
 
     li {
       margin-bottom: 0.5rem;
-      
+
       a {
         font-size: 0.85rem;
         color: #334155;
@@ -241,19 +260,24 @@ body.td-home div.lead p {
         gap: 8px;
         transition: all 0.2s ease;
 
-        i { 
+        i {
           font-size: 0.7rem;
-          color: #94a3b8; 
+          color: #94a3b8;
           line-height: 1;
         }
 
         &:hover {
           color: var(--bs-primary);
           transform: translateX(4px);
-          i { color: var(--bs-primary); }
+
+          i {
+            color: var(--bs-primary);
+          }
         }
 
-        strong { font-weight: 500; }
+        strong {
+          font-weight: 500;
+        }
       }
     }
   }
@@ -307,7 +331,6 @@ body.td-home div.lead p {
 
     // Handle tables in markdown
     table {
-      width: 100%;
       margin: 2rem 0;
       border-collapse: separate;
       border-spacing: 0;
@@ -427,6 +450,7 @@ body.kep-listing {
     .td-sidebar {
       display: none !important;
     }
+
     main.col-md-9,
     main.col-xl-8 {
       flex: 0 0 100% !important;
@@ -550,6 +574,7 @@ body.kep-listing {
     &.kep-stage-alpha {
       background: #fff8e1;
       color: #b45309;
+
       &[aria-checked="true"] {
         background: #fef3c7;
         border-color: #f59e0b;
@@ -559,6 +584,7 @@ body.kep-listing {
     &.kep-stage-beta {
       background: #e0f2fe;
       color: #0369a1;
+
       &[aria-checked="true"] {
         background: #bae6fd;
         border-color: #0ea5e9;
@@ -568,6 +594,7 @@ body.kep-listing {
     &.kep-stage-stable {
       background: #ecfdf5;
       color: #15803d;
+
       &[aria-checked="true"] {
         background: #d1fae5;
         border-color: #10b981;
@@ -577,6 +604,7 @@ body.kep-listing {
     &.kep-stage-deprecated {
       background: #f3f4f6;
       color: #4b5563;
+
       &[aria-checked="true"] {
         background: #e5e7eb;
         border-color: #94a3b8;
@@ -586,6 +614,7 @@ body.kep-listing {
     &.kep-stage-other {
       background: #eef2ff;
       color: #4338ca;
+
       &[aria-checked="true"] {
         background: #e0e7ff;
         border-color: #6366f1;
@@ -683,24 +712,43 @@ body.kep-listing {
 
 // ===== KEP Table Wrapper =====
 .kep-table-wrapper {
-  overflow-x: auto;
-  width: 100%;
+  overflow-x: visible;
+  min-width: 0;
 }
 
 // ===== KEP Table Styles =====
 #keps-table {
   font-size: 0.85rem;
-  width: 100%;
   table-layout: fixed;
 
   // Column widths — title gets remaining space
-  .kep-col-number { width: 9%; }
-  .kep-col-title { width: auto; }
-  .kep-col-sig { width: 11%; }
-  .kep-col-stage { width: 10%; }
-  .kep-col-latest { width: 10%; }
-  .kep-col-created { width: 10%; }
-  .kep-col-author { width: 15%; }
+  .kep-col-number {
+    width: 9%;
+  }
+
+  .kep-col-title {
+    width: auto;
+  }
+
+  .kep-col-sig {
+    width: 11%;
+  }
+
+  .kep-col-stage {
+    width: 10%;
+  }
+
+  .kep-col-latest {
+    width: 10%;
+  }
+
+  .kep-col-created {
+    width: 10%;
+  }
+
+  .kep-col-author {
+    width: 15%;
+  }
 
   thead th {
     font-size: 0.7rem;
@@ -715,7 +763,9 @@ body.kep-listing {
     cursor: pointer;
     user-select: none;
     transition: background 0.1s ease;
-    position: relative;
+    position: sticky;
+    top: 0;
+    z-index: 10;
 
     &:hover {
       background: #f1f5f9;
@@ -881,6 +931,8 @@ body.kep-listing {
 
 // ===== DataTable Overrides =====
 .dataTables_wrapper {
+  overflow-x: visible;
+
   .dataTables_length {
     font-size: 0.82rem;
     color: #64748b;
@@ -948,20 +1000,46 @@ body.kep-listing {
   }
 
   #keps-table {
-    // Hide Author on tablet
+
+    // Hide Author on tablet - remove width so it doesn't take space
     .kep-col-author {
+      display: none;
+      width: 0;
+      padding: 0;
+      border: 0;
+    }
+
+    th.kep-col-author,
+    td.kep-col-author {
       display: none;
     }
 
-    th, td {
+    th,
+    td {
       padding: 0.45rem 0.4rem;
     }
 
-    .kep-col-number { width: 11%; }
-    .kep-col-sig { width: 13%; }
-    .kep-col-stage { width: 12%; }
-    .kep-col-latest { width: 12%; }
-    .kep-col-created { width: 12%; }
+    // Redistribute widths for 6 visible columns (Author hidden)
+    // Total: Number(12%) + SIG(13%) + Stage(13%) + Latest(13%) + Created(13%) + Title(36%) = 100%
+    .kep-col-number {
+      width: 12%;
+    }
+
+    .kep-col-sig {
+      width: 13%;
+    }
+
+    .kep-col-stage {
+      width: 13%;
+    }
+
+    .kep-col-latest {
+      width: 13%;
+    }
+
+    .kep-col-created {
+      width: 13%;
+    }
 
     .kep-title-link {
       font-size: 0.82rem;
@@ -971,6 +1049,14 @@ body.kep-listing {
       font-size: 0.65rem;
       padding: 0.1rem 0.4rem;
     }
+  }
+}
+
+// ===== Enable horizontal scroll only on larger screens =====
+@media (min-width: 992px) {
+  #keps-table {
+    min-width: 800px;
+    overflow-x: auto;
   }
 }
 
@@ -1054,14 +1140,30 @@ body.kep-listing {
   #keps-table {
     font-size: 0.8rem;
 
-    // Hide Created, Author, Latest Milestone on phone
+    // Hide SIG, Created, Author, Latest Milestone on phone
+    .kep-col-sig,
     .kep-col-created,
     .kep-col-author,
     .kep-col-latest {
       display: none;
+      width: 0;
+      padding: 0;
+      border: 0;
     }
 
-    th, td {
+    th.kep-col-sig,
+    td.kep-col-sig,
+    th.kep-col-created,
+    td.kep-col-created,
+    th.kep-col-author,
+    td.kep-col-author,
+    th.kep-col-latest,
+    td.kep-col-latest {
+      display: none;
+    }
+
+    th,
+    td {
       padding: 0.35rem 0.3rem;
     }
 
@@ -1074,9 +1176,19 @@ body.kep-listing {
       font-size: 0.72rem;
     }
 
-    .kep-col-number { width: 14%; }
-    .kep-col-sig { width: 20%; }
-    .kep-col-stage { width: 16%; }
+    // Redistribute widths for 3 visible columns (Number, Title, Stage)
+    // Number(20%) + Stage(20%) + Title(60%) = 100%
+    .kep-col-number {
+      width: 20%;
+    }
+
+    .kep-col-title {
+      width: 60%;
+    }
+
+    .kep-col-stage {
+      width: 20%;
+    }
 
     .kep-title-link {
       font-size: 0.78rem;
@@ -1109,20 +1221,20 @@ body.kep-listing {
       display: flex;
       justify-content: center;
       flex-wrap: wrap;
-      gap: 0.25rem;
+      gap: 0.5rem;
       padding-top: 0.5rem;
 
       .paginate_button {
-        padding: 0.4rem 0.6rem;
-        font-size: 0.8rem;
-        min-height: 36px;
-        min-width: 36px;
+        padding: 0.5rem 0.75rem;
+        font-size: 0.85rem;
+        min-height: 44px;
+        min-width: 44px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
 
         &.current {
-          min-height: 36px;
+          min-height: 44px;
         }
       }
     }
@@ -1132,13 +1244,34 @@ body.kep-listing {
 // ===== Responsive: Small Phone =====
 @media (max-width: 480px) {
   #keps-table {
-    // Hide SIG and Stage — only Number + Title
-    .kep-col-sig,
-    .kep-col-stage {
+
+    // Keep SIG hidden (inherits from parent), but keep Stage visible
+    // Shows 3 columns: Number, Title, Stage
+    .kep-col-sig {
+      display: none;
+      width: 0;
+      padding: 0;
+      border: 0;
+    }
+
+    th.kep-col-sig,
+    td.kep-col-sig {
       display: none;
     }
 
-    .kep-col-number { width: 18%; }
+    // Redistribute widths for 3 visible columns (Number + Title + Stage)
+    // Number(20%) + Stage(20%) + Title(60%) = 100%
+    .kep-col-number {
+      width: 20%;
+    }
+
+    .kep-col-title {
+      width: 60%;
+    }
+
+    .kep-col-stage {
+      width: 20%;
+    }
 
     .kep-title-link {
       font-size: 0.75rem;
@@ -1151,15 +1284,16 @@ body.kep-listing {
   }
 
   .dataTables_wrapper .dataTables_paginate .paginate_button {
-    padding: 0.35rem 0.5rem;
-    font-size: 0.75rem;
-    min-height: 32px;
-    min-width: 32px;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+    min-height: 44px;
+    min-width: 44px;
   }
 }
 
 // ===== Reduced Motion =====
 @media (prefers-reduced-motion: reduce) {
+
   .kep-stage-btn,
   #keps-table tbody tr,
   .kep-filter-bar select,

--- a/content/en/OWNERS
+++ b/content/en/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the localization project for English.
+# Teams and members are visible in the root OWNERS_ALIASES file.
+
+reviewers:
+- sig-contribex-en-reviewers
+
+approvers:
+- sig-contribex-en-owners
+
+labels:
+- area/localization
+- language/en

--- a/content/en/blog/2021/peeyush-contributor-story.md
+++ b/content/en/blog/2021/peeyush-contributor-story.md
@@ -24,8 +24,8 @@ If you're mourning that loss,
 know you're not alone.
 Whatever you do to honor him,
 may it be with as much kindness as he brought to others every day.
-We have started to collect some of our <a href="https://github.com/cncf/memorials/blob/master/peeyush-gupta.md" target="_blank" rel="noreferrer">thoughts and memories of Peeyush</a> as a memorial to him and what he brought to the community.
-If you would like to share some of your own, please <a href="https://github.com/cncf/memorials/blob/master/peeyush-gupta.md" target="_blank" rel="noreferrer">open a PR adding your own memories of him.</a>
+We have started to collect some of our <a href="https://github.com/cncf/memorials/blob/main/peeyush-gupta.md" target="_blank" rel="noreferrer">thoughts and memories of Peeyush</a> as a memorial to him and what he brought to the community.
+If you would like to share some of your own, please <a href="https://github.com/cncf/memorials/blob/main/peeyush-gupta.md" target="_blank" rel="noreferrer">open a PR adding your own memories of him.</a>
 
 {{% /alert %}}
 

--- a/content/en/blog/2023/2023-10-02-steering-committee-results-2023.md
+++ b/content/en/blog/2023/2023-10-02-steering-committee-results-2023.md
@@ -8,7 +8,7 @@ author: "Kaslin Fields"
 
 The [2023 Steering Committee Election](https://github.com/kubernetes/community/tree/master/events/elections/2023) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2023. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
-This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/master/charter.md).
+This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/main/master/charter.md).
 
 Thank you to everyone who voted in the election; your participation helps support the community’s continued health and success.
 

--- a/content/en/blog/2023/2023-10-02-steering-committee-results-2023.md
+++ b/content/en/blog/2023/2023-10-02-steering-committee-results-2023.md
@@ -8,7 +8,7 @@ author: "Kaslin Fields"
 
 The [2023 Steering Committee Election](https://github.com/kubernetes/community/tree/master/events/elections/2023) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2023. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
-This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/main/master/charter.md).
+This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee's role in their [charter](https://github.com/kubernetes/steering/blob/main/charter.md).
 
 Thank you to everyone who voted in the election; your participation helps support the community’s continued health and success.
 

--- a/content/en/blog/2024/steering-committee-results-2024.md
+++ b/content/en/blog/2024/steering-committee-results-2024.md
@@ -8,7 +8,7 @@ author: "Bridget Kromhout"
 
 The [2024 Steering Committee Election](https://github.com/kubernetes/community/tree/master/elections/steering/2024) is now complete. The Kubernetes Steering Committee consists of 7 seats, 3 of which were up for election in 2024. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
-This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/master/charter.md).
+This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/main/master/charter.md).
 
 Thank you to everyone who voted in the election; your participation helps support the community’s continued health and success.
 

--- a/content/en/blog/2024/steering-committee-results-2024.md
+++ b/content/en/blog/2024/steering-committee-results-2024.md
@@ -8,7 +8,7 @@ author: "Bridget Kromhout"
 
 The [2024 Steering Committee Election](https://github.com/kubernetes/community/tree/master/elections/steering/2024) is now complete. The Kubernetes Steering Committee consists of 7 seats, 3 of which were up for election in 2024. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
-This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/main/master/charter.md).
+This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee's role in their [charter](https://github.com/kubernetes/steering/blob/main/charter.md).
 
 Thank you to everyone who voted in the election; your participation helps support the community’s continued health and success.
 

--- a/content/en/blog/2025/steering-committee-results-2025.md
+++ b/content/en/blog/2025/steering-committee-results-2025.md
@@ -8,7 +8,7 @@ author: "Arujjwal Negi"
 
 The [2025 Steering Committee Election](https://github.com/kubernetes/community/tree/master/elections/steering/2025) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2025. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
-The Steering Committee oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/master/charter.md).
+The Steering Committee oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/main/master/charter.md).
 
 Thank you to everyone who voted in the election; your participation helps support the community’s continued health and success.
 

--- a/content/en/blog/2025/steering-committee-results-2025.md
+++ b/content/en/blog/2025/steering-committee-results-2025.md
@@ -8,7 +8,7 @@ author: "Arujjwal Negi"
 
 The [2025 Steering Committee Election](https://github.com/kubernetes/community/tree/master/elections/steering/2025) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2025. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
-The Steering Committee oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/main/master/charter.md).
+The Steering Committee oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee's role in their [charter](https://github.com/kubernetes/steering/blob/main/charter.md).
 
 Thank you to everyone who voted in the election; your participation helps support the community’s continued health and success.
 

--- a/content/en/blog/2026/image-signature-routing.md
+++ b/content/en/blog/2026/image-signature-routing.md
@@ -1,0 +1,151 @@
+---
+layout: blog
+title: "Eliminating Kubernetes Image Signature Replication"
+draft: true
+date: 2026-05-18
+slug: image-signature-routing
+author: >
+  Sascha Grunert (Red Hat)
+---
+
+The [image promoter rewrite](https://kubernetes.io/blog/2026/03/17/image-promoter-rewrite/) laid the
+groundwork for simplifying how Kubernetes delivers container image signatures.
+One of the rewrite phases (Phase 6) separated image signing from signature
+replication into distinct pipeline stages. This follow-up covers the next step:
+eliminating signature replication entirely.
+
+## The problem
+
+After promoting container images to `registry.k8s.io`, the promoter signs them
+using [cosign](https://github.com/sigstore/cosign) with keyless (OIDC)
+signatures. These signatures are stored as OCI artifacts alongside the images,
+tagged with the convention `sha256-<digest>.sig` and `sha256-<digest>.att`.
+
+The `registry.k8s.io` domain is backed by [archeio](https://github.com/kubernetes/registry.k8s.io/blob/main/cmd/archeio/README.md),
+a thin redirector that routes container image requests to the nearest regional
+[Google Artifact Registry](https://cloud.google.com/artifact-registry) backend.
+When a user in Europe pulls an image, archeio redirects them to
+`europe-west2-docker.pkg.dev`; a user in Asia gets redirected to
+`asia-east1-docker.pkg.dev`, and so on across 22 regional backends.
+
+This geo-routing is great for image layers, where download locality matters for
+performance. But it created a problem for signatures: if the promoter only wrote
+a signature to one region, `cosign verify` would fail for users redirected to
+any other region. The solution was a dedicated replication pipeline that copied
+every `.sig` and `.att` tag to all 22 regional backends. This pipeline ran as a
+[periodic Prow job](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-k8sio-image-signature-replication)
+every 2 hours on weekdays, performing thousands of API calls per run: listing
+tags across all repositories, diffing what existed where, and copying the
+missing signatures.
+
+## The insight
+
+Signatures and attestations are small metadata artifacts, typically a few
+kilobytes each. Unlike image layers where geo-locality provides meaningful
+download performance improvements, fetching a signature from a non-local region
+adds negligible latency. The entire replication pipeline existed to optimize for
+a latency difference that users would never notice.
+
+## The solution
+
+Instead of replicating signatures everywhere, archeio was taught to route
+signature requests to a single canonical upstream. The change is
+straightforward: when archeio receives a manifest request for a tag matching
+`sha256-*.sig` or `sha256-*.att`, it redirects to
+`us-central1-docker.pkg.dev` (the canonical region) instead of the
+caller's nearest regional backend. All other requests continue to use
+geo-routing as before.
+
+```text
+Normal image pull:
+  registry.k8s.io ⟶ (geo-routing) ⟶ europe-west2-docker.pkg.dev
+
+Signature verification:
+  registry.k8s.io ⟶ (canonical)   ⟶ us-central1-docker.pkg.dev
+```
+
+This is configured through a new `SIGNATURE_UPSTREAM_ENDPOINT` environment
+variable on each Cloud Run instance that runs archeio.
+
+On the promoter side, the signing target was updated to explicitly use
+`us-central1-docker.pkg.dev` as the canonical registry, instead of relying on
+alphabetical sorting of registry names (which would have picked
+`asia-east1-docker.pkg.dev`). The `replicate-signatures` subcommand was then
+removed along with all supporting code.
+
+## What changed
+
+The rollout was sequenced to ensure signature verification kept working at
+every step:
+
+1. [kubernetes/registry.k8s.io#321](https://github.com/kubernetes/registry.k8s.io/pull/321):
+   Added `SIGNATURE_UPSTREAM_ENDPOINT` support to archeio
+2. [kubernetes/k8s.io#9413](https://github.com/kubernetes/k8s.io/pull/9413):
+   Deployed the new environment variable to all Cloud Run instances and updated
+   the archeio image digest
+3. Verified that `cosign verify` works against `registry.k8s.io` and that
+   `.sig`/`.att` requests redirect to `us-central1-docker.pkg.dev`
+4. [kubernetes-sigs/promo-tools#1829](https://github.com/kubernetes-sigs/promo-tools/pull/1829):
+   Removed the replication pipeline and updated the signing target, released
+   as [kpromo v4.5.0](https://github.com/kubernetes-sigs/promo-tools/releases/tag/v4.5.0)
+5. [kubernetes/test-infra#36909](https://github.com/kubernetes/test-infra/pull/36909):
+   Removed the periodic Prow replication job
+
+## Impact
+
+Removing signature replication:
+
+- **Eliminates thousands of API calls** that were spent listing tags and
+  copying signatures across 22 regions every 2 hours
+- **Removes a source of transient failures**, since the replication job was
+  susceptible to Artifact Registry rate limits
+- **Simplifies the promoter codebase** by deleting the two-phase tag listing,
+  multi-registry grouping logic, and concurrent copy orchestration (over 1,200
+  lines removed)
+- **Removes a periodic Prow job** that ran on weekdays
+
+End users see no change. `cosign verify` against `registry.k8s.io` continues to
+work exactly as before:
+
+```shell
+cosign verify registry.k8s.io/kube-apiserver:v1.36.0 \
+  --certificate-identity krel-trust@k8s-releng-prod.iam.gserviceaccount.com \
+  --certificate-oidc-issuer https://accounts.google.com
+```
+
+## Trade-offs
+
+Routing all signature requests to a single region means that if
+`us-central1` is unavailable, `cosign verify` for images served through
+`registry.k8s.io` would fail until the region recovers. This is the main
+trade-off of the approach.
+
+A few mitigating factors make this acceptable in practice:
+
+- Artifact Registry is a managed Google Cloud service with high regional
+  availability. An outage of `us-central1` would likely affect far more
+  than just signature serving.
+- Signatures are small metadata (a few KB). Even during normal operation,
+  cosign already depends on registry availability for verification, whether
+  the manifest comes from a regional or central backend.
+- Image pulls themselves are unaffected. Geo-routing for image layers
+  continues to work independently of signature availability.
+
+## What's next
+
+The broader Kubernetes ecosystem is moving toward
+[OCI 1.1 referrers](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers)
+for signature discovery, replacing the tag-based convention that cosign has used
+historically. cosign v3 defaults to storing signatures as OCI referrers. As this
+migration progresses, the tag-matching logic in archeio can eventually be
+replaced with referrer-aware routing.
+
+## Getting involved
+
+This work is tracked in
+[kubernetes-sigs/promo-tools#1762](https://github.com/kubernetes-sigs/promo-tools/issues/1762).
+If you are interested in contributing to
+[SIG Release](https://www.kubernetes.dev/community/community-groups/sigs/release/),
+join our [weekly meeting](http://bit.ly/k8s-sig-release-meeting) or reach out on
+the [#sig-release](https://kubernetes.slack.com/messages/sig-release) Slack
+channel.

--- a/content/en/blog/2026/sig-storage-spotlight-2026.md
+++ b/content/en/blog/2026/sig-storage-spotlight-2026.md
@@ -1,0 +1,201 @@
+---
+layout: blog
+title: "Spotlight on SIG Storage"
+slug: sig-storage-spotlight-2026
+date: 2026-04-15
+author: "Darshan Murthy (Apple)"
+---
+
+In our ongoing SIG Spotlight series, we shine a light on the groups that keep the Kubernetes project
+moving forward. This time, we catch up with **[SIG
+Storage](https://github.com/kubernetes/community/tree/master/sig-storage)**, the group responsible
+for persistent data, volume management, and the interfaces that connect Kubernetes workloads to the
+storage systems beneath them.
+
+We spoke with [Xing Yang](https://github.com/xing-yang), Co-Chair of SIG Storage and Software
+Engineer at VMware by Broadcom, about the SIG's history, the features shipping in recent Kubernetes
+releases, and where storage in Kubernetes is headed as AI workloads become the norm.
+
+## Introductions
+
+**Could you introduce yourself and share your role(s) within SIG Storage?**
+
+My name is Xing Yang, a software engineer at VMware by Broadcom. I'm a co-chair in SIG Storage,
+alongside another co-chair Saad Ali from Google. There are also two Tech Leads in SIG Storage:
+Michelle Au from Google and Jan Šafránek from Red Hat.
+
+**What first drew you to storage in Kubernetes, and how did you start contributing?**
+
+I have always been working in the storage domain, so SIG Storage was a natural place for me to get
+started when I began to learn Kubernetes. I started attending SIG Storage meetings, trying to figure
+out what I could do to help. This was before the first Container Storage Interface (CSI) release —
+lots of things were still evolving. It was a very exciting time.
+
+**What subprojects or areas do you actively maintain or review today?**
+
+I'm a maintainer in Kubernetes CSI. There are multiple CSI sidecars — such as `csi-provisioner`,
+`csi-attacher`, `csi-resizer`, and `csi-snapshotter` — that we need to release following every
+Kubernetes release. I'm also a co-chair for a Data Protection Working Group co-sponsored by SIG
+Storage and SIG Apps. Several features have come out of that WG aimed at filling gaps in data
+protection support within Kubernetes. One is [Volume Group
+Snapshot](https://kubernetes.io/docs/concepts/storage/volume-group-snapshots/), which provides
+crash-consistent group snapshots for multiple volumes used by an application. [Changed Block
+Tracking](https://github.com/kubernetes/enhancements/issues/3314) (CBT) is another critical feature
+from the DP WG designed to support efficient backups.
+
+## About SIG Storage
+
+**For folks who are new: what is SIG Storage, in your own words? What problems in Kubernetes are
+you trying to solve?**
+
+SIG Storage is a Special Interest Group focused on how to provide storage to containers running in
+your Kubernetes cluster. We define standard interfaces so that a storage vendor can write a driver
+and have its underlying storage system consumed by containers in Kubernetes.
+
+**Why does Kubernetes need a dedicated storage SIG — what makes storage hard in a distributed
+system?**
+
+When Kubernetes was first introduced, it was meant for stateless workloads only. Container
+applications were regarded as ephemeral and therefore did not need to persist data. However, that
+changed drastically. Stateful workloads started running in Kubernetes, and we needed a dedicated
+SIG to tackle the associated storage challenges. PersistentVolumeClaims, PersistentVolumes, and
+StorageClasses were all introduced to provision data volumes for applications running in Kubernetes.
+
+**How did SIG Storage originally form, and how has its mission changed over time?**
+
+SIG Storage was formed to address the challenges of handling persistent data within Kubernetes.
+Initially, PersistentVolumes were implemented as in-tree plugins, and the SIG managed those plugins
+while developing core storage primitives like PersistentVolumes and PersistentVolumeClaims.
+
+Container Storage Interface (CSI) was introduced later and played a crucial role in simplifying
+storage integration, enabling third-party storage providers to develop and maintain their own
+out-of-tree plugins without modifying Kubernetes core code.
+
+With basic integration addressed by CSI, the SIG's mission expanded to include advanced storage
+features that leverage the new interface. The SIG has also expanded its scope to support object
+storage through the Container Object Storage Interface (COSI).
+
+## Current Work and Roadmap
+
+**What are the top features SIG Storage is actively working on right now?**
+
+The Data Protection WG has been working on a couple of exciting features:
+
+- **VolumeGroupSnapshot** is a Kubernetes feature enabling a crash-consistent, point-in-time
+  snapshot of multiple PersistentVolumes simultaneously. This ensures data integrity for
+  applications — like databases — that rely on multiple volumes by capturing all volumes in the
+  group atomically, at the exact same point in time. We are targeting GA in the Kubernetes 1.36
+  release.
+
+- **CSI Changed Block Tracking (CBT)** enables efficient, incremental backups. By allowing storage
+  systems to report only the blocks that have changed since the last snapshot, it significantly
+  reduces the amount of data that needs to be transferred. We are targeting Beta in Kubernetes 1.36.
+
+Another feature worth highlighting is **Container Object Storage Interface (COSI)**. COSI provides
+a standard interface for provisioning and consuming object storage buckets in Kubernetes —
+standardizing object storage for containerized applications much like CSI did for block and file
+storage. COSI is now transitioning to v1alpha2, with plans for promotion to Beta in a future
+release.
+
+**What recent work from SIG Storage do you consider a "win" for users?**
+
+The graduation of [VolumeAttributesClass](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/)
+to GA in Kubernetes v1.34 is a major win for users managing stateful workloads. Previously,
+changing volume attributes like IOPS or throughput required out-of-band actions or disruptive
+operations. Now, users can dynamically tune storage properties such as IOPS or throughput directly
+through the Kubernetes API — scaling up for peak loads or down to optimize costs — without external
+processes or downtime.
+
+VolumeAttributesClass enables dynamic modification of storage characteristics without recreating
+the volume. This completes the picture by allowing users to tune both capacity and other storage
+properties dynamically, just as they can now tune both CPU and memory for compute.
+
+**Looking ahead one or two releases, what's on the roadmap that people should watch for?**
+
+I'd like to draw attention to the [Volume Health
+feature](https://github.com/kubernetes/enhancements/issues/1432). This feature is designed to offer
+critical visibility into the operational status and integrity of persistent volumes. By enabling
+storage drivers and the Kubernetes control plane to report issues, it allows for proactive
+monitoring and identification of volume-related problems.
+
+Currently, volume health information is reported via non-persistent events. We are actively
+investigating enhancements to this feature with the goal of supporting automated remediation
+capabilities in the future.
+
+**Are there areas where you'd really like more discussion or help from the community?**
+
+We always need help from the community to fix bugs, add tests, and help with reviews.
+
+We'd also like to get feedback on the Alpha feature [Mutable PV
+Affinity](https://github.com/kubernetes/enhancements/issues/4762), which was introduced in
+Kubernetes v1.35. Use cases include migrating volumes from zonal to regional storage or migrating
+from one disk type to another.
+
+Another topic is **volume replication**. It was raised at KubeCon Atlanta and has been discussed
+in the Data Protection WG. Community members interested in this topic are encouraged to join the DP
+WG meetings.
+
+**What are the biggest challenges users face today when running stateful workloads on Kubernetes?**
+
+While Kubernetes has moved stateful workloads — like databases and AI pipelines — into the
+mainstream, managing "state" in a system designed for ephemerality remains difficult:
+
+- **Data Gravity and Storage Locality**: Pods move in seconds, but data has gravity. If a node
+  fails, a pod using local storage is stuck. Operators must decide whether the failure is transient
+  or permanent — a high-stakes call. This is why we are enhancing the Volume Health feature to
+  provide the visibility needed to automate recovery choices.
+
+- **Day 2 Complexity**: Setting up a database is easy; maintaining its health over time is the real
+  challenge. Standard Kubernetes objects like StatefulSets offer a baseline, but they lack the
+  operational logic needed for tasks such as schema upgrades, engine patching, or cluster-wide
+  Kubernetes upgrades.
+
+- **Data Mobility**: Moving persistent data remains a significant hurdle — whether migrating between
+  storage tiers, shifting workloads across availability zones, or moving to a different cluster.
+  This challenge includes ongoing synchronization and replication for high availability and disaster
+  recovery across a distributed system.
+
+## Storage and AI
+
+**How do you see storage evolving in Kubernetes over the next few years, especially as AI/ML
+workloads grow?**
+
+I see several trends shaping storage in Kubernetes as it evolves from a container orchestrator into
+the "Operating System" for AI:
+
+- **More Intelligent Data Management**: We'll see a shift toward smarter CSI drivers and data
+  management tools offering advanced features like automatic tiering, snapshots, migration, and
+  replication — optimized specifically for high-performance AI/ML workflows and large data
+  platforms.
+
+- **Object Storage as a First-Class Citizen**: AI datasets now frequently reach exabyte scale,
+  making object storage the preferred choice for AI workloads. COSI is standardizing bucket
+  management just as CSI did for disks, allowing data scientists to use a `BucketClaim` to
+  provision S3-compatible storage natively and unifying object, file, and block storage into a
+  single workflow.
+
+- **Performance and Low Latency**: For AI/ML, storage needs to keep up with GPU processing speeds.
+  This will accelerate adoption of high-performance parallel file systems and NVMe-over-Fabrics
+  (NVMe-oF) technologies managed natively via Kubernetes. The line between traditional block/file
+  and memory-speed storage will continue to blur.
+
+- **Data-Aware Scheduling**: Instead of just considering CPU and RAM, the Kubernetes scheduler will
+  increasingly prioritize placing Pods based on data locality — calculating the cost of moving data
+  versus moving compute to keep massive data platforms performant.
+
+---
+
+SIG Storage continues to tackle some of the hardest problems in Kubernetes: keeping stateful
+applications running reliably, making storage operations transparent and composable, and now
+scaling up to meet the demands of AI-era workloads. Whether you're a user managing databases in
+production or a developer curious about storage internals, there's a place for you in SIG Storage.
+
+If you'd like to get involved, check out the [SIG Storage community
+page](https://github.com/kubernetes/community/tree/master/sig-storage) and join the [bi-weekly
+meetings](https://github.com/kubernetes/community/tree/master/sig-storage#meetings). You can also
+find the SIG on Slack at
+[#sig-storage](https://kubernetes.slack.com/messages/sig-storage).
+
+- [SIG Storage Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
+- [SIG Storage on Slack](https://kubernetes.slack.com/messages/sig-storage)
+- [Data Protection WG](https://github.com/kubernetes/community/blob/master/wg-data-protection/README.md)

--- a/content/en/blog/2026/sig-storage-spotlight-2026.md
+++ b/content/en/blog/2026/sig-storage-spotlight-2026.md
@@ -3,6 +3,7 @@ layout: blog
 title: "Spotlight on SIG Storage"
 slug: sig-storage-spotlight-2026
 date: 2026-04-15
+draft: true
 author: "Darshan Murthy (Apple)"
 ---
 
@@ -20,23 +21,23 @@ releases, and where storage in Kubernetes is headed as AI workloads become the n
 
 **Could you introduce yourself and share your role(s) within SIG Storage?**
 
-My name is Xing Yang, a software engineer at VMware by Broadcom. I'm a co-chair in SIG Storage,
-alongside another co-chair Saad Ali from Google. There are also two Tech Leads in SIG Storage:
-Michelle Au from Google and Jan Šafránek from Red Hat.
+My name is [Xing Yang](https://github.com/xing-yang), a software engineer at VMware by Broadcom. I'm a co-chair in SIG Storage,
+alongside another co-chair [Saad Ali](https://github.com/saad-ali) from Google. There are also two Tech Leads in SIG Storage:
+[Michelle Au](https://github.com/msau42) from Google and [Jan Šafránek](https://github.com/jsafrane) from Red Hat.
 
 **What first drew you to storage in Kubernetes, and how did you start contributing?**
 
 I have always been working in the storage domain, so SIG Storage was a natural place for me to get
-started when I began to learn Kubernetes. I started attending SIG Storage meetings, trying to figure
-out what I could do to help. This was before the first Container Storage Interface (CSI) release —
+started when I began to learn Kubernetes. I started attending [SIG Storage meetings](https://github.com/kubernetes/community/blob/main/sig-storage/README.md#meetings), trying to figure
+out what I could do to help. This was before the first [Container Storage Interface](https://github.com/container-storage-interface/spec/blob/master/spec.md) (CSI) release —
 lots of things were still evolving. It was a very exciting time.
 
 **What subprojects or areas do you actively maintain or review today?**
 
 I'm a maintainer in Kubernetes CSI. There are multiple CSI sidecars — such as `csi-provisioner`,
 `csi-attacher`, `csi-resizer`, and `csi-snapshotter` — that we need to release following every
-Kubernetes release. I'm also a co-chair for a Data Protection Working Group co-sponsored by SIG
-Storage and SIG Apps. Several features have come out of that WG aimed at filling gaps in data
+Kubernetes release. I'm also a co-chair for a [Data Protection Working Group](https://github.com/kubernetes/community/blob/main/wg-data-protection/README.md) co-sponsored by SIG
+Storage and [SIG Apps](https://github.com/kubernetes/community/tree/main/sig-apps). Several features have come out of that WG aimed at filling gaps in data
 protection support within Kubernetes. One is [Volume Group
 Snapshot](https://kubernetes.io/docs/concepts/storage/volume-group-snapshots/), which provides
 crash-consistent group snapshots for multiple volumes used by an application. [Changed Block
@@ -48,24 +49,24 @@ from the DP WG designed to support efficient backups.
 **For folks who are new: what is SIG Storage, in your own words? What problems in Kubernetes are
 you trying to solve?**
 
-SIG Storage is a Special Interest Group focused on how to provide storage to containers running in
+SIG Storage is a [Special Interest Group](https://github.com/kubernetes/community/blob/main/governance.md) focused on how to provide storage to containers running in
 your Kubernetes cluster. We define standard interfaces so that a storage vendor can write a driver
 and have its underlying storage system consumed by containers in Kubernetes.
 
-**Why does Kubernetes need a dedicated storage SIG — what makes storage hard in a distributed
+**Why does Kubernetes need a dedicated storage SIG? What makes storage hard in a distributed
 system?**
 
 When Kubernetes was first introduced, it was meant for stateless workloads only. Container
 applications were regarded as ephemeral and therefore did not need to persist data. However, that
 changed drastically. Stateful workloads started running in Kubernetes, and we needed a dedicated
-SIG to tackle the associated storage challenges. PersistentVolumeClaims, PersistentVolumes, and
-StorageClasses were all introduced to provision data volumes for applications running in Kubernetes.
+SIG to tackle the associated storage challenges. `PersistentVolumeClaims`, `PersistentVolumes`, and
+`StorageClasses` were all introduced to provision data volumes for applications running in Kubernetes.
 
 **How did SIG Storage originally form, and how has its mission changed over time?**
 
 SIG Storage was formed to address the challenges of handling persistent data within Kubernetes.
-Initially, PersistentVolumes were implemented as in-tree plugins, and the SIG managed those plugins
-while developing core storage primitives like PersistentVolumes and PersistentVolumeClaims.
+Initially, `PersistentVolumes` were implemented as in-tree plugins, and the SIG managed those plugins
+while developing core storage primitives like `PersistentVolumes` and `PersistentVolumeClaims`.
 
 Container Storage Interface (CSI) was introduced later and played a crucial role in simplifying
 storage integration, enabling third-party storage providers to develop and maintain their own
@@ -73,28 +74,27 @@ out-of-tree plugins without modifying Kubernetes core code.
 
 With basic integration addressed by CSI, the SIG's mission expanded to include advanced storage
 features that leverage the new interface. The SIG has also expanded its scope to support object
-storage through the Container Object Storage Interface (COSI).
+storage through the [Container Object Storage Interface](https://github.com/kubernetes-sigs/container-object-storage-interface) (COSI).
 
-## Current Work and Roadmap
+## Current work and roadmap
 
 **What are the top features SIG Storage is actively working on right now?**
 
 The Data Protection WG has been working on a couple of exciting features:
 
 - **VolumeGroupSnapshot** is a Kubernetes feature enabling a crash-consistent, point-in-time
-  snapshot of multiple PersistentVolumes simultaneously. This ensures data integrity for
+  snapshot of multiple `PersistentVolumes` simultaneously. This ensures data integrity for
   applications — like databases — that rely on multiple volumes by capturing all volumes in the
-  group atomically, at the exact same point in time. We are targeting GA in the Kubernetes 1.36
-  release.
+  group atomically, at the exact same point in time. It just moved to GA in Kubernetes v1.36.
 
 - **CSI Changed Block Tracking (CBT)** enables efficient, incremental backups. By allowing storage
   systems to report only the blocks that have changed since the last snapshot, it significantly
-  reduces the amount of data that needs to be transferred. We are targeting Beta in Kubernetes 1.36.
+  reduces the amount of data that needs to be transferred. It just moved to Beta in Kubernetes v1.36.
 
 Another feature worth highlighting is **Container Object Storage Interface (COSI)**. COSI provides
 a standard interface for provisioning and consuming object storage buckets in Kubernetes —
 standardizing object storage for containerized applications much like CSI did for block and file
-storage. COSI is now transitioning to v1alpha2, with plans for promotion to Beta in a future
+storage. COSI is now transitioning to `v1alpha2`, with plans for promotion to Beta in a future
 release.
 
 **What recent work from SIG Storage do you consider a "win" for users?**
@@ -106,14 +106,13 @@ operations. Now, users can dynamically tune storage properties such as IOPS or t
 through the Kubernetes API — scaling up for peak loads or down to optimize costs — without external
 processes or downtime.
 
-VolumeAttributesClass enables dynamic modification of storage characteristics without recreating
+`VolumeAttributesClass` enables dynamic modification of storage characteristics without recreating
 the volume. This completes the picture by allowing users to tune both capacity and other storage
 properties dynamically, just as they can now tune both CPU and memory for compute.
 
 **Looking ahead one or two releases, what's on the roadmap that people should watch for?**
 
-I'd like to draw attention to the [Volume Health
-feature](https://github.com/kubernetes/enhancements/issues/1432). This feature is designed to offer
+I'd like to draw attention to the [Volume Health](https://github.com/kubernetes/enhancements/issues/1432) feature. This feature is designed to offer
 critical visibility into the operational status and integrity of persistent volumes. By enabling
 storage drivers and the Kubernetes control plane to report issues, it allows for proactive
 monitoring and identification of volume-related problems.
@@ -131,7 +130,7 @@ Affinity](https://github.com/kubernetes/enhancements/issues/4762), which was int
 Kubernetes v1.35. Use cases include migrating volumes from zonal to regional storage or migrating
 from one disk type to another.
 
-Another topic is **volume replication**. It was raised at KubeCon Atlanta and has been discussed
+Another topic is **volume replication**. It was raised at [KubeCon Atlanta](https://www.cncf.io/reports/kubecon-cloudnativecon-north-america-2025/) and has been discussed
 in the Data Protection WG. Community members interested in this topic are encouraged to join the DP
 WG meetings.
 
@@ -191,11 +190,11 @@ scaling up to meet the demands of AI-era workloads. Whether you're a user managi
 production or a developer curious about storage internals, there's a place for you in SIG Storage.
 
 If you'd like to get involved, check out the [SIG Storage community
-page](https://github.com/kubernetes/community/tree/master/sig-storage) and join the [bi-weekly
+page](https://www.kubernetes.dev/community/community-groups/sigs/storage/) and join the [bi-weekly
 meetings](https://github.com/kubernetes/community/tree/master/sig-storage#meetings). You can also
 find the SIG on Slack at
 [#sig-storage](https://kubernetes.slack.com/messages/sig-storage).
 
-- [SIG Storage Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-storage)
+- [SIG Storage Mailing List](https://groups.google.com/a/kubernetes.io/g/sig-storage)
 - [SIG Storage on Slack](https://kubernetes.slack.com/messages/sig-storage)
 - [Data Protection WG](https://github.com/kubernetes/community/blob/master/wg-data-protection/README.md)

--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -13,232 +13,274 @@
 
 {{- $sigsOpts := merge $globalOpts (dict "key" "sigs-yaml-adapter") -}}
 
-{{ with resources.GetRemote $sigsUrl $sigsOpts }}
+{{- with try (resources.GetRemote $sigsUrl $sigsOpts) -}}
   {{ with .Err }}
-    {{ if eq hugo.Environment "production" }}
+    {{- if eq hugo.Environment "production" -}}
       {{ errorf "Unable to load sigs.yaml: %s" . }}
-    {{ else }}
+    {{- else -}}
       {{ warnf "Unable to load sigs.yaml: %s" . }}
     {{ end }}
-  {{ end }}
-
-  {{ with .Content | transform.Unmarshal }}
-    {{/* SIGs */}}
-    {{ range .sigs }}
-      {{ $name := .name }}
-      {{ $dir := .dir }}
-      {{ $slug := replace $dir "sig-" "" }}
-      
-      {{/* Fetch README Content */}}
-      {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
-      {{ $readmeContent := "" }}
-      {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-      {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+  {{ else with .Value }}
+    {{ with .Content | transform.Unmarshal }}
+      {{/* SIGs */}}
+      {{ range .sigs }}
+        {{ $name := .name }}
+        {{ $dir := .dir }}
+        {{ $slug := replace $dir "sig-" "" }}
+        
+        {{/* Fetch README Content */}}
+        {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
+        {{ $readmeContent := "" }}
+        {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
+        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
           {{ else }}
-            {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
           {{ end }}
-        {{ else }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
+        {{ end }}
+  
+        {{ $page := dict
+          "kind" "section"
+          "path" (printf "sigs/%s" $slug)
+          "title" (printf "SIG %s" $name)
+          "params" (dict
+            "description" .mission_statement
+            "leadership" .leadership
+            "meetings" .meetings
+            "contact" .contact
+            "subprojects" .subprojects
+            "label" .label
+            "dir" .dir
+            "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
+            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+          )
+          "content" (dict
+            "mediaType" "text/markdown"
+            "value" $readmeContent
+          )
+        }}
+        {{ $.AddPage $page }}
+  
+        {{/* Fetch Charter Content */}}
+        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $charterContent := replace .Content "\u200b" "" }}
+            {{ $charterPage := dict
+              "kind" "page"
+              "path" (printf "sigs/%s/charter" $slug)
+              "title" (printf "SIG %s Charter" $name)
+              "params" (dict
+                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "hide_summary" true
+                "toc_hide" true
+              )
+              "content" (dict              "mediaType" "text/markdown"
+                "value" $charterContent
+              )
+            }}
+            {{ $.AddPage $charterPage }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter from %s" $charterUrl }}
+            {{ else }}
+              {{ warnf "Unable to load charter from %s" $charterUrl }}
+            {{ end }}
+          {{ end }}
         {{ end }}
       {{ end }}
-
-      {{ $page := dict
-        "kind" "section"
-        "path" (printf "sigs/%s" $slug)
-        "title" (printf "SIG %s" $name)
-        "params" (dict
-          "description" .mission_statement
-          "leadership" .leadership
-          "meetings" .meetings
-          "contact" .contact
-          "subprojects" .subprojects
-          "label" .label
-          "dir" .dir
-          "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-          "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-        )
-        "content" (dict
-          "mediaType" "text/markdown"
-          "value" $readmeContent
-        )
-      }}
-      {{ $.AddPage $page }}
-
-      {{/* Fetch Charter Content */}}
-      {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-      {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-      {{ with resources.GetRemote $charterUrl $charterOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+  
+      {{/* Working Groups */}}
+      {{ range .workinggroups }}
+        {{ $name := .name }}
+        {{ $dir := .dir }}
+        {{ $slug := replace $dir "wg-" "" }}
+        
+        {{/* Fetch README Content */}}
+        {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
+        {{ $readmeContent := "" }}
+        {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
+        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
           {{ else }}
-            {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s" $dir }}
+            {{ end }}
           {{ end }}
-        {{ else }}
-          {{ $charterContent := replace .Content "\u200b" "" }}
-          {{ $charterPage := dict
-            "kind" "page"
-            "path" (printf "sigs/%s/charter" $slug)
-            "title" (printf "SIG %s Charter" $name)
-            "params" (dict
-              "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-              "hide_summary" true
-              "toc_hide" true
-            )
-            "content" (dict              "mediaType" "text/markdown"
-              "value" $charterContent
-            )
-          }}
-          {{ $.AddPage $charterPage }}
+        {{ end }}
+  
+        {{ $page := dict
+          "kind" "section"
+          "path" (printf "wg/%s" $slug)
+          "title" (printf "WG %s" $name)
+          "params" (dict
+            "description" .mission_statement
+            "leadership" .leadership
+            "meetings" .meetings
+            "contact" .contact
+            "dir" .dir
+            "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
+            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+          )
+          "content" (dict
+            "mediaType" "text/markdown"
+            "value" $readmeContent
+          )
+        }}
+        {{ $.AddPage $page }}
+  
+        {{/* Fetch Charter Content */}}
+        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $charterContent := replace .Content "\u200b" "" }}
+            {{ $charterPage := dict
+              "kind" "page"
+              "path" (printf "wg/%s/charter" $slug)
+              "title" (printf "WG %s Charter" $name)
+              "params" (dict
+                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "hide_summary" true
+                "toc_hide" true
+              )
+              "content" (dict              "mediaType" "text/markdown"
+                "value" $charterContent
+              )
+            }}
+            {{ $.AddPage $charterPage }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s" $dir }}
+            {{ end }}
+          {{ end }}
         {{ end }}
       {{ end }}
+  
+      {{/* Committees */}}
+      {{ range .committees }}
+        {{ $name := .name }}
+        {{ $dir := .dir }}
+        {{ $slug := replace $dir "committee-" "" }}
+        
+        {{/* Fetch README Content */}}
+        {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
+        {{ $readmeContent := "" }}
+        {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
+        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s" $dir }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+  
+        {{ $page := dict
+          "kind" "section"
+          "path" (printf "committees/%s" $slug)
+          "title" (printf "%s" $name)
+          "params" (dict
+            "description" .mission_statement
+            "leadership" .leadership
+            "meetings" .meetings
+            "contact" .contact
+            "dir" .dir
+            "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
+            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+          )
+          "content" (dict
+            "mediaType" "text/markdown"
+            "value" $readmeContent
+          )
+        }}
+        {{ $.AddPage $page }}
+  
+        {{/* Fetch Charter Content */}}
+        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $charterContent := replace .Content "\u200b" "" }}
+            {{ $charterPage := dict
+              "kind" "page"
+              "path" (printf "committees/%s/charter" $slug)
+              "title" (printf "%s Charter" $name)
+              "params" (dict
+                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "hide_summary" true
+                "toc_hide" true
+              )
+              "content" (dict              "mediaType" "text/markdown"
+                "value" $charterContent
+              )
+            }}
+            {{ $.AddPage $charterPage }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s" $dir }}
+            {{ end }}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- if eq hugo.Environment "production" -}}
+      {{ errorf "Unable to fetch: %s" $sigsUrl }}
+    {{- else -}}
+      {{ warnf "Unable to fetch: %s" $sigsUrl }}
     {{ end }}
-
-    {{/* Working Groups */}}
-    {{ range .workinggroups }}
-      {{ $name := .name }}
-      {{ $dir := .dir }}
-      {{ $slug := replace $dir "wg-" "" }}
-      
-      {{/* Fetch README Content */}}
-      {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
-      {{ $readmeContent := "" }}
-      {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-      {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load README for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load README for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
-        {{ end }}
-      {{ end }}
-
-      {{ $page := dict
-        "kind" "section"
-        "path" (printf "wg/%s" $slug)
-        "title" (printf "WG %s" $name)
-        "params" (dict
-          "description" .mission_statement
-          "leadership" .leadership
-          "meetings" .meetings
-          "contact" .contact
-          "dir" .dir
-          "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-          "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-        )
-        "content" (dict
-          "mediaType" "text/markdown"
-          "value" $readmeContent
-        )
-      }}
-      {{ $.AddPage $page }}
-
-      {{/* Fetch Charter Content */}}
-      {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-      {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-      {{ with resources.GetRemote $charterUrl $charterOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $charterContent := replace .Content "\u200b" "" }}
-          {{ $charterPage := dict
-            "kind" "page"
-            "path" (printf "wg/%s/charter" $slug)
-            "title" (printf "WG %s Charter" $name)
-            "params" (dict
-              "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-              "hide_summary" true
-              "toc_hide" true
-            )
-            "content" (dict              "mediaType" "text/markdown"
-              "value" $charterContent
-            )
-          }}
-          {{ $.AddPage $charterPage }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-
-    {{/* Committees */}}
-    {{ range .committees }}
-      {{ $name := .name }}
-      {{ $dir := .dir }}
-      {{ $slug := replace $dir "committee-" "" }}
-      
-      {{/* Fetch README Content */}}
-      {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
-      {{ $readmeContent := "" }}
-      {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-      {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load README for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load README for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
-        {{ end }}
-      {{ end }}
-
-      {{ $page := dict
-        "kind" "section"
-        "path" (printf "committees/%s" $slug)
-        "title" (printf "%s" $name)
-        "params" (dict
-          "description" .mission_statement
-          "leadership" .leadership
-          "meetings" .meetings
-          "contact" .contact
-          "dir" .dir
-          "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-          "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-        )
-        "content" (dict
-          "mediaType" "text/markdown"
-          "value" $readmeContent
-        )
-      }}
-      {{ $.AddPage $page }}
-
-      {{/* Fetch Charter Content */}}
-      {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-      {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-      {{ with resources.GetRemote $charterUrl $charterOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $charterContent := replace .Content "\u200b" "" }}
-          {{ $charterPage := dict
-            "kind" "page"
-            "path" (printf "committees/%s/charter" $slug)
-            "title" (printf "%s Charter" $name)
-            "params" (dict
-              "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-              "hide_summary" true
-              "toc_hide" true
-            )
-            "content" (dict              "mediaType" "text/markdown"
-              "value" $charterContent
-            )
-          }}
-          {{ $.AddPage $charterPage }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
+  {{- end -}}
+{{- end -}}

--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -10,21 +10,32 @@
 
 {{/* Fetch remote KEP data */}}
 {{- $kepDataOpts := merge $globalOpts (dict "key" "keps-json-data") -}}
-{{- with resources.GetRemote $kepDataSourceUrl $kepDataOpts -}}
+{{- with try (resources.GetRemote $kepDataSourceUrl $kepDataOpts ) -}}
   {{- with .Err -}}
     {{- if eq hugo.Environment "production" -}}
       {{- errorf "Unable to load KEP data: %s" . -}}
     {{- else -}}
       {{- warnf "Cannot load KEP data: %s" . -}}
     {{- end -}}
+  {{- else with .Value -}}
+    {{- with try (.Content | transform.Unmarshal) -}}
+      {{- with .Err -}}
+        {{- if eq hugo.Environment "production" -}}
+          {{- errorf "Unable to load KEP data: %s" . -}}
+        {{- else -}}
+          {{- warnf "Cannot load KEP data: %s" . -}}
+        {{- end -}}
+      {{- end -}}
+      {{- with .Value -}}
+        {{- $kepData = . -}}
+      {{- end -}}
+    {{- end -}}
   {{- else -}}
-    {{- $kepData = .Content | transform.Unmarshal -}}
-  {{- end -}}
-{{- else -}}
-  {{- if eq hugo.Environment "production" -}}
-    {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
-  {{- else -}}
-    {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
+    {{- if eq hugo.Environment "production" -}}
+      {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
+    {{- else -}}
+      {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 
@@ -68,28 +79,29 @@
     {{- $readmeContent := "" -}}
     {{- $readmeOpts := merge $globalOpts (dict "key" (printf "kep-readme-%s" $kep.kepNumber)) -}}
     
-    {{- $resource := resources.GetRemote $readmeUrl $readmeOpts -}}
+    {{- $resourceFetchAttempt := try (resources.GetRemote $readmeUrl $readmeOpts ) -}}
     
-    {{- /* Fallback to README.MD if README.md fails or is nil */ -}}
+    {{- /* Fallback to README.MD if README.md fetch fails or response is nil */ -}}
     {{- $needsFallback := false -}}
-    {{- if not $resource -}}
+    {{- if not $resourceFetchAttempt.Value -}}
       {{- $needsFallback = true -}}
-    {{- else if $resource.Err -}}
+    {{- else if $resourceFetchAttempt.Err -}}
       {{- $needsFallback = true -}}
     {{- end -}}
 
     {{- if $needsFallback -}}
       {{- $readmeUrlUpper := printf "%s%s/%s/README.MD" $rawBaseUrl $kep.owningSig $kep.name -}}
       {{- $readmeOptsUpper := merge $globalOpts (dict "key" (printf "kep-readme-%s-upper" $kep.kepNumber)) -}}
-      {{- $resource = resources.GetRemote $readmeUrlUpper $readmeOptsUpper -}}
+      {{- $resourceFetchAttempt = try (resources.GetRemote $readmeUrlUpper $readmeOptsUpper) -}}
     {{- end -}}
 
-    {{- if $resource -}}
-      {{- if $resource.Err -}}
-        {{- warnf "Unable to load README for KEP %s (tried .md and .MD): %s" $kep.kepNumber $resource.Err -}}
-      {{- else -}}
+    {{- with $resourceFetchAttempt -}}
+      {{- with .Err -}}
+        {{- warnf "Unable to load README for KEP %s (tried .md and .MD): %s" $kep.kepNumber . -}}
+      {{- end -}}
+      {{- with .Value -}}
         {{- /* Fix common markdown link errors in KEP READMEs to avoid build failures */ -}}
-        {{- $readmeContent = replace $resource.Content "]((http" "](http" -}}
+        {{- $readmeContent = replace .Content "]((http" "](http" -}}
         {{- $readmeContent = replace $readmeContent "/))" "/)" -}}
         {{- $readmeContent = replace $readmeContent "((http" "(http" -}}
         
@@ -105,6 +117,8 @@
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
+      {{- else -}}
+        {{- warnf "Unable to load README for KEP %s" -}}
       {{- end -}}
     {{- end -}}
 

--- a/content/en/resources/keps/_index.md
+++ b/content/en/resources/keps/_index.md
@@ -2,8 +2,10 @@
 linktitle: Enhancements
 title: Kubernetes Enhancement Proposals (KEPs)
 description: |
-  List of Kubernetes enhancements
+  Browse and filter all Kubernetes Enhancement Proposals (KEPs) across every release.
+  Search by SIG, stage, milestone version, or author.
 type: keps
+body_class: kep-listing
 ---
 
 These data come from the [kubernetes/enhancements]
@@ -15,7 +17,7 @@ To see the original Enhancement issue, click on the KEP number.  To see a summar
 If you notice an empty cell in the table, the KEP may not have updated information.
 Please raise <a href="https://github.com/kubernetes/enhancements/issues">an issue in the kubernetes/enhancements</a> repository.
 {{% /alert %}}
-###	KEP List
+## KEP List
 
 {{< keps-data >}}
 

--- a/content/en/resources/keps/_index.md
+++ b/content/en/resources/keps/_index.md
@@ -17,7 +17,6 @@ To see the original Enhancement issue, click on the KEP number.  To see a summar
 If you notice an empty cell in the table, the KEP may not have updated information.
 Please raise <a href="https://github.com/kubernetes/enhancements/issues">an issue in the kubernetes/enhancements</a> repository.
 {{% /alert %}}
-## KEP List
 
 {{< keps-data >}}
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,7 +6,8 @@ themesDir: node_modules
 enableRobotsTXT: true
 
 # Language settings
-contentDir: content/en
+defaultContentLanguage: en
+defaultContentLanguageInSubdir: false
 
 enableMissingTranslationPlaceholders: true
 disableKinds:
@@ -49,8 +50,15 @@ caches:
 # Language configuration
 languages:
   en:
+    contentDir: content/en
     title: *title # Use the YAML reference instead of repeating
     languageName: English
+    languageNameLatinScript: English
+    weight: 1
+    languagedirection: ltr
+    params:
+      languageNameLatinScript: English
+      time_format_blog: "02.01.2006"
 
 markup:
   goldmark:

--- a/i18n/en/en.toml
+++ b/i18n/en/en.toml
@@ -1,0 +1,149 @@
+# Site strings for English (en)
+# Following kubernetes/website structure using 'other' key for pluralization support
+
+[ui_search]
+other = "Search"
+
+[ui_search_placeholder]
+other = "Type name, tag, area..."
+
+[ui_view_readme_source]
+other = "View README Source"
+
+[ui_view_charter]
+other = "View Charter"
+
+[ui_view_charter_source]
+other = "View Charter Source"
+
+[ui_press_help]
+other = 'Press "?" for help.'
+
+[ui_filter]
+other = "Filter:"
+
+[ui_any_day]
+other = "Any day"
+
+[ui_monday]
+other = "Mon"
+
+[ui_tuesday]
+other = "Tue"
+
+[ui_wednesday]
+other = "Wed"
+
+[ui_thursday]
+other = "Thu"
+
+[ui_friday]
+other = "Fri"
+
+[ui_topics]
+other = "Topics:"
+
+[ui_clear]
+other = "Clear"
+
+[ui_leadership]
+other = "Leadership"
+
+[ui_chairs]
+other = "Chairs"
+
+[ui_tech_leads]
+other = "Tech Leads"
+
+[ui_meetings]
+other = "Meetings"
+
+[ui_at]
+other = "at"
+
+[ui_show_details]
+other = "Show Details"
+
+[ui_visit]
+other = "Visit"
+
+[ui_description]
+other = "Description"
+
+[ui_day]
+other = "Day"
+
+[ui_time]
+other = "Time"
+
+[ui_links]
+other = "Links"
+
+[ui_view_source]
+other = "View Source"
+
+[ui_all]
+other = "All"
+
+[ui_video_placeholder]
+other = "Kubernetes contributor site video"
+
+[kep_number]
+other = "KEP Number"
+
+[kep_title]
+other = "Title"
+
+[kep_sig]
+other = "SIG"
+
+[kep_author]
+other = "Author"
+
+[kep_created]
+other = "Created"
+
+[kep_updated]
+other = "Updated"
+
+[kep_last_updated]
+other = "Last Updated"
+
+[kep_milestone]
+other = "Milestone"
+
+[kep_milestones]
+other = "Milestones"
+
+[kep_latest]
+other = "Latest"
+
+[kep_alpha]
+other = "Alpha"
+
+[kep_beta]
+other = "Beta"
+
+[kep_stable]
+other = "Stable"
+
+[kep_depr]
+other = "Deprecated"
+
+[kep_implementation_history]
+other = "Implementation History"
+
+[kep_related_enhancements]
+other = "Related Enhancements"
+
+[kep_ownership]
+other = "Ownership"
+
+[kep_owning_sig]
+other = "Owning SIG"
+
+[kep_participating_sigs]
+other = "Participating SIGs"
+
+[kep_primary_authors]
+other = "Primary Authors"

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -6,7 +6,7 @@
     {{ end -}}
 	{{ .Content }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback }}
+		{{ partial "feedback.html" . }}
 		<br />
 	{{ end -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/calendar/list.html
+++ b/layouts/calendar/list.html
@@ -11,7 +11,7 @@
 	{{ .Content }}
   {{ partial "section-index.html" . -}}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback -}}
+		{{ partial "feedback.html" . -}}
 		<br />
 	{{ end -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/community/content.html
+++ b/layouts/community/content.html
@@ -16,7 +16,7 @@
     <div class="d-flex flex-wrap gap-2 my-4 border-top pt-4">
       {{ with .Params.remote_readme_url }}
       <a href="{{ . }}" target="_blank" class="btn btn-sm btn-outline-secondary rounded-pill">
-        <i class="fab fa-github me-1"></i> View README Source
+        <i class="fab fa-github me-1"></i> {{ T "ui_view_readme_source" }}
       </a>
       {{ end }}
       
@@ -24,12 +24,12 @@
       {{ $charterPage := .GetPage "charter" }}
       {{ if $charterPage }}
       <a href="{{ $charterPage.RelPermalink }}" class="btn btn-sm btn-primary rounded-pill">
-        <i class="fas fa-file-contract me-1"></i> View Charter
+        <i class="fas fa-file-contract me-1"></i> {{ T "ui_view_charter" }}
       </a>
       {{ else }}
         {{ with .Params.remote_charter_url }}
         <a href="{{ . }}" target="_blank" class="btn btn-sm btn-outline-secondary rounded-pill">
-          <i class="fab fa-github me-1"></i> View Charter Source
+          <i class="fab fa-github me-1"></i> {{ T "ui_view_charter_source" }}
         </a>
         {{ end }}
       {{ end }}
@@ -38,10 +38,10 @@
 
   {{ if .Params.leadership }}
   <div class="mt-5">
-    <h3 class="h4 fw-bold border-bottom pb-2 mb-4">Leadership</h3>
+    <h3 class="h4 fw-bold border-bottom pb-2 mb-4">{{ T "ui_leadership" }}</h3>
     
     {{ if .Params.leadership.chairs }}
-    <h4 class="h5 fw-semibold mb-3">Chairs</h4>
+    <h4 class="h5 fw-semibold mb-3">{{ T "ui_chairs" }}</h4>
     <div class="row g-4 mb-4">
       {{ range .Params.leadership.chairs }}
       <div class="col-md-6 col-lg-4">
@@ -64,7 +64,7 @@
     {{ end }}
 
     {{ if .Params.leadership.tech_leads }}
-    <h4 class="h5 fw-semibold mb-3">Tech Leads</h4>
+    <h4 class="h5 fw-semibold mb-3">{{ T "ui_tech_leads" }}</h4>
     <div class="row g-4 mb-4">
       {{ range .Params.leadership.tech_leads }}
       <div class="col-md-6 col-lg-4">
@@ -90,16 +90,16 @@
 
   {{ if .Params.meetings }}
   <div class="mt-5">
-    <h3 class="h4 fw-bold border-bottom pb-2 mb-4">Meetings</h3>
+    <h3 class="h4 fw-bold border-bottom pb-2 mb-4">{{ T "ui_meetings" }}</h3>
     <div class="card border-0 shadow-sm overflow-hidden">
       <div class="table-responsive">
         <table class="table table-hover mb-0">
           <thead class="bg-light">
             <tr>
-              <th class="ps-3">Description</th>
-              <th>Day</th>
-              <th>Time ({{ (index .Params.meetings 0).tz }})</th>
-              <th class="text-end pe-3">Links</th>
+              <th class="ps-3">{{ T "ui_description" }}</th>
+              <th>{{ T "ui_day" }}</th>
+              <th>{{ T "ui_time" }} ({{ (index .Params.meetings 0).tz }})</th>
+              <th class="text-end pe-3">{{ T "ui_links" }}</th>
             </tr>
           </thead>
           <tbody>

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -13,7 +13,7 @@
     {{ partial "section-index.html" . -}}
   {{ end }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback -}}
+		{{ partial "feedback.html" . -}}
 		<br />
 	{{ end -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -18,7 +18,7 @@ This file needs to be removed once Docsy has been updated to 0.10.0.
     {{ partial "section-index.html" . -}}
   {{ end }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback -}}
+		{{ partial "feedback.html" . -}}
 		<br />
 	{{ end -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/keps/list.html
+++ b/layouts/keps/list.html
@@ -11,7 +11,7 @@
 	{{ .Content }}
 	{{/* Intentionally omit section-index.html to avoid listing all KEP pages */}}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback -}}
+		{{ partial "feedback.html" . -}}
 		<br />
 	{{ end -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/keps/single.html
+++ b/layouts/keps/single.html
@@ -8,7 +8,7 @@
       
       {{/* Column 1: Implementation & History */}}
       <div class="kep-banner-col">
-        <div class="kep-banner-label">Implementation History</div>
+        <div class="kep-banner-label">{{ T "kep_implementation_history" }}</div>
         
         <div class="kep-status-group mb-4">
           <div class="d-flex flex-wrap gap-2">
@@ -24,19 +24,19 @@
         <div class="kep-data-grid mb-4">
           {{ with .Params.creationDate }}
           <div class="kep-data-row">
-            <span class="kep-data-label">Created</span>
+            <span class="kep-data-label">{{ T "kep_created" }}</span>
             <span class="kep-data-value">{{ . }}</span>
           </div>
           {{ end }}
           {{ with .Params.lastUpdated }}
           <div class="kep-data-row">
-            <span class="kep-data-label">Updated</span>
+            <span class="kep-data-label">{{ T "kep_updated" }}</span>
             <span class="kep-data-value">{{ . }}</span>
           </div>
           {{ end }}
           {{ with .Params.latestMilestone }}
           <div class="kep-data-row">
-            <span class="kep-data-label">Latest</span>
+            <span class="kep-data-label">{{ T "kep_latest" }}</span>
             <span class="kep-data-value">{{ . }}</span>
           </div>
           {{ end }}
@@ -45,29 +45,29 @@
         {{ with .Params.milestone }}
         {{ if or .alpha .beta .stable .deprecated }}
         <div class="kep-milestones-refined pt-3 border-top">
-          <div class="kep-banner-sublabel">Milestones</div>
+          <div class="kep-banner-sublabel">{{ T "kep_milestones" }}</div>
           <div class="kep-data-grid">
             {{ with .alpha }}
             <div class="kep-data-row">
-              <span class="kep-data-label"><span class="dot alpha"></span> Alpha</span>
+              <span class="kep-data-label"><span class="dot alpha"></span> {{ T "kep_alpha" }}</span>
               <span class="kep-data-value"><code>{{ . }}</code></span>
             </div>
             {{ end }}
             {{ with .beta }}
             <div class="kep-data-row">
-              <span class="kep-data-label"><span class="dot beta"></span> Beta</span>
+              <span class="kep-data-label"><span class="dot beta"></span> {{ T "kep_beta" }}</span>
               <span class="kep-data-value"><code>{{ . }}</code></span>
             </div>
             {{ end }}
             {{ with .stable }}
             <div class="kep-data-row">
-              <span class="kep-data-label"><span class="dot stable"></span> Stable</span>
+              <span class="kep-data-label"><span class="dot stable"></span> {{ T "kep_stable" }}</span>
               <span class="kep-data-value"><code>{{ . }}</code></span>
             </div>
             {{ end }}
             {{ with .deprecated }}
             <div class="kep-data-row">
-              <span class="kep-data-label"><span class="dot deprecated"></span> Depr.</span>
+              <span class="kep-data-label"><span class="dot deprecated"></span> {{ T "kep_depr" }}</span>
               <span class="kep-data-value"><code>{{ . }}</code></span>
             </div>
             {{ end }}
@@ -78,7 +78,7 @@
 
         {{ with .Params.seeAlso }}
         <div class="kep-related-refined pt-3 border-top mt-3">
-          <div class="kep-banner-sublabel">Related Enhancements</div>
+          <div class="kep-banner-sublabel">{{ T "kep_related_enhancements" }}</div>
           <ul class="kep-link-list">
             {{ range . }}
             <li>
@@ -98,23 +98,23 @@
 
       {{/* Column 2: Ownership & People */}}
       <div class="kep-banner-col border-start-refined">
-        <div class="kep-banner-label">Ownership</div>
+        <div class="kep-banner-label">{{ T "kep_ownership" }}</div>
         
         <div class="kep-sig-section mb-4">
-          <div class="kep-banner-sublabel">Owning SIG</div>
+          <div class="kep-banner-sublabel">{{ T "kep_owning_sig" }}</div>
           {{- $owningSigSlug := strings.TrimPrefix "sig-" .Params.owningSig -}}
           {{- with .Site.GetPage (printf "community/community-groups/sigs/%s" $owningSigSlug) -}}
             <a href="{{ .RelPermalink }}" class="kep-main-link">{{ .LinkTitle | default .Title }}</a>
           {{- else -}}
             <a href="https://github.com/kubernetes/community/tree/master/{{ $.Params.owningSig }}" class="kep-main-link">
-              SIG {{ $owningSigSlug | humanize | title }}
+              {{ T "kep_sig" }} {{ $owningSigSlug | humanize | title }}
             </a>
           {{- end -}}
         </div>
 
         {{ with .Params.participatingSigs }}
         <div class="kep-sig-section mb-4 pt-3 border-top">
-          <div class="kep-banner-sublabel">Participating SIGs</div>
+          <div class="kep-banner-sublabel">{{ T "kep_participating_sigs" }}</div>
           <div class="d-flex flex-wrap gap-2">
             {{ range $i, $sig := . }}
               {{- $sigSlug := strings.TrimPrefix "sig-" $sig -}}
@@ -132,7 +132,7 @@
 
         {{ with .Params.authors }}
         <div class="kep-people-section pt-3 border-top">
-          <div class="kep-banner-sublabel">Primary Authors</div>
+          <div class="kep-banner-sublabel">{{ T "kep_primary_authors" }}</div>
           <div class="kep-people-grid">
             {{ range . }}
             <a href="https://github.com/{{ trim . "@" }}" target="_blank" rel="noopener" class="kep-person-link">

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,43 +1,217 @@
-{{/*
-    This file is a 1:1 copy of the one in docsy but with adding scripts
-    for enabling Datatables on the KEP page.
-
-    Remove this notice if a better way is found to include the scripts.
-*/}}
-
-{{ with .Site.Params.algolia_docsearch }}
-<!-- scripts for algolia docsearch -->
-{{ end }}
-
 {{ if .HasShortcode "keps-data" }}
-<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.js"></script>
-<script type="text/javascript">
-    $(document).ready(function () {
-        $('#keps-table').DataTable({
-            lengthMenu: [
-                [10, 25, 50, -1],
-                [10, 25, 50, 'All'],
-            ],
-            order: [[2, 'asc'], [0, 'asc']],
-        });
+<script src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.js"></script>
+<script>
+(function() {
+  'use strict';
+
+  // Sort release options newest first — runs even if DataTable fails
+  function sortReleases() {
+    var select = document.getElementById('kep-filter-release');
+    if (!select) return;
+    var options = Array.from(select.options).slice(1);
+    options.sort(function(a, b) {
+      var va = (a.value.match(/[\d.]+/) || ['0'])[0].split('.').map(Number);
+      var vb = (b.value.match(/[\d.]+/) || ['0'])[0].split('.').map(Number);
+      for (var i = 0; i < Math.max(va.length, vb.length); i++) {
+        var na = va[i] || 0;
+        var nb = vb[i] || 0;
+        if (na !== nb) return nb - na;
+      }
+      return 0;
     });
+    options.forEach(function(o) { select.appendChild(o); });
+  }
+
+  sortReleases();
+
+  if (typeof $ === 'undefined' || !$.fn || !$.fn.DataTable) return;
+
+  function initKepTable() {
+    var table = document.getElementById('keps-table');
+    if (!table) return;
+
+    var $table = $(table);
+    var activeStages = new Set();
+    var searchTerm = '';
+
+    // Filter function — reads plain-text cell content from data[]
+    // data[2] = SIG, data[3] = Stage, data[4] = Latest Milestone
+    $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
+      var selRelease = document.getElementById('kep-filter-release');
+      var selSig = document.getElementById('kep-filter-sig');
+      var releaseVal = selRelease ? selRelease.value : '';
+      var sigVal = selSig ? selSig.value : '';
+
+      var tr = settings.aoData[dataIndex].nTr;
+      var rowRelease = tr ? (tr.getAttribute('data-latest-milestone') || '') : '';
+      var rowSig = tr ? (tr.getAttribute('data-sig') || '') : '';
+      var rowStage = tr ? (tr.getAttribute('data-stage') || '').toLowerCase() : '';
+
+      if (releaseVal && rowRelease !== releaseVal) return false;
+      if (sigVal && rowSig !== sigVal) return false;
+
+      if (activeStages.size > 0) {
+        var match = false;
+        activeStages.forEach(function(stage) {
+          if (stage === 'other') {
+            if (['alpha','beta','stable','deprecated'].indexOf(rowStage) === -1 && rowStage !== '') match = true;
+          } else if (rowStage === stage) {
+            match = true;
+          }
+        });
+        if (!match) return false;
+      }
+
+      if (searchTerm) {
+        var term = searchTerm.toLowerCase();
+        var rowText = data.join(' ').toLowerCase();
+        var rowAuthors = tr ? (tr.getAttribute('data-authors') || '').toLowerCase() : '';
+        if (rowText.indexOf(term) === -1 && rowAuthors.indexOf(term) === -1) return false;
+      }
+
+      return true;
+    });
+
+    var dt = $table.DataTable({
+      lengthMenu: [[10, 25, 50, 100], [10, 25, 50, 100]],
+      pageLength: 10,
+      order: [[0, 'desc']],
+      columnDefs: [
+        { type: 'num', targets: [0] },
+        { orderable: false, targets: [6] },
+        { type: 'date', targets: [5] }
+      ],
+      dom: 'ltip',
+      search: { search: '', regex: false, smart: false },
+      language: { zeroRecords: 'No KEPs match your filters.' },
+      drawCallback: function() {
+        var info = this.api().page.info();
+        var c = document.querySelector('.kep-results-count');
+        if (c) c.textContent = info.recordsDisplay === info.recordsTotal
+          ? info.recordsTotal + ' KEPs'
+          : 'Showing ' + info.recordsDisplay + ' of ' + info.recordsTotal + ' KEPs';
+      }
+    });
+
+    // Vanilla JS event listeners — no jQuery quirks
+    var searchInput = document.getElementById('kep-search');
+    if (searchInput) {
+      searchInput.addEventListener('input', function() {
+        searchTerm = this.value;
+        dt.draw();
+      });
+    }
+
+    var releaseSelect = document.getElementById('kep-filter-release');
+    if (releaseSelect) {
+      releaseSelect.addEventListener('change', function() {
+        dt.draw();
+        syncHash();
+      });
+    }
+
+    var sigSelect = document.getElementById('kep-filter-sig');
+    if (sigSelect) {
+      sigSelect.addEventListener('change', function() {
+        dt.draw();
+        syncHash();
+      });
+    }
+
+    function toggleStage(btn) {
+      var stage = btn.getAttribute('data-stage');
+      var checked = btn.getAttribute('aria-checked') === 'true';
+      btn.setAttribute('aria-checked', checked ? 'false' : 'true');
+      if (checked) activeStages.delete(stage);
+      else activeStages.add(stage);
+      dt.draw();
+      syncHash();
+    }
+
+    document.querySelectorAll('.kep-stage-btn').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        toggleStage(this);
+      });
+      btn.addEventListener('keydown', function(e) {
+        if (e.key === ' ' || e.key === 'Enter') {
+          e.preventDefault();
+          toggleStage(this);
+        }
+      });
+    });
+
+    var toggleBtn = document.getElementById('kep-filter-toggle-btn');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', function() {
+        var expanded = this.getAttribute('aria-expanded') === 'true';
+        this.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+        var filterBar = document.querySelector('.kep-filter-bar');
+        if (filterBar) filterBar.classList.toggle('visible');
+      });
+    }
+
+    function syncHash() {
+      var parts = [];
+      var releaseEl = document.getElementById('kep-filter-release');
+      var sigEl = document.getElementById('kep-filter-sig');
+      var r = releaseEl ? releaseEl.value : '';
+      var s = sigEl ? sigEl.value : '';
+      if (r) parts.push('release=' + encodeURIComponent(r));
+      if (s) parts.push('sig=' + encodeURIComponent(s));
+      if (activeStages.size) parts.push('stage=' + encodeURIComponent(Array.from(activeStages).join(',')));
+      var hash = parts.length ? '#' + parts.join('&') : '';
+      history.replaceState(null, '', hash || window.location.pathname);
+    }
+
+    function applyHash() {
+      var h = window.location.hash.slice(1);
+      if (!h) return;
+      var params = {};
+      h.split('&').forEach(function(p) {
+        var kv = p.split('=');
+        if (kv.length === 2) params[decodeURIComponent(kv[0])] = decodeURIComponent(kv[1]);
+      });
+      var releaseEl = document.getElementById('kep-filter-release');
+      var sigEl = document.getElementById('kep-filter-sig');
+      if (params.release && releaseEl) releaseEl.value = params.release;
+      if (params.sig && sigEl) sigEl.value = params.sig;
+      if (params.stage) {
+        params.stage.split(',').forEach(function(s) {
+          activeStages.add(s);
+          var btn = document.querySelector('.kep-stage-btn[data-stage="' + s + '"]');
+          if (btn) btn.setAttribute('aria-checked', 'true');
+        });
+      }
+      dt.draw();
+    }
+
+    applyHash();
+    window.addEventListener('hashchange', applyHash);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initKepTable);
+  } else {
+    initKepTable();
+  }
+})();
 </script>
 {{ end }}
 
-{{/* Sticky header scroll behavior */}}
+{{/* Sticky header */}}
 <script>
 function initStickyHeader() {
-  const navbar = document.querySelector('.td-navbar');
+  var navbar = document.querySelector('.td-navbar');
   if (!navbar) return;
 
-  const updateNavbar = () => {
+  var updateNavbar = function() {
     navbar.classList.toggle('scrolled', window.scrollY > 10);
   };
 
   window.addEventListener('scroll', updateNavbar);
   updateNavbar();
 
-  const observer = new MutationObserver(() => {
+  var observer = new MutationObserver(function() {
     if (!navbar.classList.contains('scrolled') && window.scrollY > 10) {
       navbar.classList.add('scrolled');
     }

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,22 +1,20 @@
-{{/*
-    This file is a 1:1 copy of the one in docsy but with adding stylesheets
-    for enabling Datatables on the KEP page.
-
-    Remove this notice if a better way is found to include the stylesheets.
-*/}}
-
-{{ with .Site.Params.algolia_docsearch }}
-<!-- stylesheet for algolia docsearch -->
-{{ end }}
-
 {{ if .HasShortcode "keps-data" }}
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.12.1/css/jquery.dataTables.css">
-<style>
-    .kep-milestone {
-        font-weight: bold;
-    }
-
-</style>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Kubernetes Enhancement Proposals (KEPs)",
+  "description": "Browse and filter all Kubernetes Enhancement Proposals across every release.",
+  "about": {
+    "@type": "Thing",
+    "name": "Kubernetes Enhancement Proposals"
+  }
+}
+</script>
 {{ end }}
 
 <link rel="canonical" href="{{ with .Params.canonicalURL }}{{ . }}{{ else }}{{ .Permalink }}{{ end }}">

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -11,7 +11,7 @@
 	{{ .Content }}
   {{ partial "section-index.html" . -}}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback -}}
+		{{ partial "feedback.html" . -}}
 		<br />
 	{{ end -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,20 +1,20 @@
 {{- $kepDataSourceUrl := "https://storage.googleapis.com/k8s-keps/keps.json" -}}
 {{- $kepData := "" -}}
-{{- with resources.GetRemote $kepDataSourceUrl -}}
+{{- with try (resources.GetRemote $kepDataSourceUrl ) -}}
   {{- with .Err -}}
     {{- if eq hugo.Environment "production" }}
-      {{ errorf "Unable to load KEP data: %s" . }}
+      {{ errorf "Unable to load KEP data from %s: %s" $kepDataSourceUrl . -}}
     {{- else -}}
-      {{- warnf "Cannot load KEP data: %s" . -}}
+      {{- warnf "Cannot load KEP data from %s: %s" $kepDataSourceUrl . -}}
     {{- end -}}
-  {{- else -}}
+  {{- else with .Value -}}
     {{- $kepData = .Content | transform.Unmarshal -}}
-  {{- end -}}
-{{- else -}}
-  {{- if eq hugo.Environment "production" }}
-    {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
   {{- else -}}
-    {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
+    {{- if eq hugo.Environment "production" }}
+      {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
+    {{- else -}}
+      {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,13 +1,4 @@
 {{- $kepDataSourceUrl := "https://storage.googleapis.com/k8s-keps/keps.json" -}}
-{{/*
-  Datatables is used in the page to enrich the list of KEPs.
-  The stylesheets and scripts required are in `partials/hooks/head-end.html`
-  and `partials/hooks/body-end.html` respectively.
-
-  Note: In order to configure Datatable parameters for changing any behavior, edit
-  the `DataTable` initialization in `partials/hooks/body-end.html`
-
-*/}}
 {{- $kepData := "" -}}
 {{- with resources.GetRemote $kepDataSourceUrl -}}
   {{- with .Err -}}
@@ -27,96 +18,168 @@
   {{- end -}}
 {{- end -}}
 
-{{/* Define stages that are "beyond provisional" for linking to internal pages */}}
 {{- $validStages := slice "alpha" "beta" "stable" "deprecated" -}}
-{{- $validStatuses := slice "implementable" "implemented" -}}
 
-<div>
-  <table id="keps-table" class="table table-hover mt-2 col-md-12 table-sm">
-    <thead class="thead-light">
-      <tr>
-        <th scope="col" class="col-md-1">KEP Number</th>
-        <th scope="col" class="col-md-3">Title</th>
-        <th scope="col" class="col-md-2">SIG</th>
-        <th scope="col" class="col-md-2">Author</th>
-        <th scope="col" class="col-md-1">Created</th>
-        <th scope="col" class="col-md-1">Last Updated</th>
-        <th scope="col" class="col-md-1">Milestone</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{range $index, $data := $kepData}}
-          {{- $isValidStage := in $validStages $data.stage -}}
-          {{- $isValidStatus := in $validStatuses $data.status -}}
-          <tr>
-            <td>
-              {{- if or $isValidStage $isValidStatus -}}
-              <a href="/resources/keps/{{ $data.kepNumber }}/">
-                {{ printf "%s" $data.kepNumber }}
-              </a>
-              {{- else -}}
-              <a href="https://features.k8s.io/{{ $data.kepNumber }}">
-                {{ printf "%s" $data.kepNumber }}
-              </a>
+{{- /* Build unique release and SIG lists */ -}}
+{{- $releaseSet := dict -}}
+{{- $sigSet := dict -}}
+{{- range $kepData -}}
+  {{- $lm := .latestMilestone -}}
+  {{- if and $lm (ne $lm "0.0") -}}
+    {{- $releaseSet = merge $releaseSet (dict $lm true) -}}
+  {{- end -}}
+  {{- $sig := .owningSig -}}
+  {{- if $sig -}}
+    {{- $sigSet = merge $sigSet (dict $sig true) -}}
+  {{- end -}}
+{{- end -}}
+{{- $releases := slice -}}
+{{- range $k, $_ := $releaseSet -}}{{- $releases = $releases | append $k -}}{{- end -}}
+{{- $sigs := slice -}}
+{{- range $k, $_ := $sigSet -}}{{- $sigs = $sigs | append $k -}}{{- end -}}
+
+<div class="kep-page">
+  <div class="kep-filter-bar" role="search" aria-label="Filter KEPs">
+    <div class="kep-filter-row kep-filter-selects">
+      <div class="kep-filter-group">
+        <label for="kep-filter-release">Release</label>
+        <select id="kep-filter-release" aria-label="Filter by release">
+          <option value="">All Releases</option>
+          {{- range $releases }}
+          <option value="{{ strings.TrimPrefix "v" . }}">{{ strings.TrimPrefix "v" . }}</option>
+          {{- end }}
+        </select>
+      </div>
+      <div class="kep-filter-group">
+        <label for="kep-filter-sig">SIG</label>
+        <select id="kep-filter-sig" aria-label="Filter by SIG">
+          <option value="">All SIGs</option>
+          {{- range sort $sigs }}
+          <option value="{{ . }}">{{ strings.TrimPrefix "sig-" . }}</option>
+          {{- end }}
+        </select>
+      </div>
+    </div>
+    <div class="kep-filter-row">
+      <fieldset class="kep-stage-toggles">
+        <legend>Stage</legend>
+        <button data-stage="alpha" class="kep-stage-btn kep-stage-alpha" role="checkbox" aria-checked="false" type="button">&alpha; Alpha</button>
+        <button data-stage="beta" class="kep-stage-btn kep-stage-beta" role="checkbox" aria-checked="false" type="button">&beta; Beta</button>
+        <button data-stage="stable" class="kep-stage-btn kep-stage-stable" role="checkbox" aria-checked="false" type="button">Stable</button>
+        <button data-stage="deprecated" class="kep-stage-btn kep-stage-deprecated" role="checkbox" aria-checked="false" type="button">Deprecated</button>
+        <button data-stage="other" class="kep-stage-btn kep-stage-other" role="checkbox" aria-checked="false" type="button">Other</button>
+      </fieldset>
+    </div>
+    <div class="kep-filter-row kep-filter-actions">
+      <div class="kep-search-group">
+        <svg class="kep-search-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85-.017.016zm-5.242.156a5 5 0 1 1 0-10 5 5 0 0 1 0 10z" fill="currentColor"/></svg>
+        <input type="search" id="kep-search" class="kep-search-input" placeholder="Search by title, KEP number, author..." aria-label="Search by title, KEP number, author...">
+      </div>
+      <div class="kep-results-count" aria-live="polite" role="status"></div>
+    </div>
+  </div>
+
+  <div class="kep-filter-toggle">
+    <button id="kep-filter-toggle-btn" class="kep-filter-toggle-btn" type="button" aria-expanded="false">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 2.5a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0zM4.5 8a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0zM9 13.5a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0z" fill="currentColor"/></svg>
+      Filters
+    </button>
+  </div>
+
+  <div class="kep-table-wrapper">
+    <table id="keps-table" class="table table-hover table-sm">
+      <caption class="visually-hidden">List of Kubernetes Enhancement Proposals (KEPs)</caption>
+      <thead class="thead-light">
+        <tr>
+          <th scope="col" class="kep-col-number">KEP Number</th>
+          <th scope="col" class="kep-col-title">Title</th>
+          <th scope="col" class="kep-col-sig">SIG</th>
+          <th scope="col" class="kep-col-stage">Stage</th>
+          <th scope="col" class="kep-col-latest">Latest Milestone</th>
+          <th scope="col" class="kep-col-created">Created</th>
+          <th scope="col" class="kep-col-author">Author</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range $data := $kepData }}
+          {{- $stage := $data.stage -}}
+          {{- if not $stage }}
+            {{- if or (eq $data.status "implementable") (eq $data.status "implemented") }}
+              {{- $stage = $data.status -}}
+            {{- else if eq $data.status "provisional" -}}
+              {{- $stage = "provisional" -}}
+            {{- end -}}
+          {{- end -}}
+          {{- $stageClass := $stage -}}
+          {{- if and $stage (not (in $validStages $stage)) }}{{ $stageClass = "other" }}{{ end -}}
+          {{- $latest := $data.latestMilestone -}}
+          {{- if not $latest }}
+            {{- range $s := slice "stable" "beta" "alpha" "deprecated" }}
+              {{- if not $latest }}
+                {{- with index $data.milestone $s }}{{ if . }}{{ $latest = printf "%s: %s" $s . }}{{ end }}{{ end }}
               {{- end -}}
+            {{- end -}}
+          {{- end -}}
+          {{- $latestVersion := strings.TrimPrefix "v" $latest -}}
+          {{- $numAuthors := len $data.authors -}}
+          {{- $allAuthors := "" -}}
+          {{- range $data.authors -}}
+            {{- $allAuthors = printf "%s %s" $allAuthors (trim . "@") -}}
+          {{- end -}}
+          <tr data-stage="{{ $stage }}" data-latest-milestone="{{ strings.TrimPrefix "v" $data.latestMilestone }}" data-sig="{{ $data.owningSig }}" data-kep="{{ $data.kepNumber }}" data-created="{{ $data.creationDate }}" data-authors="{{ $allAuthors }}">
+            <td class="kep-col-number" data-order="{{ $data.kepNumber }}">
+              <a href="/resources/keps/{{ $data.kepNumber }}/" class="kep-number-link">{{ $data.kepNumber }}</a>
             </td>
-            <td>
-              {{- if or $isValidStage $isValidStatus -}}
-              <a href="/resources/keps/{{ $data.kepNumber }}/">
-                {{ printf "%s" $data.title }}
-              </a>
-              {{- else -}}
-              <a href="https://github.com/kubernetes/enhancements/tree/master/keps/{{$data.owningSig}}/{{$data.name}}#summary">
-                {{ printf "%s" $data.title }}
-              </a>
-              {{- end -}}
+            <td class="kep-col-title">
+              <a href="/resources/keps/{{ $data.kepNumber }}/" class="kep-title-link">{{ $data.title }}</a>
             </td>
-            <td>
+            <td class="kep-col-sig">
               {{- $sigSlug := strings.TrimPrefix "sig-" $data.owningSig -}}
               {{- with site.GetPage (printf "community/community-groups/sigs/%s" $sigSlug) -}}
-                <a href="{{ .RelPermalink }}">{{ .LinkTitle | default .Title }}</a>
+                <a href="{{ .RelPermalink }}" class="kep-sig-link">{{ .LinkTitle | default .Title }}</a>
               {{- else -}}
-                <a href="https://github.com/kubernetes/community/tree/master/{{ $data.owningSig }}">
-                  SIG {{ $sigSlug | humanize | title }}
-                </a>
+                <a href="https://github.com/kubernetes/community/tree/master/{{ $data.owningSig }}" class="kep-sig-link">SIG {{ $sigSlug | humanize | title }}</a>
               {{- end -}}
             </td>
-            <td>
-              {{ range $index, $author := $data.authors }}
-              {{- if $index -}}, {{ end -}}
-              <a href="https://github.com/{{ trim $author "@" }}">
-                <span class="github-user">@{{ trim $author "@" }}</span>
-              </a>
-              {{ end }}
+            <td class="kep-col-stage">
+              {{- if $stage }}
+              <span class="kep-stage-badge kep-stage-{{ $stageClass }}">{{ $stage }}</span>
+              {{- else }}
+              <span class="kep-no-data">&mdash;</span>
+              {{- end }}
             </td>
-            <td>
-                {{ if $data.creationDate }}
-                  <time datetime="{{ $data.creationDate }}">{{ $data.creationDate }}</time>
-                {{ end }}
+            <td class="kep-col-latest">
+              {{- if $latest }}
+                <span class="kep-latest-version">{{ $latestVersion }}</span>
+              {{- else }}
+                <span class="kep-no-data">&mdash;</span>
+              {{- end }}
             </td>
-            <td>
-                {{ if $data.lastUpdated }}
-                  <time datetime="{{ $data.lastUpdated }}">{{ $data.lastUpdated }}</time>
-                {{ end }}
-              </span>
+            <td class="kep-col-created">
+              {{- if $data.creationDate }}
+                <time datetime="{{ $data.creationDate }}">{{ $data.creationDate }}</time>
+              {{- else }}
+                <span class="kep-no-data">&mdash;</span>
+              {{- end }}
             </td>
-            <td>
-              <ul class="list-unstyled">
-                {{ range $stage, $milestone := $data.milestone }}
-                  {{ if $milestone }}
-                  {{- $version := strings.TrimPrefix "v" $milestone -}}
-                  <li>
-                    {{ $stage }}:
-                    <a href="https://github.com/kubernetes/sig-release/tree/master/releases/release-{{ $version }}" class="kep-milestone" target="_blank" rel="noopener noreferrer">
-                      {{ $milestone }}
-                    </a>
-                  </li>
-                  {{ end }}
-                {{ end }}
-              </ul>
+            <td class="kep-col-author">
+              {{- if $data.authors }}
+                {{ range $i, $author := $data.authors }}
+                  {{- if lt $i 2 }}
+                    {{- if $i }}, {{ end }}
+                    <a href="https://github.com/{{ trim $author "@" }}" class="kep-author-link">{{ trim $author "@" }}</a>
+                  {{- end }}
+                {{- end }}
+                {{- if gt $numAuthors 2 }}
+                  <span class="kep-author-etal">et al.</span>
+                {{- end }}
+              {{- else }}
+                <span class="kep-no-data">&mdash;</span>
+              {{- end }}
             </td>
           </tr>
-      {{ end }}
-    </tbody>
-  </table>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -24,9 +24,20 @@
 {{- $releaseSet := dict -}}
 {{- $sigSet := dict -}}
 {{- range $kepData -}}
+  {{- $kep := . -}}
   {{- $lm := .latestMilestone -}}
   {{- if and $lm (ne $lm "0.0") -}}
     {{- $releaseSet = merge $releaseSet (dict $lm true) -}}
+  {{- else -}}
+    {{- /* Fallback: check milestone map for any non-empty value */ -}}
+    {{- range $s := slice "stable" "beta" "alpha" "deprecated" -}}
+      {{- if not $lm -}}
+        {{- with index $kep.milestone $s -}}{{- if . -}}{{- $lm = . -}}{{- end -}}{{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if $lm -}}
+      {{- $releaseSet = merge $releaseSet (dict $lm true) -}}
+    {{- end -}}
   {{- end -}}
   {{- $sig := .owningSig -}}
   {{- if $sig -}}
@@ -126,7 +137,8 @@
           {{- range $data.authors -}}
             {{- $allAuthors = printf "%s %s" $allAuthors (trim . "@") -}}
           {{- end -}}
-          <tr data-stage="{{ $stage }}" data-latest-milestone="{{ strings.TrimPrefix "v" $data.latestMilestone }}" data-sig="{{ $data.owningSig }}" data-kep="{{ $data.kepNumber }}" data-created="{{ $data.creationDate }}" data-authors="{{ $allAuthors }}">
+          {{- $allAuthors = strings.TrimLeft $allAuthors " " -}}
+          <tr data-stage="{{ $stage }}" data-latest-milestone="{{ if $latest }}{{ strings.TrimPrefix "v" $latest }}{{ end }}" data-sig="{{ $data.owningSig }}" data-kep="{{ $data.kepNumber }}" data-created="{{ $data.creationDate }}" data-authors="{{ $allAuthors }}">
             <td class="kep-col-number" data-order="{{ $data.kepNumber }}">
               <a href="/resources/keps/{{ $data.kepNumber }}/" class="kep-number-link">{{ $data.kepNumber }}</a>
             </td>

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -63,8 +63,8 @@
     <div class="kep-filter-row">
       <fieldset class="kep-stage-toggles">
         <legend>Stage</legend>
-        <button data-stage="alpha" class="kep-stage-btn kep-stage-alpha" role="checkbox" aria-checked="false" type="button">&alpha; Alpha</button>
-        <button data-stage="beta" class="kep-stage-btn kep-stage-beta" role="checkbox" aria-checked="false" type="button">&beta; Beta</button>
+        <button data-stage="alpha" class="kep-stage-btn kep-stage-alpha" role="checkbox" aria-checked="false" type="button">Alpha</button>
+        <button data-stage="beta" class="kep-stage-btn kep-stage-beta" role="checkbox" aria-checked="false" type="button">Beta</button>
         <button data-stage="stable" class="kep-stage-btn kep-stage-stable" role="checkbox" aria-checked="false" type="button">Stable</button>
         <button data-stage="deprecated" class="kep-stage-btn kep-stage-deprecated" role="checkbox" aria-checked="false" type="button">Deprecated</button>
         <button data-stage="other" class="kep-stage-btn kep-stage-other" role="checkbox" aria-checked="false" type="button">Other</button>

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -19,6 +19,7 @@
 {{- end -}}
 
 {{- $validStages := slice "alpha" "beta" "stable" "deprecated" -}}
+{{- $validStatuses := slice "implementable" "implemented" -}}
 
 {{- /* Build unique release and SIG lists */ -}}
 {{- $releaseSet := dict -}}
@@ -113,6 +114,9 @@
       </thead>
       <tbody>
         {{ range $data := $kepData }}
+          {{- $hasValidStage := and $data.stage (in $validStages $data.stage) -}}
+          {{- $hasValidStatus := and $data.status (in $validStatuses $data.status) -}}
+          {{- $hasPage := or $hasValidStage $hasValidStatus -}}
           {{- $stage := $data.stage -}}
           {{- if not $stage }}
             {{- if or (eq $data.status "implementable") (eq $data.status "implemented") }}
@@ -140,10 +144,18 @@
           {{- $allAuthors = strings.TrimLeft $allAuthors " " -}}
           <tr data-stage="{{ $stage }}" data-latest-milestone="{{ if $latest }}{{ strings.TrimPrefix "v" $latest }}{{ end }}" data-sig="{{ $data.owningSig }}" data-kep="{{ $data.kepNumber }}" data-created="{{ $data.creationDate }}" data-authors="{{ $allAuthors }}">
             <td class="kep-col-number" data-order="{{ $data.kepNumber }}">
+              {{- if $hasPage }}
               <a href="/resources/keps/{{ $data.kepNumber }}/" class="kep-number-link">{{ $data.kepNumber }}</a>
+              {{- else }}
+              <a href="https://features.k8s.io/{{ $data.kepNumber }}" class="kep-number-link">{{ $data.kepNumber }}</a>
+              {{- end }}
             </td>
             <td class="kep-col-title">
+              {{- if $hasPage }}
               <a href="/resources/keps/{{ $data.kepNumber }}/" class="kep-title-link">{{ $data.title }}</a>
+              {{- else }}
+              <a href="https://features.k8s.io/{{ $data.kepNumber }}" class="kep-title-link">{{ $data.title }}</a>
+              {{- end }}
             </td>
             <td class="kep-col-sig">
               {{- $sigSlug := strings.TrimPrefix "sig-" $data.owningSig -}}

--- a/layouts/shortcodes/playlist.html
+++ b/layouts/shortcodes/playlist.html
@@ -1,6 +1,6 @@
 {{ $id    := .Get 0 }}
 {{ $size  := .Get 1 | default 100 }}
-{{ $title := .Get 2 | default "Kubernetes contributor site video" }}
+{{ $title := .Get 2 | default (T "ui_video_placeholder") }}
 {{ $url   := printf "https://www.youtube.com/embed/videoseries?list=%s" $id }}
 <div class="youtube-embed" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
   <iframe src="{{ $url }}" style="position: absolute; top: 0; left: 0; width: {{ $size }}%; height: {{ $size }}%; border: 0;" allowfullscreen title="{{ $title }}"></iframe>

--- a/layouts/shortcodes/sigs-list.html
+++ b/layouts/shortcodes/sigs-list.html
@@ -15,15 +15,16 @@
 {{- $cacheOpts := dict "key" "sigs-yaml" -}}
 {{- $opts = merge $opts $cacheOpts -}}
 
-{{ with resources.GetRemote $sigsUrl $opts }}
-  {{ with .Err }}
+{{- with try (resources.GetRemote $sigsUrl $opts) -}}
+  {{- with .Err -}}
     {{ if eq hugo.Environment "production" }}
       {{ errorf "Unable to load sigs.yaml: %s" . }}
     {{ else }}
       {{ warnf "Unable to load sigs.yaml: %s" . }}
     {{ end }}
-  {{ end }}
-  {{ with .Content | transform.Unmarshal }}
+  {{- end -}}
+  {{- with .Value -}}
+    {{- with .Content | transform.Unmarshal -}}
 <div class="sigs-container my-4">
   <div class="row">
     <!-- Sticky Header Wrapper -->
@@ -441,5 +442,6 @@
     </div>
   </div>
 </div>
-{{ end }}
-{{ end }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/shortcodes/sigs-list.html
+++ b/layouts/shortcodes/sigs-list.html
@@ -50,33 +50,33 @@
       <div class="card shadow-sm border-0">
         <div class="card-body p-2 d-flex flex-column flex-md-row align-items-md-center gap-2">
           <div class="fw-bold d-none d-lg-flex align-items-center me-2 text-nowrap">
-            <i class="fas fa-filter me-2 text-primary"></i> Filter:
+            <i class="fas fa-filter me-2 text-primary"></i> {{ T "ui_filter" }}
           </div>
           
           <div class="input-group input-group-sm border rounded flex-grow-1" style="max-width: 300px;">
             <span class="input-group-text bg-white border-0"><i class="fas fa-search"></i></span>
-            <input type="text" id="sigSearchInput" class="form-control border-0" placeholder="Type name, tag, area..." aria-label="Filter community groups by name, tag, or label">
+            <input type="text" id="sigSearchInput" class="form-control border-0" placeholder="{{ T "ui_search_placeholder" }}" aria-label="{{ T "ui_search_placeholder" }}">
           </div>
 
           <div class="d-none d-md-flex align-items-center gap-2">
             <select id="dayFilter" class="form-select form-select-sm border shadow-none" style="width: auto;" aria-label="Filter community groups by meeting day">
-              <option value="">Any day</option>
-              <option value="monday">Mon</option>
-              <option value="tuesday">Tue</option>
-              <option value="wednesday">Wed</option>
-              <option value="thursday">Thu</option>
-              <option value="friday">Fri</option>
+              <option value="">{{ T "ui_any_day" }}</option>
+              <option value="monday">{{ T "ui_monday" }}</option>
+              <option value="tuesday">{{ T "ui_tuesday" }}</option>
+              <option value="wednesday">{{ T "ui_wednesday" }}</option>
+              <option value="thursday">{{ T "ui_thursday" }}</option>
+              <option value="friday">{{ T "ui_friday" }}</option>
             </select>
           </div>
 
           <div class="d-none d-md-flex flex-wrap gap-1 align-items-center ms-md-auto" id="topicFilters" role="group" aria-label="Filter by topic">
-            <span class="small text-muted me-1 d-none d-md-inline">Topics:</span>
+            <span class="small text-muted me-1 d-none d-md-inline">{{ T "ui_topics" }}</span>
             <button type="button" data-tag="architecture" class="badge border-0 py-1 px-2 topic-tag">#Arch</button>
             <button type="button" data-tag="cloud" class="badge border-0 py-1 px-2 topic-tag">#Cloud</button>
             <button type="button" data-tag="dev" class="badge border-0 py-1 px-2 topic-tag">#DevEx</button>
             <button type="button" data-tag="storage" class="badge border-0 py-1 px-2 topic-tag">#Storage</button>
             <button type="button" data-tag="network" class="badge border-0 py-1 px-2 topic-tag">#Network</button>
-            <button type="button" id="clearFilters" class="badge bg-danger bg-opacity-10 text-danger border-0 py-1 px-2 d-none">Clear</button>
+            <button type="button" id="clearFilters" class="badge bg-danger bg-opacity-10 text-danger border-0 py-1 px-2 d-none">{{ T "ui_clear" }}</button>
           </div>
         </div>
       </div>
@@ -116,7 +116,7 @@
                     <h5 class="fw-bold mb-0 text-primary h6">
                       <a href="/community/community-groups/sigs/{{ .dir | replaceRE "^sig-" "" }}/" class="text-decoration-none text-primary">{{ .name }}</a>
                     </h5>
-                    <a href="https://github.com/kubernetes/community/tree/{{ $defaultBranch }}/{{ .dir }}" class="text-muted" title="View Source"><i class="fab fa-github"></i></a>
+                    <a href="https://github.com/kubernetes/community/tree/{{ $defaultBranch }}/{{ .dir }}" class="text-muted" title="{{ T "ui_view_source" }}"><i class="fab fa-github"></i></a>
                   </div>
                   
                   <div class="mb-3">
@@ -129,11 +129,11 @@
                   <div class="collapse mt-auto" id="collapse-{{ .dir | urlize }}">
                     {{ if .leadership }}
                     <div class="mb-3">
-                      <h6 class="fw-bold small text-uppercase text-muted border-bottom pb-1 mb-2">Leadership</h6>
+                      <h6 class="fw-bold small text-uppercase text-muted border-bottom pb-1 mb-2">{{ T "ui_leadership" }}</h6>
                       
                       {{ if .leadership.chairs }}
                       <div class="mb-2">
-                        <div class="small fw-semibold text-dark mb-1">Chairs</div>
+                        <div class="small fw-semibold text-dark mb-1">{{ T "ui_chairs" }}</div>
                         <div class="d-flex flex-wrap gap-1">
                           {{ range .leadership.chairs }}
                           <a href="https://github.com/{{ .github }}" class="badge bg-primary bg-opacity-10 text-primary border-0 text-decoration-none py-1 px-2">
@@ -146,7 +146,7 @@
 
                       {{ if .leadership.tech_leads }}
                       <div>
-                        <div class="small fw-semibold text-dark mb-1">Tech Leads</div>
+                        <div class="small fw-semibold text-dark mb-1">{{ T "ui_tech_leads" }}</div>
                         <div class="d-flex flex-wrap gap-1">
                           {{ range .leadership.tech_leads }}
                           <a href="https://github.com/{{ .github }}" class="badge bg-secondary bg-opacity-10 text-secondary border-0 text-decoration-none py-1 px-2">
@@ -161,7 +161,7 @@
 
                     {{ if gt (len $allMeetings) 0 }}
                     <div class="bg-primary bg-opacity-10 p-2 rounded-3 mb-3">
-                      <h6 class="fw-bold small text-uppercase text-primary mb-2"><i class="far fa-clock me-1"></i> Meetings ({{ len $allMeetings }})</h6>
+                      <h6 class="fw-bold small text-uppercase text-primary mb-2"><i class="far fa-clock me-1"></i> {{ T "ui_meetings" }} ({{ len $allMeetings }})</h6>
                       <div style="max-height: 180px; overflow-y: auto;" class="pe-2">
                         {{ range $index, $meeting := $allMeetings }}
                         <div class="mb-2 {{ if lt (add $index 1) (len $allMeetings) }}border-bottom border-primary border-opacity-10 pb-2{{ end }}">
@@ -174,7 +174,7 @@
                             </div>
                         </div>
                         <div class="small text-dark">
-                          {{ .day }} at <span class="fw-bold">{{ .time }} {{ .tz }}</span>
+                          {{ .day }} {{ T "ui_at" }} <span class="fw-bold">{{ .time }} {{ .tz }}</span>
                         </div>
                       </div>
                       {{ end }}
@@ -185,7 +185,7 @@
 
                   <div class="d-flex flex-wrap gap-2 mt-auto align-items-center justify-content-between pt-2">
                     <button class="btn btn-sm btn-light text-primary rounded-pill px-3" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ .dir | urlize }}" aria-expanded="false" aria-controls="collapse-{{ .dir | urlize }}">
-                      <i class="fas fa-chevron-down me-1 toggle-icon"></i> <span class="toggle-text">Show Details</span>
+                      <i class="fas fa-chevron-down me-1 toggle-icon"></i> <span class="toggle-text">{{ T "ui_show_details" }}</span>
                     </button>
                     <div class="d-flex gap-2">
                       {{ if .contact.slack }}
@@ -199,7 +199,7 @@
                       {{ end }}
 
                       <a href="/community/community-groups/sigs/{{ .dir | replaceRE "^sig-" "" }}/" class="btn btn-sm btn-outline-primary rounded-pill px-3">
-                        Visit <i class="fas fa-arrow-right ms-1"></i>
+                        {{ T "ui_visit" }} <i class="fas fa-arrow-right ms-1"></i>
                       </a>
                     </div>
                   </div>
@@ -234,7 +234,7 @@
                     <h5 class="fw-bold mb-0 text-primary h6">
                       <a href="/community/community-groups/wg/{{ .dir | replaceRE "^sig-" "" | replaceRE "^wg-" "" }}/" class="text-decoration-none text-primary">WG {{ .name }}</a>
                     </h5>
-                    <a href="https://github.com/kubernetes/community/tree/{{ $defaultBranch }}/{{ .dir }}" class="text-muted" title="View Source"><i class="fab fa-github"></i></a>
+                    <a href="https://github.com/kubernetes/community/tree/{{ $defaultBranch }}/{{ .dir }}" class="text-muted" title="{{ T "ui_view_source" }}"><i class="fab fa-github"></i></a>
                   </div>
                   
                   <div class="mb-3">
@@ -247,11 +247,11 @@
                   <div class="collapse mt-auto" id="collapse-{{ .dir | urlize }}">
                     {{ if .leadership }}
                     <div class="mb-3">
-                      <h6 class="fw-bold small text-uppercase text-muted border-bottom pb-1 mb-2">Leadership</h6>
+                      <h6 class="fw-bold small text-uppercase text-muted border-bottom pb-1 mb-2">{{ T "ui_leadership" }}</h6>
                       
                       {{ if .leadership.chairs }}
                       <div class="mb-2">
-                        <div class="small fw-semibold text-dark mb-1">Chairs</div>
+                        <div class="small fw-semibold text-dark mb-1">{{ T "ui_chairs" }}</div>
                         <div class="d-flex flex-wrap gap-1">
                           {{ range .leadership.chairs }}
                           <a href="https://github.com/{{ .github }}" class="badge bg-primary bg-opacity-10 text-primary border-0 text-decoration-none py-1 px-2">
@@ -264,7 +264,7 @@
 
                       {{ if .leadership.tech_leads }}
                       <div>
-                        <div class="small fw-semibold text-dark mb-1">Tech Leads</div>
+                        <div class="small fw-semibold text-dark mb-1">{{ T "ui_tech_leads" }}</div>
                         <div class="d-flex flex-wrap gap-1">
                           {{ range .leadership.tech_leads }}
                           <a href="https://github.com/{{ .github }}" class="badge bg-secondary bg-opacity-10 text-secondary border-0 text-decoration-none py-1 px-2">
@@ -279,7 +279,7 @@
 
                     {{ if gt (len $allMeetings) 0 }}
                     <div class="bg-primary bg-opacity-10 p-2 rounded-3 mb-3">
-                      <h6 class="fw-bold small text-uppercase text-primary mb-2"><i class="far fa-clock me-1"></i> Meetings ({{ len $allMeetings }})</h6>
+                      <h6 class="fw-bold small text-uppercase text-primary mb-2"><i class="far fa-clock me-1"></i> {{ T "ui_meetings" }} ({{ len $allMeetings }})</h6>
                       <div style="max-height: 180px; overflow-y: auto;" class="pe-2">
                         {{ range $index, $meeting := $allMeetings }}
                         <div class="mb-2 {{ if lt (add $index 1) (len $allMeetings) }}border-bottom border-primary border-opacity-10 pb-2{{ end }}">
@@ -292,7 +292,7 @@
                             </div>
                         </div>
                         <div class="small text-dark">
-                          {{ .day }} at <span class="fw-bold">{{ .time }} {{ .tz }}</span>
+                          {{ .day }} {{ T "ui_at" }} <span class="fw-bold">{{ .time }} {{ .tz }}</span>
                         </div>
                       </div>
                       {{ end }}
@@ -303,7 +303,7 @@
 
                   <div class="d-flex flex-wrap gap-2 mt-auto align-items-center justify-content-between pt-2">
                     <button class="btn btn-sm btn-light text-primary rounded-pill px-3" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ .dir | urlize }}" aria-expanded="false" aria-controls="collapse-{{ .dir | urlize }}">
-                      <i class="fas fa-chevron-down me-1 toggle-icon"></i> <span class="toggle-text">Show Details</span>
+                      <i class="fas fa-chevron-down me-1 toggle-icon"></i> <span class="toggle-text">{{ T "ui_show_details" }}</span>
                     </button>
                     <div class="d-flex gap-2">
                       {{ if .contact.slack }}
@@ -313,7 +313,7 @@
                       {{ end }}
 
                       <a href="/community/community-groups/wg/{{ .dir | replaceRE "^wg-" "" }}/" class="btn btn-sm btn-outline-primary rounded-pill px-3">
-                        Visit <i class="fas fa-arrow-right ms-1"></i>
+                        {{ T "ui_visit" }} <i class="fas fa-arrow-right ms-1"></i>
                       </a>
                     </div>
                   </div>
@@ -348,7 +348,7 @@
                     <h5 class="fw-bold mb-0 text-primary h6">
                       <a href="/community/community-groups/committees/{{ .dir | replaceRE "^sig-" "" | replaceRE "^committee-" "" }}/" class="text-decoration-none text-primary">{{ .name }}</a>
                     </h5>
-                    <a href="https://github.com/kubernetes/community/tree/{{ $defaultBranch }}/{{ .dir }}" class="text-muted" title="View Source"><i class="fab fa-github"></i></a>
+                    <a href="https://github.com/kubernetes/community/tree/{{ $defaultBranch }}/{{ .dir }}" class="text-muted" title="{{ T "ui_view_source" }}"><i class="fab fa-github"></i></a>
                   </div>
                   
                   <div class="mb-3">
@@ -361,7 +361,7 @@
                   <div class="collapse mt-auto" id="collapse-{{ .dir | urlize }}">
                     {{ if gt (len $allMeetings) 0 }}
                     <div class="bg-primary bg-opacity-10 p-2 rounded-3 mb-3">
-                      <h6 class="fw-bold small text-uppercase text-primary mb-2"><i class="far fa-clock me-1"></i> Meetings ({{ len $allMeetings }})</h6>
+                      <h6 class="fw-bold small text-uppercase text-primary mb-2"><i class="far fa-clock me-1"></i> {{ T "ui_meetings" }} ({{ len $allMeetings }})</h6>
                       <div style="max-height: 180px; overflow-y: auto;" class="pe-2">
                         {{ range $index, $meeting := $allMeetings }}
                         <div class="mb-2 {{ if lt (add $index 1) (len $allMeetings) }}border-bottom border-primary border-opacity-10 pb-2{{ end }}">
@@ -374,7 +374,7 @@
                             </div>
                         </div>
                         <div class="small text-dark">
-                          {{ .day }} at <span class="fw-bold">{{ .time }} {{ .tz }}</span>
+                          {{ .day }} {{ T "ui_at" }} <span class="fw-bold">{{ .time }} {{ .tz }}</span>
                         </div>
                       </div>
                       {{ end }}
@@ -383,11 +383,11 @@
                     {{ end }}
                     {{ if .leadership }}
                     <div class="mb-3">
-                      <h6 class="fw-bold small text-uppercase text-muted border-bottom pb-1 mb-2">Leadership</h6>
+                      <h6 class="fw-bold small text-uppercase text-muted border-bottom pb-1 mb-2">{{ T "ui_leadership" }}</h6>
                       
                       {{ if .leadership.chairs }}
                       <div class="mb-2">
-                        <div class="small fw-semibold text-dark mb-1">Chairs</div>
+                        <div class="small fw-semibold text-dark mb-1">{{ T "ui_chairs" }}</div>
                         <div class="d-flex flex-wrap gap-1">
                           {{ range .leadership.chairs }}
                           <a href="https://github.com/{{ .github }}" class="badge bg-primary bg-opacity-10 text-primary border-0 text-decoration-none py-1 px-2">
@@ -400,7 +400,7 @@
 
                       {{ if .leadership.tech_leads }}
                       <div>
-                        <div class="small fw-semibold text-dark mb-1">Tech Leads</div>
+                        <div class="small fw-semibold text-dark mb-1">{{ T "ui_tech_leads" }}</div>
                         <div class="d-flex flex-wrap gap-1">
                           {{ range .leadership.tech_leads }}
                           <a href="https://github.com/{{ .github }}" class="badge bg-secondary bg-opacity-10 text-secondary border-0 text-decoration-none py-1 px-2">
@@ -416,7 +416,7 @@
 
                   <div class="d-flex flex-wrap gap-2 mt-auto align-items-center justify-content-between pt-2">
                     <button class="btn btn-sm btn-light text-primary rounded-pill px-3" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{ .dir | urlize }}" aria-expanded="false" aria-controls="collapse-{{ .dir | urlize }}">
-                      <i class="fas fa-chevron-down me-1 toggle-icon"></i> <span class="toggle-text">Show Details</span>
+                      <i class="fas fa-chevron-down me-1 toggle-icon"></i> <span class="toggle-text">{{ T "ui_show_details" }}</span>
                     </button>
                     <div class="d-flex gap-2">
                       {{ if .contact.slack }}
@@ -426,7 +426,7 @@
                       {{ end }}
 
                       <a href="/community/community-groups/committees/{{ .dir | replaceRE "^sig-" "" | replaceRE "^committee-" "" }}/" class="btn btn-sm btn-outline-primary rounded-pill px-3">
-                        Visit <i class="fas fa-arrow-right ms-1"></i>
+                        {{ T "ui_visit" }} <i class="fas fa-arrow-right ms-1"></i>
                       </a>
                     </div>
                   </div>

--- a/layouts/swagger/list.html
+++ b/layouts/swagger/list.html
@@ -16,7 +16,7 @@ This file needs to be removed once Docsy has been updated to 0.10.0.
 	{{ .Content }}
   {{ partial "section-index.html" . -}}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.Config.Services.GoogleAnalytics.ID)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback -}}
+		{{ partial "feedback.html" . -}}
 		<br />
 	{{ end -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.133.0"
-NODE_VERSION = "20.16.0"
+NODE_VERSION = "20.17.0"
+HUGO_VERSION = "0.144.2"
 
 [context.production.environment]
 HUGO_ENV = "production"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^6.6.0",
         "autoprefixer": "^10.4.20",
-        "docsy": "github:google/docsy#semver:0.7.2",
+        "docsy": "github:google/docsy#semver:0.8.0",
         "postcss-cli": "^10.1.0"
       }
     },
@@ -63,62 +63,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@oozcitak/dom": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
-      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/url": "1.0.4",
-        "@oozcitak/util": "8.3.8"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@oozcitak/infra": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
-      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@oozcitak/util": "8.3.8"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/@oozcitak/url": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
-      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/@oozcitak/util": {
-      "version": "8.3.8",
-      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
-      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -129,25 +73,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
@@ -190,39 +115,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -261,17 +153,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -284,14 +165,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/bootstrap": {
       "version": "5.2.3",
@@ -381,52 +254,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cheerio": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
-      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.1.0",
-        "encoding-sniffer": "^0.2.0",
-        "htmlparser2": "^9.1.0",
-        "parse5": "^7.1.2",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0",
-        "parse5-parser-stream": "^7.1.2",
-        "undici": "^6.19.5",
-        "whatwg-mimetype": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.17"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -487,95 +314,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/dependency-graph": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
@@ -600,9 +338,10 @@
       }
     },
     "node_modules/docsy": {
-      "version": "0.7.2",
-      "resolved": "git+ssh://git@github.com/google/docsy.git#fd669b752b7f83fb2eb57cacd2c8f334f86ca7d2",
+      "version": "0.8.0",
+      "resolved": "git+ssh://git@github.com/google/docsy.git#6bb4f99d1eab4976fb80d1488c81ba12b1715c05",
       "dev": true,
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "6.4.0",
@@ -610,73 +349,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "markdown-link-check": "^3.11.2",
-        "prettier": "^3.0.3"
-      }
-    },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause",
-      "optional": true
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -693,35 +365,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/encoding-sniffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
-      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -730,66 +373,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-glob": {
@@ -899,22 +482,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -968,82 +535,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/html-link-extractor": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/html-link-extractor/-/html-link-extractor-1.0.5.tgz",
-      "integrity": "sha512-ADd49pudM157uWHwHQPUSX4ssMsvR/yHIswOR5CUfBdK9g9ZYGMhVSE6KZVHJ6kCkR0gH4htsfzU6zECDNVwyw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "cheerio": "^1.0.0-rc.10"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.1.0",
-        "entities": "^4.5.0"
-      }
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1052,43 +543,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/is-absolute-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-binary-path": {
@@ -1147,46 +601,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-relative-url": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-4.0.0.tgz",
-      "integrity": "sha512-PkzoL1qKAYXNFct5IKdKRH/iBQou/oCC85QhXj6WKtUQBliZ4Yfd3Zk27RHu9KQG8r6zgvAA2AQKC9p+rqTszg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-absolute-url": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1213,94 +627,6 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
-    "node_modules/link-check": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/link-check/-/link-check-5.4.0.tgz",
-      "integrity": "sha512-0Pf4xBVUnwJdbDgpBlhHNmWDtbVjHTpIFs+JaBuIsC9PKRxjv4KMGCO2Gc8lkVnqMf9B/yaNY+9zmMlO5MyToQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "is-relative-url": "^4.0.0",
-        "ms": "^2.1.3",
-        "needle": "^3.3.1",
-        "node-email-verifier": "^2.0.0",
-        "proxy-agent": "^6.4.0"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/markdown-link-check": {
-      "version": "3.13.6",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.13.6.tgz",
-      "integrity": "sha512-JiqexKOR+oaBovJ16x/VEN886CzPI48bSGUcKJvnkHVS8xSb9fRJtsdcLwG8+5QQ/V0UZKFmW8JEZFcZbd0BBA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "async": "^3.2.6",
-        "chalk": "^5.3.0",
-        "commander": "^12.1.0",
-        "link-check": "^5.4.0",
-        "markdown-link-extractor": "^4.0.2",
-        "needle": "^3.3.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.4.0",
-        "xmlbuilder2": "^3.1.1"
-      },
-      "bin": {
-        "markdown-link-check": "markdown-link-check"
-      }
-    },
-    "node_modules/markdown-link-check/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/markdown-link-extractor": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-4.0.2.tgz",
-      "integrity": "sha512-5cUOu4Vwx1wenJgxaudsJ8xwLUMN7747yDJX3V/L7+gi3e4MsCm7w5nbrDQQy8nEfnl4r5NV3pDXMAjhGXYXAw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "html-link-extractor": "^1.0.5",
-        "marked": "^12.0.1"
-      }
-    },
-    "node_modules/marked": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1325,14 +651,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -1350,50 +668,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/needle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
-      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/node-email-verifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-email-verifier/-/node-email-verifier-2.0.0.tgz",
-      "integrity": "sha512-AHcppjOH2KT0mxakrxFMOMjV/gOVMRpYvnJUkNfgF9oJ3INdVmqcMFJ5TlM8elpTPwt6A7bSp1IMnnWcxGom/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3",
-        "validator": "^13.11.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -1421,99 +695,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.1.0.tgz",
-      "integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/parse5": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
-      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "entities": "^4.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-type": {
@@ -1686,23 +867,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -1712,46 +876,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -1842,22 +966,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -1871,61 +979,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1935,14 +988,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -1992,25 +1037,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
-    "node_modules/undici": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
-      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -2052,42 +1078,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/validator": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -2104,23 +1094,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/xmlbuilder2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
-      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@oozcitak/dom": "1.15.10",
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8",
-        "js-yaml": "3.14.1"
-      },
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.6.0",
     "autoprefixer": "^10.4.20",
-    "docsy": "github:google/docsy#semver:0.7.2",
+    "docsy": "github:google/docsy#semver:0.8.0",
     "postcss-cli": "^10.1.0"
   },
   "scripts": {


### PR DESCRIPTION
This PR updates links to the `kubernetes/steering` repository to use the `main` branch.

The `kubernetes/steering` repository has already migrated its default branch from `master` to `main`.

Part of #686.
Addressing feedback from #713 review to split changes by repository.