### PR TITLE
Bump versions of Hugo and Node

### DIFF
--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -13,232 +13,274 @@
 
 {{- $sigsOpts := merge $globalOpts (dict "key" "sigs-yaml-adapter") -}}
 
-{{ with resources.GetRemote $sigsUrl $sigsOpts }}
+{{- with try (resources.GetRemote $sigsUrl $sigsOpts) -}}
   {{ with .Err }}
-    {{ if eq hugo.Environment "production" }}
+    {{- if eq hugo.Environment "production" -}}
       {{ errorf "Unable to load sigs.yaml: %s" . }}
-    {{ else }}
+    {{- else -}}
       {{ warnf "Unable to load sigs.yaml: %s" . }}
     {{ end }}
-  {{ end }}
-
-  {{ with .Content | transform.Unmarshal }}
-    {{/* SIGs */}}
-    {{ range .sigs }}
-      {{ $name := .name }}
-      {{ $dir := .dir }}
-      {{ $slug := replace $dir "sig-" "" }}
-      
-      {{/* Fetch README Content */}}
-      {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
-      {{ $readmeContent := "" }}
-      {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-      {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+  {{ else with .Value }}
+    {{ with .Content | transform.Unmarshal }}
+      {{/* SIGs */}}
+      {{ range .sigs }}
+        {{ $name := .name }}
+        {{ $dir := .dir }}
+        {{ $slug := replace $dir "sig-" "" }}
+        
+        {{/* Fetch README Content */}}
+        {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
+        {{ $readmeContent := "" }}
+        {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
+        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
           {{ else }}
-            {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
           {{ end }}
-        {{ else }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
+        {{ end }}
+  
+        {{ $page := dict
+          "kind" "section"
+          "path" (printf "sigs/%s" $slug)
+          "title" (printf "SIG %s" $name)
+          "params" (dict
+            "description" .mission_statement
+            "leadership" .leadership
+            "meetings" .meetings
+            "contact" .contact
+            "subprojects" .subprojects
+            "label" .label
+            "dir" .dir
+            "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
+            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+          )
+          "content" (dict
+            "mediaType" "text/markdown"
+            "value" $readmeContent
+          )
+        }}
+        {{ $.AddPage $page }}
+  
+        {{/* Fetch Charter Content */}}
+        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $charterContent := replace .Content "\u200b" "" }}
+            {{ $charterPage := dict
+              "kind" "page"
+              "path" (printf "sigs/%s/charter" $slug)
+              "title" (printf "SIG %s Charter" $name)
+              "params" (dict
+                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "hide_summary" true
+                "toc_hide" true
+              )
+              "content" (dict              "mediaType" "text/markdown"
+                "value" $charterContent
+              )
+            }}
+            {{ $.AddPage $charterPage }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter from %s" $charterUrl }}
+            {{ else }}
+              {{ warnf "Unable to load charter from %s" $charterUrl }}
+            {{ end }}
+          {{ end }}
         {{ end }}
       {{ end }}
-
-      {{ $page := dict
-        "kind" "section"
-        "path" (printf "sigs/%s" $slug)
-        "title" (printf "SIG %s" $name)
-        "params" (dict
-          "description" .mission_statement
-          "leadership" .leadership
-          "meetings" .meetings
-          "contact" .contact
-          "subprojects" .subprojects
-          "label" .label
-          "dir" .dir
-          "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-          "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-        )
-        "content" (dict
-          "mediaType" "text/markdown"
-          "value" $readmeContent
-        )
-      }}
-      {{ $.AddPage $page }}
-
-      {{/* Fetch Charter Content */}}
-      {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-      {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-      {{ with resources.GetRemote $charterUrl $charterOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+  
+      {{/* Working Groups */}}
+      {{ range .workinggroups }}
+        {{ $name := .name }}
+        {{ $dir := .dir }}
+        {{ $slug := replace $dir "wg-" "" }}
+        
+        {{/* Fetch README Content */}}
+        {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
+        {{ $readmeContent := "" }}
+        {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
+        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
           {{ else }}
-            {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s" $dir }}
+            {{ end }}
           {{ end }}
-        {{ else }}
-          {{ $charterContent := replace .Content "\u200b" "" }}
-          {{ $charterPage := dict
-            "kind" "page"
-            "path" (printf "sigs/%s/charter" $slug)
-            "title" (printf "SIG %s Charter" $name)
-            "params" (dict
-              "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-              "hide_summary" true
-              "toc_hide" true
-            )
-            "content" (dict              "mediaType" "text/markdown"
-              "value" $charterContent
-            )
-          }}
-          {{ $.AddPage $charterPage }}
+        {{ end }}
+  
+        {{ $page := dict
+          "kind" "section"
+          "path" (printf "wg/%s" $slug)
+          "title" (printf "WG %s" $name)
+          "params" (dict
+            "description" .mission_statement
+            "leadership" .leadership
+            "meetings" .meetings
+            "contact" .contact
+            "dir" .dir
+            "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
+            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+          )
+          "content" (dict
+            "mediaType" "text/markdown"
+            "value" $readmeContent
+          )
+        }}
+        {{ $.AddPage $page }}
+  
+        {{/* Fetch Charter Content */}}
+        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $charterContent := replace .Content "\u200b" "" }}
+            {{ $charterPage := dict
+              "kind" "page"
+              "path" (printf "wg/%s/charter" $slug)
+              "title" (printf "WG %s Charter" $name)
+              "params" (dict
+                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "hide_summary" true
+                "toc_hide" true
+              )
+              "content" (dict              "mediaType" "text/markdown"
+                "value" $charterContent
+              )
+            }}
+            {{ $.AddPage $charterPage }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s" $dir }}
+            {{ end }}
+          {{ end }}
         {{ end }}
       {{ end }}
+  
+      {{/* Committees */}}
+      {{ range .committees }}
+        {{ $name := .name }}
+        {{ $dir := .dir }}
+        {{ $slug := replace $dir "committee-" "" }}
+        
+        {{/* Fetch README Content */}}
+        {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
+        {{ $readmeContent := "" }}
+        {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
+        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s" $dir }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+  
+        {{ $page := dict
+          "kind" "section"
+          "path" (printf "committees/%s" $slug)
+          "title" (printf "%s" $name)
+          "params" (dict
+            "description" .mission_statement
+            "leadership" .leadership
+            "meetings" .meetings
+            "contact" .contact
+            "dir" .dir
+            "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
+            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+          )
+          "content" (dict
+            "mediaType" "text/markdown"
+            "value" $readmeContent
+          )
+        }}
+        {{ $.AddPage $page }}
+  
+        {{/* Fetch Charter Content */}}
+        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
+            {{ $charterContent := replace .Content "\u200b" "" }}
+            {{ $charterPage := dict
+              "kind" "page"
+              "path" (printf "committees/%s/charter" $slug)
+              "title" (printf "%s Charter" $name)
+              "params" (dict
+                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "hide_summary" true
+                "toc_hide" true
+              )
+              "content" (dict              "mediaType" "text/markdown"
+                "value" $charterContent
+              )
+            }}
+            {{ $.AddPage $charterPage }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s" $dir }}
+            {{ end }}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- if eq hugo.Environment "production" -}}
+      {{ errorf "Unable to fetch: %s" $sigsUrl }}
+    {{- else -}}
+      {{ warnf "Unable to fetch: %s" $sigsUrl }}
     {{ end }}
-
-    {{/* Working Groups */}}
-    {{ range .workinggroups }}
-      {{ $name := .name }}
-      {{ $dir := .dir }}
-      {{ $slug := replace $dir "wg-" "" }}
-      
-      {{/* Fetch README Content */}}
-      {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
-      {{ $readmeContent := "" }}
-      {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-      {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load README for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load README for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
-        {{ end }}
-      {{ end }}
-
-      {{ $page := dict
-        "kind" "section"
-        "path" (printf "wg/%s" $slug)
-        "title" (printf "WG %s" $name)
-        "params" (dict
-          "description" .mission_statement
-          "leadership" .leadership
-          "meetings" .meetings
-          "contact" .contact
-          "dir" .dir
-          "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-          "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-        )
-        "content" (dict
-          "mediaType" "text/markdown"
-          "value" $readmeContent
-        )
-      }}
-      {{ $.AddPage $page }}
-
-      {{/* Fetch Charter Content */}}
-      {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-      {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-      {{ with resources.GetRemote $charterUrl $charterOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $charterContent := replace .Content "\u200b" "" }}
-          {{ $charterPage := dict
-            "kind" "page"
-            "path" (printf "wg/%s/charter" $slug)
-            "title" (printf "WG %s Charter" $name)
-            "params" (dict
-              "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-              "hide_summary" true
-              "toc_hide" true
-            )
-            "content" (dict              "mediaType" "text/markdown"
-              "value" $charterContent
-            )
-          }}
-          {{ $.AddPage $charterPage }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-
-    {{/* Committees */}}
-    {{ range .committees }}
-      {{ $name := .name }}
-      {{ $dir := .dir }}
-      {{ $slug := replace $dir "committee-" "" }}
-      
-      {{/* Fetch README Content */}}
-      {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
-      {{ $readmeContent := "" }}
-      {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-      {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load README for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load README for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
-        {{ end }}
-      {{ end }}
-
-      {{ $page := dict
-        "kind" "section"
-        "path" (printf "committees/%s" $slug)
-        "title" (printf "%s" $name)
-        "params" (dict
-          "description" .mission_statement
-          "leadership" .leadership
-          "meetings" .meetings
-          "contact" .contact
-          "dir" .dir
-          "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-          "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-        )
-        "content" (dict
-          "mediaType" "text/markdown"
-          "value" $readmeContent
-        )
-      }}
-      {{ $.AddPage $page }}
-
-      {{/* Fetch Charter Content */}}
-      {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-      {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-      {{ with resources.GetRemote $charterUrl $charterOpts }}
-        {{ if .Err }}
-          {{ if eq hugo.Environment "production" }}
-            {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ else }}
-            {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
-          {{ end }}
-        {{ else }}
-          {{ $charterContent := replace .Content "\u200b" "" }}
-          {{ $charterPage := dict
-            "kind" "page"
-            "path" (printf "committees/%s/charter" $slug)
-            "title" (printf "%s Charter" $name)
-            "params" (dict
-              "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-              "hide_summary" true
-              "toc_hide" true
-            )
-            "content" (dict              "mediaType" "text/markdown"
-              "value" $charterContent
-            )
-          }}
-          {{ $.AddPage $charterPage }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
+  {{- end -}}
+{{- end -}}

--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -10,21 +10,32 @@
 
 {{/* Fetch remote KEP data */}}
 {{- $kepDataOpts := merge $globalOpts (dict "key" "keps-json-data") -}}
-{{- with resources.GetRemote $kepDataSourceUrl $kepDataOpts -}}
+{{- with try (resources.GetRemote $kepDataSourceUrl $kepDataOpts ) -}}
   {{- with .Err -}}
     {{- if eq hugo.Environment "production" -}}
       {{- errorf "Unable to load KEP data: %s" . -}}
     {{- else -}}
       {{- warnf "Cannot load KEP data: %s" . -}}
     {{- end -}}
+  {{- else with .Value -}}
+    {{- with try (.Content | transform.Unmarshal) -}}
+      {{- with .Err -}}
+        {{- if eq hugo.Environment "production" -}}
+          {{- errorf "Unable to load KEP data: %s" . -}}
+        {{- else -}}
+          {{- warnf "Cannot load KEP data: %s" . -}}
+        {{- end -}}
+      {{- end -}}
+      {{- with .Value -}}
+        {{- $kepData = . -}}
+      {{- end -}}
+    {{- end -}}
   {{- else -}}
-    {{- $kepData = .Content | transform.Unmarshal -}}
-  {{- end -}}
-{{- else -}}
-  {{- if eq hugo.Environment "production" -}}
-    {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
-  {{- else -}}
-    {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
+    {{- if eq hugo.Environment "production" -}}
+      {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
+    {{- else -}}
+      {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 
@@ -68,28 +79,29 @@
     {{- $readmeContent := "" -}}
     {{- $readmeOpts := merge $globalOpts (dict "key" (printf "kep-readme-%s" $kep.kepNumber)) -}}
     
-    {{- $resource := resources.GetRemote $readmeUrl $readmeOpts -}}
+    {{- $resourceFetchAttempt := try (resources.GetRemote $readmeUrl $readmeOpts ) -}}
     
-    {{- /* Fallback to README.MD if README.md fails or is nil */ -}}
+    {{- /* Fallback to README.MD if README.md fetch fails or response is nil */ -}}
     {{- $needsFallback := false -}}
-    {{- if not $resource -}}
+    {{- if not $resourceFetchAttempt.Value -}}
       {{- $needsFallback = true -}}
-    {{- else if $resource.Err -}}
+    {{- else if $resourceFetchAttempt.Err -}}
       {{- $needsFallback = true -}}
     {{- end -}}
 
     {{- if $needsFallback -}}
       {{- $readmeUrlUpper := printf "%s%s/%s/README.MD" $rawBaseUrl $kep.owningSig $kep.name -}}
       {{- $readmeOptsUpper := merge $globalOpts (dict "key" (printf "kep-readme-%s-upper" $kep.kepNumber)) -}}
-      {{- $resource = resources.GetRemote $readmeUrlUpper $readmeOptsUpper -}}
+      {{- $resourceFetchAttempt = try (resources.GetRemote $readmeUrlUpper $readmeOptsUpper) -}}
     {{- end -}}
 
-    {{- if $resource -}}
-      {{- if $resource.Err -}}
-        {{- warnf "Unable to load README for KEP %s (tried .md and .MD): %s" $kep.kepNumber $resource.Err -}}
-      {{- else -}}
+    {{- with $resourceFetchAttempt -}}
+      {{- with .Err -}}
+        {{- warnf "Unable to load README for KEP %s (tried .md and .MD): %s" $kep.kepNumber . -}}
+      {{- end -}}
+      {{- with .Value -}}
         {{- /* Fix common markdown link errors in KEP READMEs to avoid build failures */ -}}
-        {{- $readmeContent = replace $resource.Content "]((http" "](http" -}}
+        {{- $readmeContent = replace .Content "]((http" "](http" -}}
         {{- $readmeContent = replace $readmeContent "/))" "/)" -}}
         {{- $readmeContent = replace $readmeContent "((http" "(http" -}}
         
@@ -105,6 +117,8 @@
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
+      {{- else -}}
+        {{- warnf "Unable to load README for KEP %s" -}}
       {{- end -}}
     {{- end -}}
 

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,20 +1,20 @@
 {{- $kepDataSourceUrl := "https://storage.googleapis.com/k8s-keps/keps.json" -}}
 {{- $kepData := "" -}}
-{{- with resources.GetRemote $kepDataSourceUrl -}}
+{{- with try (resources.GetRemote $kepDataSourceUrl ) -}}
   {{- with .Err -}}
     {{- if eq hugo.Environment "production" }}
-      {{ errorf "Unable to load KEP data: %s" . }}
+      {{ errorf "Unable to load KEP data from %s: %s" $kepDataSourceUrl . -}}
     {{- else -}}
-      {{- warnf "Cannot load KEP data: %s" . -}}
+      {{- warnf "Cannot load KEP data from %s: %s" $kepDataSourceUrl . -}}
     {{- end -}}
-  {{- else -}}
+  {{- else with .Value -}}
     {{- $kepData = .Content | transform.Unmarshal -}}
-  {{- end -}}
-{{- else -}}
-  {{- if eq hugo.Environment "production" }}
-    {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
   {{- else -}}
-    {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
+    {{- if eq hugo.Environment "production" }}
+      {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
+    {{- else -}}
+      {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/shortcodes/sigs-list.html
+++ b/layouts/shortcodes/sigs-list.html
@@ -15,15 +15,16 @@
 {{- $cacheOpts := dict "key" "sigs-yaml" -}}
 {{- $opts = merge $opts $cacheOpts -}}
 
-{{ with resources.GetRemote $sigsUrl $opts }}
-  {{ with .Err }}
+{{- with try (resources.GetRemote $sigsUrl $opts) -}}
+  {{- with .Err -}}
     {{ if eq hugo.Environment "production" }}
       {{ errorf "Unable to load sigs.yaml: %s" . }}
     {{ else }}
       {{ warnf "Unable to load sigs.yaml: %s" . }}
     {{ end }}
-  {{ end }}
-  {{ with .Content | transform.Unmarshal }}
+  {{- end -}}
+  {{- with .Value -}}
+    {{- with .Content | transform.Unmarshal -}}
 <div class="sigs-container my-4">
   <div class="row">
     <!-- Sticky Header Wrapper -->
@@ -441,5 +442,6 @@
     </div>
   </div>
 </div>
-{{ end }}
-{{ end }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.133.0"
-NODE_VERSION = "20.16.0"
+NODE_VERSION = "20.17.0"
+HUGO_VERSION = "0.144.2"
 
 [context.production.environment]
 HUGO_ENV = "production"


### PR DESCRIPTION
Match what's used on the main Kubernetes website: https://github.com/kubernetes/website (as of commit https://github.com/kubernetes/website/commit/3aa217192d14ad125ccffa123edf29712db96b8f).

```diff
-HUGO_VERSION = "0.133.0"
-NODE_VERSION = "20.16.0"
+NODE_VERSION = "20.17.0"
+HUGO_VERSION = "0.144.2"
```

Tested locally; looks OK.