### PR TITLE
Update image signature routing blog post date

### DIFF
--- a/content/en/blog/2026/image-signature-routing.md
+++ b/content/en/blog/2026/image-signature-routing.md
@@ -1,8 +1,7 @@
 ---
 layout: blog
 title: "Eliminating Kubernetes Image Signature Replication"
-draft: true
-date: 2026-05-18
+date: 2026-06-05
 slug: image-signature-routing
 author: >
   Sascha Grunert (Red Hat)


### PR DESCRIPTION
Follow-up on #719: set the publishing date to 2026-06-01 and remove draft status.