### PR TITLE
Add Call for Help workflow for SIG assistance requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/call-for-help.yaml
+++ b/.github/ISSUE_TEMPLATE/call-for-help.yaml
@@ -1,0 +1,50 @@
+---
+name: Call for Help
+about: Request assistance for a SIG project to prevent critical gaps
+title: '[Call for Help] <project-name>: <brief-description>'
+labels: ['call-for-help']
+---
+
+## Project Information
+
+- **Project Name**: <!-- e.g., ingress-nginx, kubernetes-sigs/cluster-api -->
+- **GitHub Repository**: <!-- e.g., kubernetes/ingress-nginx -->
+- **SIG/Working Group**: <!-- e.g., SIG Network, WG Serving -->
+
+## Request Type
+
+What kind of help is needed? (check all that apply)
+
+- [ ] **Reviewers** - Need additional reviewers for PRs
+- [ ] **Maintainers** - Need new maintainers to prevent single point of failure
+- [ ] **Security** - Security-focused assistance needed
+- [ ] **Mentorship** - Need help onboarding new contributors
+- [ ] **Other** - Describe below
+
+## Description
+
+<!-- Provide details about the situation and why help is needed -->
+
+
+
+## Contact Information
+
+- **Slack Handle**: <!-- e.g., @username -->
+- **Email**: <!-- contact@email.com -->
+- **Preferred Contact Method**: [ ] Slack [ ] Email [ ] GitHub
+
+## New Contributor Orientation
+
+- [ ] **Feature in NCO** - Include this project in New Contributor Orientation for new contributors
+
+## Links
+
+- **Good First Issues**: <!-- link to good first issues -->
+- **Onboarding Guide**: <!-- link to contributing guide -->
+- **OWNERS File**: <!-- link to OWNERS -->
+
+---
+
+**Note**: This request requires approval from a SIG Chair or Tech Lead from your SIG.
+Once approved with `/approve`, this issue will be displayed in the Community Resilience Dashboard
+and optionally in New Contributor Orientation.

--- a/.github/ISSUE_TEMPLATE/call-for-help.yaml
+++ b/.github/ISSUE_TEMPLATE/call-for-help.yaml
@@ -1,50 +1,82 @@
----
 name: Call for Help
-about: Request assistance for a SIG project to prevent critical gaps
-title: '[Call for Help] <project-name>: <brief-description>'
-labels: ['call-for-help']
----
+description: Request assistance for a SIG project to prevent critical gaps
+title: "[Call for Help] <project-name>: <brief-description>"
+labels:
+  - call-for-help
+body:
+  - type: input
+    id: project-name
+    label: Project Name
+    description: "e.g., ingress-nginx, kubernetes-sigs/cluster-api"
+    placeholder: "Enter project or repository name"
 
-## Project Information
+  - type: input
+    id: github-repo
+    label: GitHub Repository
+    description: "e.g., kubernetes/ingress-nginx"
+    placeholder: "Enter the full repository path"
 
-- **Project Name**: <!-- e.g., ingress-nginx, kubernetes-sigs/cluster-api -->
-- **GitHub Repository**: <!-- e.g., kubernetes/ingress-nginx -->
-- **SIG/Working Group**: <!-- e.g., SIG Network, WG Serving -->
+  - type: input
+    id: sig-wg
+    label: SIG/Working Group
+    description: "e.g., SIG Network, WG Serving"
+    placeholder: "Enter the SIG or WG name"
 
-## Request Type
+  - type: checkboxes
+    id: request-type
+    label: Request Type
+    description: What kind of help is needed?
+    options:
+      - label: Reviewers - Need additional reviewers for PRs
+        required: false
+      - label: Maintainers - Need new maintainers to prevent single point of failure
+        required: false
+      - label: Security - Security-focused assistance needed
+        required: false
+      - label: Mentorship - Need help onboarding new contributors
+        required: false
 
-What kind of help is needed? (check all that apply)
+  - type: textarea
+    id: description
+    label: Description
+    description: Provide details about the situation and why help is needed
+    placeholder: "Describe the current situation and what kind of help you need..."
 
-- [ ] **Reviewers** - Need additional reviewers for PRs
-- [ ] **Maintainers** - Need new maintainers to prevent single point of failure
-- [ ] **Security** - Security-focused assistance needed
-- [ ] **Mentorship** - Need help onboarding new contributors
-- [ ] **Other** - Describe below
+  - type: input
+    id: slack-handle
+    label: Slack Handle
+    description: Your GitHub username for Slack
+    placeholder: "@username"
 
