### PR TITLE
fix: align KEP listing layout with standard site spacing

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -428,40 +428,6 @@ body.td-home div.lead p {
   }
 }
 
-// ===== KEP Listing Full Width =====
-body.kep-listing {
-
-  .td-sidebar-toc {
-    display: none !important;
-  }
-
-  // Desktop & Tablet: expand main to fill hidden TOC space
-  main.col-xl-8 {
-    @media (min-width: 768px) {
-      flex: 0 0 83.333333% !important;
-      max-width: 83.333333% !important;
-      width: 83.333333% !important;
-      padding: 0 3rem;
-    }
-  }
-
-  // Mobile: hide left sidebar and go full-width
-  @media (max-width: 767px) {
-    .td-sidebar {
-      display: none !important;
-    }
-
-    main.col-md-9,
-    main.col-xl-8 {
-      flex: 0 0 100% !important;
-      max-width: 100% !important;
-      width: 100% !important;
-      padding-left: 1rem !important;
-      padding-right: 1rem !important;
-    }
-  }
-}
-
 // ===== KEP Filter Bar =====
 .kep-filter-bar {
   background: #fff;
@@ -712,14 +678,42 @@ body.kep-listing {
 
 // ===== KEP Table Wrapper =====
 .kep-table-wrapper {
-  overflow-x: visible;
+  clear: both;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   min-width: 0;
+  scrollbar-width: thin;
+  scrollbar-color: #64748b transparent;
+
+  &:focus-visible {
+    outline: 2px solid #326ce5;
+    outline-offset: -2px;
+  }
+
+  &::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #64748b;
+    border-radius: 4px;
+
+    &:hover {
+      background: #475569;
+    }
+  }
 }
 
 // ===== KEP Table Styles =====
 #keps-table {
   font-size: 0.85rem;
   table-layout: fixed;
+  width: 100%;
+  min-width: 950px;
 
   // Column widths — title gets remaining space
   .kep-col-number {
@@ -783,6 +777,10 @@ body.kep-listing {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    &.kep-col-title {
+      white-space: normal;
+    }
   }
 
   tbody tr {
@@ -793,8 +791,8 @@ body.kep-listing {
     }
 
     &:focus-within {
-      outline: 2px solid #326ce5;
-      outline-offset: -2px;
+      background-color: #f1f5f9;
+      outline: none;
     }
   }
 
@@ -827,7 +825,8 @@ body.kep-listing {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
+    word-break: break-word;
   }
 
   .kep-sig-link {
@@ -1000,45 +999,9 @@ body.kep-listing {
   }
 
   #keps-table {
-
-    // Hide Author on tablet - remove width so it doesn't take space
-    .kep-col-author {
-      display: none;
-      width: 0;
-      padding: 0;
-      border: 0;
-    }
-
-    th.kep-col-author,
-    td.kep-col-author {
-      display: none;
-    }
-
     th,
     td {
       padding: 0.45rem 0.4rem;
-    }
-
-    // Redistribute widths for 6 visible columns (Author hidden)
-    // Total: Number(12%) + SIG(13%) + Stage(13%) + Latest(13%) + Created(13%) + Title(36%) = 100%
-    .kep-col-number {
-      width: 12%;
-    }
-
-    .kep-col-sig {
-      width: 13%;
-    }
-
-    .kep-col-stage {
-      width: 13%;
-    }
-
-    .kep-col-latest {
-      width: 13%;
-    }
-
-    .kep-col-created {
-      width: 13%;
     }
 
     .kep-title-link {
@@ -1052,14 +1015,6 @@ body.kep-listing {
   }
 }
 
-// ===== Enable horizontal scroll only on larger screens =====
-@media (min-width: 992px) {
-  #keps-table {
-    min-width: 800px;
-    overflow-x: auto;
-  }
-}
-
 // ===== Responsive: Phone =====
 @media (max-width: 768px) {
   .kep-page {
@@ -1067,15 +1022,28 @@ body.kep-listing {
   }
 
   .kep-filter-bar {
-    display: none;
-    border-radius: 0;
+    display: block;
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+    overflow: hidden;
+    border-top: none;
+    border-bottom: none;
     border-left: none;
     border-right: none;
-    margin: 0 0 1rem;
-    padding: 0.75rem 1rem;
+    border-radius: 0;
+    margin: 0;
+    padding: 0 1rem;
+    transition: max-height 0.25s ease-out, opacity 0.25s ease-out, visibility 0.25s ease-out, margin-bottom 0.25s ease-out, padding 0.25s ease-out;
 
     &.visible {
-      display: block;
+      max-height: 500px; /* enough height to display mobile filters */
+      opacity: 1;
+      visibility: visible;
+      margin: 0 0 1rem;
+      padding: 0.75rem 1rem;
+      border-top: 1px solid #e2e8f0;
+      border-bottom: 1px solid #e2e8f0;
     }
 
     .kep-filter-row {
@@ -1140,68 +1108,32 @@ body.kep-listing {
   #keps-table {
     font-size: 0.8rem;
 
-    // Hide SIG, Created, Author, Latest Milestone on phone
-    .kep-col-sig,
-    .kep-col-created,
-    .kep-col-author,
-    .kep-col-latest {
-      display: none;
-      width: 0;
-      padding: 0;
-      border: 0;
-    }
-
-    th.kep-col-sig,
-    td.kep-col-sig,
-    th.kep-col-created,
-    td.kep-col-created,
-    th.kep-col-author,
-    td.kep-col-author,
-    th.kep-col-latest,
-    td.kep-col-latest {
-      display: none;
-    }
-
     th,
     td {
       padding: 0.35rem 0.3rem;
     }
 
     th {
-      font-size: 0.65rem;
+      font-size: 0.75rem;
       letter-spacing: 0.04em;
     }
 
     td:first-child {
-      font-size: 0.72rem;
-    }
-
-    // Redistribute widths for 3 visible columns (Number, Title, Stage)
-    // Number(20%) + Stage(20%) + Title(60%) = 100%
-    .kep-col-number {
-      width: 20%;
-    }
-
-    .kep-col-title {
-      width: 60%;
-    }
-
-    .kep-col-stage {
-      width: 20%;
+      font-size: 0.75rem;
     }
 
     .kep-title-link {
-      font-size: 0.78rem;
+      font-size: 0.8rem;
       line-height: 1.3;
     }
 
     .kep-sig-link {
-      font-size: 0.72rem;
+      font-size: 0.75rem;
     }
 
     .kep-stage-badge {
-      font-size: 0.6rem;
-      padding: 0.08rem 0.35rem;
+      font-size: 0.7rem;
+      padding: 0.12rem 0.4rem;
       letter-spacing: 0;
     }
   }
@@ -1244,35 +1176,6 @@ body.kep-listing {
 // ===== Responsive: Small Phone =====
 @media (max-width: 480px) {
   #keps-table {
-
-    // Keep SIG hidden (inherits from parent), but keep Stage visible
-    // Shows 3 columns: Number, Title, Stage
-    .kep-col-sig {
-      display: none;
-      width: 0;
-      padding: 0;
-      border: 0;
-    }
-
-    th.kep-col-sig,
-    td.kep-col-sig {
-      display: none;
-    }
-
-    // Redistribute widths for 3 visible columns (Number + Title + Stage)
-    // Number(20%) + Stage(20%) + Title(60%) = 100%
-    .kep-col-number {
-      width: 20%;
-    }
-
-    .kep-col-title {
-      width: 60%;
-    }
-
-    .kep-col-stage {
-      width: 20%;
-    }
-
     .kep-title-link {
       font-size: 0.75rem;
     }
@@ -1294,6 +1197,7 @@ body.kep-listing {
 // ===== Reduced Motion =====
 @media (prefers-reduced-motion: reduce) {
 
+  .kep-filter-bar,
   .kep-stage-btn,
   #keps-table tbody tr,
   .kep-filter-bar select,

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,5 +1,5 @@
 {{ if .HasShortcode "keps-data" }}
-<script src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.js"></script>
+<script src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.js" integrity="sha384-KhMc4ulEz1xrlAOwFgGUzujfQW+yJsnvk5/kqSqIDJ24NpxlJmN5MI1EA2QzQMFm" crossorigin="anonymous"></script>
 <script>
 (function() {
   'use strict';
@@ -34,11 +34,13 @@
     var activeStages = new Set();
     var searchTerm = '';
 
+    // Cache elements outside the search loop callback to prevent performance issues
+    var selRelease = document.getElementById('kep-filter-release');
+    var selSig = document.getElementById('kep-filter-sig');
+
     // Filter function — reads plain-text cell content from data[]
     // data[2] = SIG, data[3] = Stage, data[4] = Latest Milestone
     $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
-      var selRelease = document.getElementById('kep-filter-release');
-      var selSig = document.getElementById('kep-filter-sig');
       var releaseVal = selRelease ? selRelease.value : '';
       var sigVal = selSig ? selSig.value : '';
 
@@ -81,15 +83,16 @@
         { orderable: false, targets: [6] },
         { type: 'date', targets: [5] }
       ],
-      dom: 'ltip',
+      dom: 'l<"kep-table-wrapper"t>ip',
       search: { search: '', regex: false, smart: false },
       language: { zeroRecords: 'No KEPs match your filters.' },
-      drawCallback: function() {
-        var info = this.api().page.info();
-        var c = document.querySelector('.kep-results-count');
-        if (c) c.textContent = info.recordsDisplay === info.recordsTotal
-          ? info.recordsTotal + ' KEPs'
-          : 'Showing ' + info.recordsDisplay + ' of ' + info.recordsTotal + ' KEPs';
+      initComplete: function() {
+        var wrapper = document.querySelector('.kep-table-wrapper');
+        if (wrapper) {
+          wrapper.setAttribute('tabindex', '0');
+          wrapper.setAttribute('role', 'region');
+          wrapper.setAttribute('aria-label', 'Kubernetes Enhancement Proposals table, scrollable');
+        }
       }
     });
 
@@ -131,12 +134,6 @@
     document.querySelectorAll('.kep-stage-btn').forEach(function(btn) {
       btn.addEventListener('click', function() {
         toggleStage(this);
-      });
-      btn.addEventListener('keydown', function(e) {
-        if (e.key === ' ' || e.key === 'Enter') {
-          e.preventDefault();
-          toggleStage(this);
-        }
       });
     });
 

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -51,11 +51,11 @@
 {{- range $k, $_ := $sigSet -}}{{- $sigs = $sigs | append $k -}}{{- end -}}
 
 <div class="kep-page">
-  <div class="kep-filter-bar" role="search" aria-label="Filter KEPs">
+  <div id="kep-filter-bar" class="kep-filter-bar" role="search" aria-label="Filter KEPs">
     <div class="kep-filter-row kep-filter-selects">
       <div class="kep-filter-group">
         <label for="kep-filter-release">Release</label>
-        <select id="kep-filter-release" aria-label="Filter by release">
+        <select id="kep-filter-release">
           <option value="">All Releases</option>
           {{- range $releases }}
           <option value="{{ strings.TrimPrefix "v" . }}">{{ strings.TrimPrefix "v" . }}</option>
@@ -64,7 +64,7 @@
       </div>
       <div class="kep-filter-group">
         <label for="kep-filter-sig">SIG</label>
-        <select id="kep-filter-sig" aria-label="Filter by SIG">
+        <select id="kep-filter-sig">
           <option value="">All SIGs</option>
           {{- range sort $sigs }}
           <option value="{{ . }}">{{ strings.TrimPrefix "sig-" . }}</option>
@@ -87,19 +87,17 @@
         <svg class="kep-search-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85-.017.016zm-5.242.156a5 5 0 1 1 0-10 5 5 0 0 1 0 10z" fill="currentColor"/></svg>
         <input type="search" id="kep-search" class="kep-search-input" placeholder="Search by title, KEP number, author..." aria-label="Search by title, KEP number, author...">
       </div>
-      <div class="kep-results-count" aria-live="polite" role="status"></div>
     </div>
   </div>
 
   <div class="kep-filter-toggle">
-    <button id="kep-filter-toggle-btn" class="kep-filter-toggle-btn" type="button" aria-expanded="false">
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M6 2.5a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0zM4.5 8a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0zM9 13.5a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0z" fill="currentColor"/></svg>
+    <button id="kep-filter-toggle-btn" class="kep-filter-toggle-btn" type="button" aria-expanded="false" aria-controls="kep-filter-bar">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1.5 4h13M1.5 8h13M1.5 12h13M5 2.5v3M11 6.5v3M7 10.5v3"/></svg>
       Filters
     </button>
   </div>
 
-  <div class="kep-table-wrapper">
-    <table id="keps-table" class="table table-hover table-sm">
+  <table id="keps-table" class="table table-hover table-sm">
       <caption class="visually-hidden">List of Kubernetes Enhancement Proposals (KEPs)</caption>
       <thead class="thead-light">
         <tr>
@@ -205,5 +203,4 @@
         {{ end }}
       </tbody>
     </table>
-  </div>
 </div>


### PR DESCRIPTION
## Preview links

| Page | What to check |
|------|---------------|
| [`/resources/keps/`](https://deploy-preview-734--kubernetes-contributor.netlify.app/resources/keps/) | Left sidebar, content padding, and TOC column should match `/community/`. **Table should have a thin horizontal scrollbar at the bottom on mobile/tablet and when the table is wider than the column (e.g., 1200px desktop with sidebar). Swipe or drag the table to scroll horizontally and see hidden columns / full cell text.** |
| [`/community/`](https://deploy-preview-734--kubernetes-contributor.netlify.app/community/) | Reference layout — should remain unchanged; KEPs page should match this structure |
| [`/resources/keps/1027/`](https://deploy-preview-734--kubernetes-contributor.netlify.app/resources/keps/1027/) | Single KEP page — should be unchanged (never used the `kep-listing` body class) |
| [`/resources/`](https://deploy-preview-734--kubernetes-contributor.netlify.app/resources/) | Sibling section page — sanity check that nothing in the Resources section regressed |