### PR TITLE
fix: malformed href attributes in homepage and event FAQ pages

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -59,10 +59,10 @@ There are many ways you can stay involved with the Kubernetes Contributor commun
 
 <ul class="center">
   <li>Join one of our <a href="/community/community-groups">community groups</a></li>
-  <li>Contribute to and explore our <a href="/docs/guide">contributor</a> and <a href=" https://git.k8s.io/community/contributors/devel/ ">developer</a> guides</li>
-  <li>Voice your thoughts and have them heard at one of our weekly <a href="https://git.k8s.io/community/sig-contributor-experience#meetings ">Contributor Experience meetings</a></li>
-  <li>Take a journey to <a href="https://git.k8s.io/community/community-membership.md ">becoming a reviewer or approver</a></li>
-  <li>Find out how we make decisions, organize, and how to get involved in <a href="http://git.k8s.io/community/governance.md">governance</a></li>
+  <li>Contribute to and explore our <a href="/docs/guide">contributor</a> and <a href="https://git.k8s.io/community/contributors/devel/">developer</a> guides</li>
+  <li>Voice your thoughts and have them heard at one of our weekly <a href="https://git.k8s.io/community/sig-contributor-experience#meetings">Contributor Experience meetings</a></li>
+  <li>Take a journey to <a href="https://git.k8s.io/community/community-membership.md">becoming a reviewer or approver</a></li>
+  <li>Find out how we make decisions, organize, and how to get involved in <a href="https://git.k8s.io/community/governance.md">governance</a></li>
 </ul>
 
 {{% /blocks/section %}}

--- a/content/en/events/2022/kcseu/faq.md
+++ b/content/en/events/2022/kcseu/faq.md
@@ -62,7 +62,7 @@ Kubernetes Orgs:
 <ul>
 <li><a href="https://github.com/kubernetes" rel="noopener noreferrer" target="_blank">kubernetes</a></li>
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
-<li><a href="https://github.com/kubernetes-csi rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
+<li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
 </ul>
 

--- a/content/en/events/2022/kcsna/faq.md
+++ b/content/en/events/2022/kcsna/faq.md
@@ -60,7 +60,7 @@ Kubernetes Orgs:
 <ul>
 <li><a href="https://github.com/kubernetes" rel="noopener noreferrer" target="_blank">kubernetes</a></li>
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
-<li><a href="https://github.com/kubernetes-csi rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
+<li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
 </ul>
 

--- a/content/en/events/2023/kcscn/faq.md
+++ b/content/en/events/2023/kcscn/faq.md
@@ -63,7 +63,7 @@ Kubernetes Orgs:
 <ul>
 <li><a href="https://github.com/kubernetes" rel="noopener noreferrer" target="_blank">kubernetes</a></li>
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
-<li><a href="https://github.com/kubernetes-csi rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
+<li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
 <li><a href="https://github.com/etcd-io" rel="noopener noreferrer" target="_blank">etcd-io</a></li>
 </ul>

--- a/content/en/events/2023/kcseu/faq.md
+++ b/content/en/events/2023/kcseu/faq.md
@@ -61,7 +61,7 @@ Kubernetes Orgs:
 <ul>
 <li><a href="https://github.com/kubernetes" rel="noopener noreferrer" target="_blank">kubernetes</a></li>
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
-<li><a href="https://github.com/kubernetes-csi rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
+<li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
 </ul>
 

--- a/content/en/events/2023/kcsna/faq.md
+++ b/content/en/events/2023/kcsna/faq.md
@@ -61,7 +61,7 @@ Kubernetes Orgs:
 <ul>
 <li><a href="https://github.com/kubernetes" rel="noopener noreferrer" target="_blank">kubernetes</a></li>
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
-<li><a href="https://github.com/kubernetes-csi rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
+<li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
 </ul>
 

--- a/content/en/events/2024/kcsna/faq.md
+++ b/content/en/events/2024/kcsna/faq.md
@@ -62,7 +62,7 @@ Kubernetes Orgs:
 <ul>
 <li><a href="https://github.com/kubernetes" rel="noopener noreferrer" target="_blank">kubernetes</a></li>
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
-<li><a href="https://github.com/kubernetes-csi rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
+<li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
 <li><a href="https://github.com/etcd-io" rel="noopener noreferrer" target="_blank">etcd-io</a></li>
 </ul>


### PR DESCRIPTION
Fixes broken links in the homepage and 6 event FAQ pages.

Issue 1 - `content/en/_index.md`: three `href` values have stray whitespace (one has both leading and trailing spaces), one uses `http://` instead of `https://`. Browsers include the spaces in the URL so those links just 404.

Issue 2 - `content/en/events/{2022,2023,2024}/*/faq.md` (6 files): the `kubernetes-csi` list item is missing a closing `"` after the URL. Browser reads `https://github.com/kubernetes-csi rel="noopener noreferrer" target="_blank"` as the literal href value -- link is completely busted.

How to repro: open https://www.kubernetes.dev/ and hover "developer guides", "Contributor Experience meetings", "becoming a reviewer or approver", or "governance" -- spaces show up in the URL bar. For the FAQ issue open any 2022-2024 event FAQ and click the kubernetes-csi org link.

Refs #679