### PR TITLE
fix: deduplicate KEP release filter dropdown

### DIFF
--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -28,7 +28,8 @@
   {{- $kep := . -}}
   {{- $lm := .latestMilestone -}}
   {{- if and $lm (ne $lm "0.0") -}}
-    {{- $releaseSet = merge $releaseSet (dict $lm true) -}}
+    {{- $normalizedLm := strings.TrimPrefix "v" $lm -}}
+    {{- $releaseSet = merge $releaseSet (dict $normalizedLm true) -}}
   {{- else -}}
     {{- /* Fallback: check milestone map for any non-empty value */ -}}
     {{- range $s := slice "stable" "beta" "alpha" "deprecated" -}}
@@ -37,7 +38,8 @@
       {{- end -}}
     {{- end -}}
     {{- if $lm -}}
-      {{- $releaseSet = merge $releaseSet (dict $lm true) -}}
+      {{- $normalizedLm := strings.TrimPrefix "v" $lm -}}
+      {{- $releaseSet = merge $releaseSet (dict $normalizedLm true) -}}
     {{- end -}}
   {{- end -}}
   {{- $sig := .owningSig -}}


### PR DESCRIPTION
The release filter on the KEPs page shows duplicate versions because the upstream data mixes bare (1.14) and prefixed (v1.14) milestones. The template was adding both to the dictionary, then stripping v only at render time, which produces identical <option> tags.

Closes #743

Page to test: https://deploy-preview-744--kubernetes-contributor.netlify.app/resources/keps/