-## Description
+  - type: input
+    id: email
+    label: Email
+    description: Contact email (optional)
+    placeholder: "contact@email.com"
 
-<!-- Provide details about the situation and why help is needed -->
+  - type: checkboxes
+    id: nco-feature
+    label: New Contributor Orientation
+    description: Include this project in NCO for new contributors
+    options:
+      - label: Yes, feature this project in New Contributor Orientation
+        required: false
 
+  - type: input
+    id: good-first-issues
+    label: Good First Issues Link
+    description: Link to good first issues for this project
+    placeholder: "https://github.com/org/repo/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue"
 
+  - type: input
+    id: onboarding-guide
+    label: Onboarding Guide Link
+    description: Link to contributing/onboarding guide
+    placeholder: "https://kubernetes.dev/docs/..."
 
-## Contact Information
-
-- **Slack Handle**: <!-- e.g., @username -->
-- **Email**: <!-- contact@email.com -->
-- **Preferred Contact Method**: [ ] Slack [ ] Email [ ] GitHub
-
-## New Contributor Orientation
-
-- [ ] **Feature in NCO** - Include this project in New Contributor Orientation for new contributors
-
-## Links
-
-- **Good First Issues**: <!-- link to good first issues -->
-- **Onboarding Guide**: <!-- link to contributing guide -->
-- **OWNERS File**: <!-- link to OWNERS -->
-
----
-
-**Note**: This request requires approval from a SIG Chair or Tech Lead from your SIG.
-Once approved with `/approve`, this issue will be displayed in the Community Resilience Dashboard
-and optionally in New Contributor Orientation.
+  - type: markdown
+    value: |
+      ---
+      **Note**: This request requires approval from a SIG Chair or Tech Lead from your SIG.
+      Once approved with `/approve`, this issue will be displayed in the Community Resilience Dashboard
+      and optionally in New Contributor Orientation.

