### PR TITLE
Bump release information page to v1.37

### DIFF
--- a/external-sources/kubernetes/sig-release
+++ b/external-sources/kubernetes/sig-release
@@ -1,1 +1,1 @@
-"/releases/release-1.36/README.md","/resources/release/index.md"
+"/releases/release-1.37/README.md","/resources/release/index.md"


### PR DESCRIPTION
Bumping the release information page content following the kick-off of [v1.37 release (notification here)](https://groups.google.com/g/kubernetes-sig-release/c/mJL4S1b-l-U) and schedule finalized https://rel.k8s.io/v137

Page to update: https://www.kubernetes.dev/resources/release/

Preview Page: https://deploy-preview-732--kubernetes-contributor.netlify.app/resources/release/

_Ref https://github.com/kubernetes/sig-release/issues/3015_

/assign @Priyankasaggu11929