### PR TITLE
fix: netlify prod build failure

### DIFF
--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -241,39 +241,41 @@
         {{ $.AddPage $page }}
   
         {{/* Fetch Charter Content */}}
-        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
-        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
-          {{ with .Err }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+        {{ if and (ne $dir "committee-security-response") (ne $dir "committee-steering") }}
+          {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+          {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+          {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
+            {{ with .Err }}
+              {{ if eq hugo.Environment "production" }}
+                {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+              {{ else }}
+                {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+              {{ end }}
+            {{ else with .Value }}
+              {{ $charterContent := replace .Content "\u200b" "" }}
+              {{ $charterPage := dict
+                "kind" "page"
+                "path" (printf "committees/%s/charter" $slug)
+                "title" (printf "%s Charter" $name)
+                "params" (dict
+                  "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                  "hide_summary" true
+                  "toc_hide" true
+                )
+                "content" (dict              "mediaType" "text/markdown"
+                  "value" $charterContent
+                )
+              }}
+              {{ $.AddPage $charterPage }}
             {{ else }}
-              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
-            {{ end }}
-          {{ else with .Value }}
-            {{ $charterContent := replace .Content "\u200b" "" }}
-            {{ $charterPage := dict
-              "kind" "page"
-              "path" (printf "committees/%s/charter" $slug)
-              "title" (printf "%s Charter" $name)
-              "params" (dict
-                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
-                "hide_summary" true
-                "toc_hide" true
-              )
-              "content" (dict              "mediaType" "text/markdown"
-                "value" $charterContent
-              )
-            }}
-            {{ $.AddPage $charterPage }}
-          {{ else }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load charter for %s" $dir }}
-            {{ else }}
-              {{ warnf "Unable to load charter for %s" $dir }}
-            {{ end }}
+              {{ if eq hugo.Environment "production" }}
+                {{ errorf "Unable to load charter for %s" $dir }}
+              {{ else }}
+                {{ warnf "Unable to load charter for %s" $dir }}
+              {{ end }}
+            {{- end -}}
           {{- end -}}
-        {{- end -}}
+        {{ end }}
       {{- end -}}
     {{- end -}}
   {{- else -}}

--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -219,7 +219,15 @@
             {{ end }}
           {{ end }}
         {{ end }}
-  
+        {{ $charterLink := .charter_link }}
+        {{ $remoteCharterUrl := "" }}
+        {{ if $charterLink }}
+          {{ $remoteCharterUrl = printf "%s%s/%s" $githubBaseUrl $dir $charterLink }}
+          {{ if hasPrefix $charterLink "http" }}
+            {{ $remoteCharterUrl = $charterLink }}
+          {{ end }}
+        {{ end }}
+
         {{ $page := dict
           "kind" "section"
           "path" (printf "committees/%s" $slug)
@@ -231,7 +239,7 @@
             "contact" .contact
             "dir" .dir
             "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+            "remote_charter_url" $remoteCharterUrl
           )
           "content" (dict
             "mediaType" "text/markdown"
@@ -239,10 +247,9 @@
           )
         }}
         {{ $.AddPage $page }}
-  
-        {{/* Fetch Charter Content */}}
-        {{ if and (ne $dir "committee-security-response") (ne $dir "committee-steering") }}
-          {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+
+        {{ if and $charterLink (not (hasPrefix $charterLink "http")) }}
+          {{ $charterUrl := printf "%s%s/%s" $rawBaseUrl $dir $charterLink }}
           {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
           {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
             {{ with .Err }}
@@ -258,11 +265,12 @@
                 "path" (printf "committees/%s/charter" $slug)
                 "title" (printf "%s Charter" $name)
                 "params" (dict
-                  "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                  "remote_charter_url" (printf "%s%s/%s" $githubBaseUrl $dir $charterLink)
                   "hide_summary" true
                   "toc_hide" true
                 )
-                "content" (dict              "mediaType" "text/markdown"
+                "content" (dict
+                  "mediaType" "text/markdown"
                   "value" $charterContent
                 )
               }}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -46,12 +46,11 @@ caches:
     dir: ':cacheDir/modules'
     maxAge: -1
 
+# Use npm-installed copies of Docsy's Hugo Module deps so Hugo skips `go get`
+# at build time. The `go get` walks go.mod's transitive imports and fails
+# wherever the dependency is absent (e.g. Netlify).
 module:
-  imports:
-    - path: github.com/FortAwesome/Font-Awesome
-      ignoreImports: true
-    - path: github.com/twbs/bootstrap
-      ignoreImports: true
+  replacements: "github.com/twbs/bootstrap -> bootstrap, github.com/FortAwesome/Font-Awesome -> @fortawesome/fontawesome-free"
 
 # Language configuration
 languages:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -46,6 +46,13 @@ caches:
     dir: ':cacheDir/modules'
     maxAge: -1
 
+module:
+  imports:
+    - path: github.com/FortAwesome/Font-Awesome
+      ignoreImports: true
+    - path: github.com/twbs/bootstrap
+      ignoreImports: true
+
 # Language configuration
 languages:
   en:


### PR DESCRIPTION
- Fix netlify prod build failure

Instead of hardcoding committee directory names that lack a `charter.md`, this PR:

1. Uses the `charter_link` field from sigs.yaml to determine if a committee has a charter
2. For local charters (relative path like `charter.md`), constructs the URL dynamically and fetches the content
3. For external charters (URL like `https://git.k8s.io/steering/charter.md`), sets the `remote_charter_url` directly without fetching
4. For committees without a `charter_link` field (e.g., `committee-security-response`), no charter page is created

This approach stays in sync with sigs.yaml automatically and won't need updating when new committees are added.

## Committees affected

| Committee | charter_link | Behavior |
|-----------|-------------|----------|
| committee-code-of-conduct | `charter.md` | Local fetch |
| committee-steering | `https://git.k8s.io/steering/charter.md` | External URL used directly |
| committee-security-response | (none) | No charter page created |

Closes: #729 

cc @TineoC 