--- a/assets/css/call-for-help.css
+++ b/assets/css/call-for-help.css
@@ -1,0 +1,130 @@
+.call-for-help-section {
+  margin: 2rem 0;
+}
+
+.call-for-help-section h3 {
+  margin-bottom: 0.5rem;
+  color: var(--bs-body-color);
+}
+
+.section-desc {
+  margin-bottom: 1.5rem;
+  color: var(--bs-secondary-color);
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.call-for-help-card {
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: var(--bs-body-bg);
+  transition: box-shadow 0.2s ease;
+}
+
+.call-for-help-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.call-for-help-card.stale {
+  border-color: var(--bs-warning);
+  opacity: 0.8;
+}
+
+.call-for-help-card.nco-featured {
+  border-left: 4px solid var(--bs-success);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+}
+
+.project-name {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.project-name a {
+  text-decoration: none;
+}
+
+.nco-badge {
+  display: inline-block;
+  background: var(--bs-success);
+  color: white;
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.25rem;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+.request-type {
+  font-size: 0.85rem;
+  color: var(--bs-secondary-color);
+  background: var(--bs-tertiary-bg);
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.card-body {
+  margin-bottom: 1rem;
+}
+
+.issue-title {
+  font-size: 0.9rem;
+  color: var(--bs-body-color);
+  margin-bottom: 0.5rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: var(--bs-secondary-color);
+}
+
+.stale-badge {
+  color: var(--bs-warning);
+  font-weight: 600;
+}
+
+.card-footer {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.card-footer .btn {
+  font-size: 0.85rem;
+}
+
+.no-requests {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bs-tertiary-bg);
+  border-radius: 0.5rem;
+}
+
+.no-requests .help-text {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: var(--bs-secondary-color);
+}
+
+.loading {
+  text-align: center;
+  padding: 2rem;
+  color: var(--bs-secondary-color);
+}

--- a/assets/js/call-for-help.js
+++ b/assets/js/call-for-help.js
@@ -1,5 +1,5 @@
 // Call for Help integration for Community Resilience Dashboard
-// Fetches issues labeled 'call-for-help' from GitHub API
+// Fetches issues labeled 'call-for-help-approved' from GitHub API
 
 (function() {
   'use strict';
@@ -7,7 +7,7 @@
   const GITHUB_API = 'https://api.github.com';
   const REPO_OWNER = 'kubernetes';
   const REPO_NAME = 'contributor-site';
-  const REQUIRED_LABELS = ['call-for-help', 'call-for-help-approved'];
+  const APPROVED_LABEL = 'call-for-help-approved';
   const NCO_LABELS = ['sig-contribex-nco'];
 
   const RequestType = {
@@ -18,9 +18,16 @@
     OTHER: 'Other'
   };
 
+  function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
   async function fetchCallForHelpIssues() {
     try {
-      const url = `${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/issues?labels=call-for-help&state=open&per_page=50`;
+      // Fetch only approved issues
+      const url = `${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/issues?labels=${APPROVED_LABEL}&state=open&per_page=50`;
       const response = await fetch(url);
 
       if (!response.ok) {
@@ -79,31 +86,95 @@
     const card = document.createElement('div');
     card.className = `call-for-help-card${isStale ? ' stale' : ''}${issue.hasNCO ? ' nco-featured' : ''}`;
 
-    card.innerHTML = `
-      <div class="card-header">
-        <h4 class="project-name">
-          <a href="${issue.url}" target="_blank" rel="noopener">${issue.project}</a>
-          ${issue.hasNCO ? '<span class="nco-badge">NCO</span>' : ''}
-        </h4>
-        <span class="request-type">${issue.requestType.join(', ')}</span>
-      </div>
-      <div class="card-body">
-        <p class="issue-title">${issue.title}</p>
-        <div class="card-meta">
-          <span class="issue-number">#${issue.number}</span>
-          <span class="created-date">${daysSinceCreated} days ago</span>
-          ${isStale ? '<span class="stale-badge">Stale</span>' : ''}
-        </div>
-      </div>
-      <div class="card-footer">
-        <a href="${issue.url}" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener">
-          View Issue
-        </a>
-        <a href="${issue.url.replace('issues/', 'issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue')}" class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener">
-          Good First Issues
-        </a>
-      </div>
-    `;
+    // Header
+    const header = document.createElement('div');
+    header.className = 'card-header';
+
+    const titleWrapper = document.createElement('h4');
+    titleWrapper.className = 'project-name';
+
+    const link = document.createElement('a');
+    link.href = issue.url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = issue.project;
+
+    titleWrapper.appendChild(link);
+
+    if (issue.hasNCO) {
+      const ncoBadge = document.createElement('span');
+      ncoBadge.className = 'nco-badge';
+      ncoBadge.textContent = 'NCO';
+      titleWrapper.appendChild(ncoBadge);
+    }
+
+    const typeSpan = document.createElement('span');
+    typeSpan.className = 'request-type';
+    typeSpan.textContent = issue.requestType.join(', ');
+
+    header.appendChild(titleWrapper);
+    header.appendChild(typeSpan);
+
+    // Body
+    const body = document.createElement('div');
+    body.className = 'card-body';
+
+    const titlePara = document.createElement('p');
+    titlePara.className = 'issue-title';
+    titlePara.textContent = issue.title;
+
+    const metaDiv = document.createElement('div');
+    metaDiv.className = 'card-meta';
+
+    const numberSpan = document.createElement('span');
+    numberSpan.className = 'issue-number';
+    numberSpan.textContent = '#' + issue.number;
+
+    const dateSpan = document.createElement('span');
+    dateSpan.className = 'created-date';
+    dateSpan.textContent = daysSinceCreated + ' days ago';
+
+    metaDiv.appendChild(numberSpan);
+    metaDiv.appendChild(dateSpan);
+
+    if (isStale) {
+      const staleBadge = document.createElement('span');
+      staleBadge.className = 'stale-badge';
+      staleBadge.textContent = 'Stale';
+      metaDiv.appendChild(staleBadge);
+    }
+
+    body.appendChild(titlePara);
+    body.appendChild(metaDiv);
+
+    // Footer
+    const footer = document.createElement('div');
+    footer.className = 'card-footer';
+
+    // Fix malformed Good First Issues URL
+    const baseUrl = issue.url.replace(/\/issues\/\d+$/, '');
+
+    const viewBtn = document.createElement('a');
+    viewBtn.href = issue.url;
+    viewBtn.className = 'btn btn-sm btn-outline-primary';
+    viewBtn.target = '_blank';
+    viewBtn.rel = 'noopener';
+    viewBtn.textContent = 'View Issue';
+
+    const gfiBtn = document.createElement('a');
+    gfiBtn.href = baseUrl + '?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue';
+    gfiBtn.className = 'btn btn-sm btn-outline-secondary';
+    gfiBtn.target = '_blank';
+    gfiBtn.rel = 'noopener';
+    gfiBtn.textContent = 'Good First Issues';
+
+    footer.appendChild(viewBtn);
+    footer.appendChild(gfiBtn);
+
+    // Append all sections
+    card.appendChild(header);
+    card.appendChild(body);
+    card.appendChild(footer);
 
     return card;
   }

--- a/assets/js/call-for-help.js
+++ b/assets/js/call-for-help.js
@@ -1,0 +1,171 @@
+// Call for Help integration for Community Resilience Dashboard
+// Fetches issues labeled 'call-for-help' from GitHub API
+
+(function() {
+  'use strict';
+
+  const GITHUB_API = 'https://api.github.com';
+  const REPO_OWNER = 'kubernetes';
+  const REPO_NAME = 'contributor-site';
+  const REQUIRED_LABELS = ['call-for-help', 'call-for-help-approved'];
+  const NCO_LABELS = ['sig-contribex-nco'];
+
+  const RequestType = {
+    REVIEWERS: 'Reviewers',
+    MAINTAINERS: 'Maintainers',
+    SECURITY: 'Security',
+    MENTORSHIP: 'Mentorship',
+    OTHER: 'Other'
+  };
+
+  async function fetchCallForHelpIssues() {
+    try {
+      const url = `${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/issues?labels=call-for-help&state=open&per_page=50`;
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        console.error('Failed to fetch Call for Help issues:', response.status);
+        return [];
+      }
+
+      const issues = await response.json();
+      return issues.filter(issue => !issue.pull_request);
+    } catch (error) {
+      console.error('Error fetching Call for Help issues:', error);
+      return [];
+    }
+  }
+
+  function parseRequestType(body) {
+    const types = [];
+    const lowerBody = body.toLowerCase();
+
+    if (lowerBody.includes('reviewer')) types.push(RequestType.REVIEWERS);
+    if (lowerBody.includes('maintainer')) types.push(RequestType.MAINTAINERS);
+    if (lowerBody.includes('security')) types.push(RequestType.SECURITY);
+    if (lowerBody.includes('mentorship') || lowerBody.includes('mentor')) types.push(RequestType.MENTORSHIP);
+    if (lowerBody.includes('other')) types.push(RequestType.OTHER);
+
+    return types.length > 0 ? types : [RequestType.OTHER];
+  }
+
+  function extractProjectInfo(issue) {
+    const title = issue.title;
+    const body = issue.body || '';
+
+    const projectMatch = title.match(/\[Call for Help\]\s*([^:]+):/);
+    const project = projectMatch ? projectMatch[1].trim() : title;
+
+    const labels = issue.labels.map(l => l.name);
+    const hasNCO = NCO_LABELS.some(l => labels.includes(l));
+
+    return {
+      number: issue.number,
+      title: issue.title,
+      project: project,
+      url: issue.html_url,
+      requestType: parseRequestType(body),
+      hasNCO: hasNCO,
+      createdAt: new Date(issue.created_at),
+      labels: labels,
+      state: issue.state
+    };
+  }
+
+  function createProjectCard(issue) {
+    const daysSinceCreated = Math.floor((Date.now() - issue.createdAt.getTime()) / (1000 * 60 * 60 * 24));
+    const isStale = daysSinceCreated > 90;
+
+    const card = document.createElement('div');
+    card.className = `call-for-help-card${isStale ? ' stale' : ''}${issue.hasNCO ? ' nco-featured' : ''}`;
+
+    card.innerHTML = `
+      <div class="card-header">
+        <h4 class="project-name">
+          <a href="${issue.url}" target="_blank" rel="noopener">${issue.project}</a>
+          ${issue.hasNCO ? '<span class="nco-badge">NCO</span>' : ''}
+        </h4>
+        <span class="request-type">${issue.requestType.join(', ')}</span>
+      </div>
+      <div class="card-body">
+        <p class="issue-title">${issue.title}</p>
+        <div class="card-meta">
+          <span class="issue-number">#${issue.number}</span>
+          <span class="created-date">${daysSinceCreated} days ago</span>
+          ${isStale ? '<span class="stale-badge">Stale</span>' : ''}
+        </div>
+      </div>
+      <div class="card-footer">
+        <a href="${issue.url}" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener">
+          View Issue
+        </a>
+        <a href="${issue.url.replace('issues/', 'issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue')}" class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener">
+          Good First Issues
+        </a>
+      </div>
+    `;
+
+    return card;
+  }
+
+  async function initCallForHelpDashboard(containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    container.innerHTML = '<div class="loading">Loading Call for Help requests...</div>';
+
+    const issues = await fetchCallForHelpIssues();
+    const parsed = issues.map(extractProjectInfo);
+
+    if (parsed.length === 0) {
+      container.innerHTML = `
+        <div class="no-requests">
+          <p>No active Call for Help requests at this time.</p>
+          <p class="help-text">
+            SIG Chairs and Tech Leads can
+            <a href="https://github.com/${REPO_OWNER}/${REPO_NAME}/issues/new?template=call-for-help.yaml" target="_blank" rel="noopener">
+              create a request
+            </a>
+            if their project needs assistance.
+          </p>
+        </div>
+      `;
+      return;
+    }
+
+    const ncoProjects = parsed.filter(p => p.hasNCO);
+    const otherProjects = parsed.filter(p => !p.hasNCO);
+
+    let html = '<div class="call-for-help-section">';
+
+    if (ncoProjects.length > 0) {
+      html += `
+        <div class="nco-projects">
+          <h3>New Contributor Orientation Featured Projects</h3>
+          <p class="section-desc">These projects are looking for new contributors!</p>
+          <div class="projects-grid">
+            ${ncoProjects.map(p => createProjectCard(p).outerHTML).join('')}
+          </div>
+        </div>
+      `;
+    }
+
+    if (otherProjects.length > 0) {
+      html += `
+        <div class="other-projects">
+          <h3>Projects Needing Assistance</h3>
+          <div class="projects-grid">
+            ${otherProjects.map(p => createProjectCard(p).outerHTML).join('')}
+          </div>
+        </div>
+      `;
+    }
+
+    html += '</div>';
+    container.innerHTML = html;
+  }
+
+  window.initCallForHelpDashboard = initCallForHelpDashboard;
+  window.fetchCallForHelpIssues = fetchCallForHelpIssues;
+
+})();

--- a/assets/js/sigs-filter.js
+++ b/assets/js/sigs-filter.js
@@ -65,14 +65,19 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Handle URL hash for tab activation
   if (window.location.hash) {
-    const hash = window.location.hash;
-    const tabEl = document.querySelector(`button[data-bs-target="${hash}"]`);
-    if (tabEl) {
-      // Check if bootstrap is available
-      if (typeof bootstrap !== 'undefined') {
-        const tab = new bootstrap.Tab(tabEl);
-        tab.show();
+    try {
+      const hash = window.location.hash;
+      const tabEl = document.querySelector(`button[data-bs-target="${hash}"]`);
+      if (tabEl) {
+        // Check if bootstrap is available
+        if (typeof bootstrap !== 'undefined') {
+          const tab = new bootstrap.Tab(tabEl);
+          tab.show();
+        }
       }
+    } catch (e) {
+      // Silently ignore invalid selector syntax
+      console.debug('Could not activate tab from hash:', e.message);
     }
   }
 

--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -13,230 +13,237 @@
 
 {{- $sigsOpts := merge $globalOpts (dict "key" "sigs-yaml-adapter") -}}
 
-{{ with resources.GetRemote $sigsUrl $sigsOpts }}
+{{ $sigsResource := try (resources.GetRemote $sigsUrl $sigsOpts) }}
+{{ with $sigsResource }}
   {{ with .Err }}
     {{ if eq hugo.Environment "production" }}
       {{ errorf "Unable to load sigs.yaml: %s" . }}
     {{ else }}
       {{ warnf "Unable to load sigs.yaml: %s" . }}
     {{ end }}
-  {{ end }}
+  {{ else }}
+    {{ with .Content | transform.Unmarshal }}
+      {{/* SIGs */}}
+      {{ range .sigs }}
+        {{ $name := .name }}
+        {{ $dir := .dir }}
+        {{ $slug := replace $dir "sig-" "" }}
 
-  {{ with .Content | transform.Unmarshal }}
-    {{/* SIGs */}}
-    {{ range .sigs }}
-      {{ $name := .name }}
-      {{ $dir := .dir }}
-      {{ $slug := replace $dir "sig-" "" }}
-      
-      {{/* Fetch README Content */}}
-      {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
-      {{ $readmeContent := "" }}
-      {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-      {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+        {{/* Fetch README Content */}}
+        {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
+        {{ $readmeContent := "" }}
+        {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
+        {{ $readmeResource := try (resources.GetRemote $readmeUrl $readmeOpts) }}
+        {{ with $readmeResource }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir . }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir . }}
+            {{ end }}
           {{ else }}
-            {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
           {{ end }}
-        {{ else }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
+        {{ end }}
+
+        {{ $page := dict
+          "kind" "section"
+          "path" (printf "sigs/%s" $slug)
+          "title" (printf "SIG %s" $name)
+          "params" (dict
+            "description" .mission_statement
+            "leadership" .leadership
+            "meetings" .meetings
+            "contact" .contact
+            "subprojects" .subprojects
+            "label" .label
+            "dir" .dir
+            "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
+            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+          )
+          "content" (dict
+            "mediaType" "text/markdown"
+            "value" $readmeContent
+          )
+        }}
+        {{ $.AddPage $page }}
+
+        {{/* Fetch Charter Content */}}
+        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+        {{ $charterResource := try (resources.GetRemote $charterUrl $charterOpts) }}
+        {{ with $charterResource }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir . }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir . }}
+            {{ end }}
+          {{ else }}
+            {{ $charterContent := replace .Content "\u200b" "" }}
+            {{ $charterPage := dict
+              "kind" "page"
+              "path" (printf "sigs/%s/charter" $slug)
+              "title" (printf "SIG %s Charter" $name)
+              "params" (dict
+                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "hide_summary" true
+                "toc_hide" true
+              )
+              "content" (dict              "mediaType" "text/markdown"
+                "value" $charterContent
+              )
+            }}
+            {{ $.AddPage $charterPage }}
+          {{ end }}
         {{ end }}
       {{ end }}
 
-      {{ $page := dict
-        "kind" "section"
-        "path" (printf "sigs/%s" $slug)
-        "title" (printf "SIG %s" $name)
-        "params" (dict
-          "description" .mission_statement
-          "leadership" .leadership
-          "meetings" .meetings
-          "contact" .contact
-          "subprojects" .subprojects
-          "label" .label
-          "dir" .dir
-          "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-          "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-        )
-        "content" (dict
-          "mediaType" "text/markdown"
-          "value" $readmeContent
-        )
-      }}
-      {{ $.AddPage $page }}
+      {{/* Working Groups */}}
+      {{ range .workinggroups }}
+        {{ $name := .name }}
+        {{ $dir := .dir }}
+        {{ $slug := replace $dir "wg-" "" }}
 
-      {{/* Fetch Charter Content */}}
-      {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-      {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-      {{ with resources.GetRemote $charterUrl $charterOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+        {{/* Fetch README Content */}}
+        {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
+        {{ $readmeContent := "" }}
+        {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
+        {{ $readmeResource := try (resources.GetRemote $readmeUrl $readmeOpts) }}
+        {{ with $readmeResource }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir . }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir . }}
+            {{ end }}
           {{ else }}
-            {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
           {{ end }}
-        {{ else }}
-          {{ $charterContent := replace .Content "\u200b" "" }}
-          {{ $charterPage := dict
-            "kind" "page"
-            "path" (printf "sigs/%s/charter" $slug)
-            "title" (printf "SIG %s Charter" $name)
-            "params" (dict
-              "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-              "hide_summary" true
-              "toc_hide" true
-            )
-            "content" (dict              "mediaType" "text/markdown"
-              "value" $charterContent
-            )
-          }}
-          {{ $.AddPage $charterPage }}
         {{ end }}
-      {{ end }}
-    {{ end }}
 
-    {{/* Working Groups */}}
-    {{ range .workinggroups }}
-      {{ $name := .name }}
-      {{ $dir := .dir }}
-      {{ $slug := replace $dir "wg-" "" }}
-      
-      {{/* Fetch README Content */}}
-      {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
-      {{ $readmeContent := "" }}
-      {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-      {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+        {{ $page := dict
+          "kind" "section"
+          "path" (printf "wg/%s" $slug)
+          "title" (printf "WG %s" $name)
+          "params" (dict
+            "description" .mission_statement
+            "leadership" .leadership
+            "meetings" .meetings
+            "contact" .contact
+            "dir" .dir
+            "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
+            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+          )
+          "content" (dict
+            "mediaType" "text/markdown"
+            "value" $readmeContent
+          )
+        }}
+        {{ $.AddPage $page }}
+
+        {{/* Fetch Charter Content */}}
+        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+        {{ $charterResource := try (resources.GetRemote $charterUrl $charterOpts) }}
+        {{ with $charterResource }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir . }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir . }}
+            {{ end }}
           {{ else }}
-            {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ $charterContent := replace .Content "\u200b" "" }}
+            {{ $charterPage := dict
+              "kind" "page"
+              "path" (printf "wg/%s/charter" $slug)
+              "title" (printf "WG %s Charter" $name)
+              "params" (dict
+                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "hide_summary" true
+                "toc_hide" true
+              )
+              "content" (dict              "mediaType" "text/markdown"
+                "value" $charterContent
+              )
+            }}
+            {{ $.AddPage $charterPage }}
           {{ end }}
-        {{ else }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
-        {{ end }}
-      {{ end }}
-
-      {{ $page := dict
-        "kind" "section"
-        "path" (printf "wg/%s" $slug)
-        "title" (printf "WG %s" $name)
-        "params" (dict
-          "description" .mission_statement
-          "leadership" .leadership
-          "meetings" .meetings
-          "contact" .contact
-          "dir" .dir
-          "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-          "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-        )
-        "content" (dict
-          "mediaType" "text/markdown"
-          "value" $readmeContent
-        )
-      }}
-      {{ $.AddPage $page }}
-
-      {{/* Fetch Charter Content */}}
-      {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-      {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-      {{ with resources.GetRemote $charterUrl $charterOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $charterContent := replace .Content "\u200b" "" }}
-          {{ $charterPage := dict
-            "kind" "page"
-            "path" (printf "wg/%s/charter" $slug)
-            "title" (printf "WG %s Charter" $name)
-            "params" (dict
-              "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-              "hide_summary" true
-              "toc_hide" true
-            )
-            "content" (dict              "mediaType" "text/markdown"
-              "value" $charterContent
-            )
-          }}
-          {{ $.AddPage $charterPage }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-
-    {{/* Committees */}}
-    {{ range .committees }}
-      {{ $name := .name }}
-      {{ $dir := .dir }}
-      {{ $slug := replace $dir "committee-" "" }}
-      
-      {{/* Fetch README Content */}}
-      {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
-      {{ $readmeContent := "" }}
-      {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-      {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load README for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load README for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
         {{ end }}
       {{ end }}
 
-      {{ $page := dict
-        "kind" "section"
-        "path" (printf "committees/%s" $slug)
-        "title" (printf "%s" $name)
-        "params" (dict
-          "description" .mission_statement
-          "leadership" .leadership
-          "meetings" .meetings
-          "contact" .contact
-          "dir" .dir
-          "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-          "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-        )
-        "content" (dict
-          "mediaType" "text/markdown"
-          "value" $readmeContent
-        )
-      }}
-      {{ $.AddPage $page }}
+      {{/* Committees */}}
+      {{ range .committees }}
+        {{ $name := .name }}
+        {{ $dir := .dir }}
+        {{ $slug := replace $dir "committee-" "" }}
 
-      {{/* Fetch Charter Content */}}
-      {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-      {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-      {{ with resources.GetRemote $charterUrl $charterOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+        {{/* Fetch README Content */}}
+        {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
+        {{ $readmeContent := "" }}
+        {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
+        {{ $readmeResource := try (resources.GetRemote $readmeUrl $readmeOpts) }}
+        {{ with $readmeResource }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir . }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir . }}
+            {{ end }}
           {{ else }}
-            {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
           {{ end }}
-        {{ else }}
-          {{ $charterContent := replace .Content "\u200b" "" }}
-          {{ $charterPage := dict
-            "kind" "page"
-            "path" (printf "committees/%s/charter" $slug)
-            "title" (printf "%s Charter" $name)
-            "params" (dict
-              "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-              "hide_summary" true
-              "toc_hide" true
-            )
-            "content" (dict              "mediaType" "text/markdown"
-              "value" $charterContent
-            )
-          }}
-          {{ $.AddPage $charterPage }}
+        {{ end }}
+
+        {{ $page := dict
+          "kind" "section"
+          "path" (printf "committees/%s" $slug)
+          "title" (printf "%s" $name)
+          "params" (dict
+            "description" .mission_statement
+            "leadership" .leadership
+            "meetings" .meetings
+            "contact" .contact
+            "dir" .dir
+            "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
+            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+          )
+          "content" (dict
+            "mediaType" "text/markdown"
+            "value" $readmeContent
+          )
+        }}
+        {{ $.AddPage $page }}
+
+        {{/* Fetch Charter Content */}}
+        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+        {{ $charterResource := try (resources.GetRemote $charterUrl $charterOpts) }}
+        {{ with $charterResource }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir . }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir . }}
+            {{ end }}
+          {{ else }}
+            {{ $charterContent := replace .Content "\u200b" "" }}
+            {{ $charterPage := dict
+              "kind" "page"
+              "path" (printf "committees/%s/charter" $slug)
+              "title" (printf "%s Charter" $name)
+              "params" (dict
+                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "hide_summary" true
+                "toc_hide" true
+              )
+              "content" (dict              "mediaType" "text/markdown"
+                "value" $charterContent
+              )
+            }}
+            {{ $.AddPage $charterPage }}
+          {{ end }}
         {{ end }}
       {{ end }}
     {{ end }}

--- a/content/en/community/community-groups/wg/_index.md
+++ b/content/en/community/community-groups/wg/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Working Groups
-description: "Working Groups (WBs) are temporary groups created to achieve a specific goal spanning multiple SIGs."
+description: "Working Groups (WGs) are temporary groups created to achieve a specific goal spanning multiple SIGs."
 weight: 20
 hide_section_index: true
 ---

--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -103,7 +103,7 @@
         
         {{- /* 2. Fix relative paths (not starting with http, #, or / and not containing :) */ -}}
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `<img\s+([^>]*?)src="([^/#:][^:"]*)"([^>]*)>` (printf `<img %1ssrc="%s%2"%3>` $kepDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
       {{- end -}}
     {{- end -}}

--- a/content/en/resources/services.md
+++ b/content/en/resources/services.md
@@ -120,7 +120,7 @@ For more information, see the [Slack Guidelines].
 
 
 [slack-config]: https://git.k8s.io/community/communication/slack-config
-[Slack Request]: https://github.com/kubernetes/community/issues/new?assignees=&labels=area%2Fcommunity-management%2C+area%2Fslack-management%2C+sig%2Fcontributor-experience&template=slack-request.yml&title=REQUEST%3A+New+Slack+%3C%5Bchannel%7Cusergroup%7Cbot%7Ctoken%7Cwebhook%5D%3E+%3C%5Bchannel%7Cusergroup%7Cbot%7Ctoken%7Cwebhook%5D+name%3E
+[Slack Request]: https://github.com/kubernetes/community/issues/new?assignees=&labels=area%2Fcommunity-management%2C+area%2Fslack-management%2C+sig%2Fcontributor-experience&template=comms-request.yaml&title=REQUEST%3A+New+Slack+%3C%5Bchannel%7Cusergroup%7Cbot%7Ctoken%7Cwebhook%5D%3E+%3C%5Bchannel%7Cusergroup%7Cbot%7Ctoken%7Cwebhook%5D+name%3E
 [Slack Guidelines]: https://git.k8s.io/community/communication/slack-guidelines.md
 
 

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,10 +1,13 @@
 {{- $u := .Destination -}}
-{{- /* 
+{{- /*
   Robustly handle URLs with parentheses or extra spaces from external sources (e.g. KEP READMEs).
-  This prevents build failures like "first path segment in URL cannot contain colon" when 
+  This prevents build failures like "first path segment in URL cannot contain colon" when
   a link destination is wrapped in extra parentheses.
 */ -}}
-{{- $u = trim $u " ()" -}}
+{{- $u = trim $u " " -}}
+{{- if and (hasPrefix $u "(") (hasSuffix $u ")") -}}
+  {{- $u = substr $u 1 -1 -}}
+{{- end -}}
 <a href="{{ $u | safeURL }}"
   {{ with .Title }} title="{{ . }}"{{ end }}
   {{ if strings.HasPrefix $u "http" }} target="_blank" rel="noopener"{{ end }}>

--- a/layouts/shortcodes/call-for-help.html
+++ b/layouts/shortcodes/call-for-help.html
@@ -1,0 +1,37 @@
+{{ $showNCOOnly := .Get "ncoOnly" }}
+{{ $title := .Get "title" | default "Call for Help" }}
+
+<div class="call-for-help-container my-4">
+  {{ if $title }}
+  <h2>{{ $title }}</h2>
+  {{ end }}
+
+  <div id="callForHelpDashboard" class="call-for-help-dashboard">
+    <p class="loading">Loading Call for Help requests...</p>
+  </div>
+</div>
+
+{{ $css := resources.Get "css/call-for-help.css" | minify | fingerprint }}
+<link rel="stylesheet" href="{{ $css.RelPermalink }}">
+
+{{ $js := resources.Get "js/call-for-help.js" | minify | fingerprint }}
+<script src="{{ $js.RelPermalink }}"></script>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    window.initCallForHelpDashboard('callForHelpDashboard');
+  });
+
+  function displayIssues(issues) {
+    const dashboard = document.getElementById('callForHelpDashboard');
+    if (!issues || issues.length === 0) {
+      dashboard.innerHTML = '<p class="no-requests">No active requests.</p>';
+      return;
+    }
+    dashboard.innerHTML = '';
+    issues.forEach(function(issue) {
+      const card = window.createProjectCard(issue);
+      dashboard.appendChild(card);
+    });
+  }
+</script>


### PR DESCRIPTION
## Summary

Adds the Call for Help feature to enable SIGs to request assistance from the community.

### Changes
- `.github/ISSUE_TEMPLATE/call-for-help.yaml` - Issue template for Call for Help requests
- `assets/css/call-for-help.css` - Dashboard styles
- `assets/js/call-for-help.js` - GitHub API integration
- `layouts/shortcodes/call-for-help.html` - Hugo shortcode

This enables the Community Resilience Dashboard feature where SIGs can request assistance and get approved by SIG leads.