### PR TITLE
fix: replace curly quotes with straight quotes in etcd-io link

### DIFF
--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -13,43 +13,24 @@
 
 {{- $sigsOpts := merge $globalOpts (dict "key" "sigs-yaml-adapter") -}}
 
-{{- with try (resources.GetRemote $sigsUrl $sigsOpts) -}}
-  {{ with .Err }}
-    {{- if eq hugo.Environment "production" -}}
-      {{ errorf "Unable to load sigs.yaml: %s" . }}
-    {{- else -}}
-      {{ warnf "Unable to load sigs.yaml: %s" . }}
-    {{ end }}
-  {{ else with .Value }}
-    {{ with .Content | transform.Unmarshal }}
+{{- with resources.GetRemote $sigsUrl $sigsOpts -}}
+  {{- with . | transform.Unmarshal -}}
       {{/* SIGs */}}
       {{ range .sigs }}
         {{ $name := .name }}
         {{ $dir := .dir }}
         {{ $slug := replace $dir "sig-" "" }}
-        
+
         {{/* Fetch README Content */}}
         {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
         {{ $readmeContent := "" }}
         {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
-          {{ with .Err }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
-            {{ else }}
-              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
-            {{ end }}
-          {{ else with .Value }}
-            {{ $readmeContent = replace .Content "\u200b" "" }}
-          {{ else }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
-            {{ else }}
-              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
-            {{ end }}
-          {{ end }}
+        {{ with resources.GetRemote $readmeUrl $readmeOpts }}
+          {{ $readmeContent = replace .Content "\u200b" "" }}
+        {{ else }}
+          {{ warnf "Unable to load README for %s" $dir }}
         {{ end }}
-  
+
         {{ $page := dict
           "kind" "section"
           "path" (printf "sigs/%s" $slug)
@@ -71,18 +52,11 @@
           )
         }}
         {{ $.AddPage $page }}
-  
+
         {{/* Fetch Charter Content */}}
         {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
         {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
-          {{ with .Err }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
-            {{ else }}
-              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
-            {{ end }}
-          {{ else with .Value }}
+        {{ with resources.GetRemote $charterUrl $charterOpts }}
             {{ $charterContent := replace .Content "\u200b" "" }}
             {{ $charterPage := dict
               "kind" "page"
@@ -98,44 +72,27 @@
               )
             }}
             {{ $.AddPage $charterPage }}
-          {{ else }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load charter from %s" $charterUrl }}
-            {{ else }}
-              {{ warnf "Unable to load charter from %s" $charterUrl }}
-            {{ end }}
-          {{ end }}
+        {{ else }}
+          {{ warnf "Unable to load charter for %s" $dir }}
         {{ end }}
       {{ end }}
-  
+
       {{/* Working Groups */}}
       {{ range .workinggroups }}
         {{ $name := .name }}
         {{ $dir := .dir }}
         {{ $slug := replace $dir "wg-" "" }}
-        
+
         {{/* Fetch README Content */}}
         {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
         {{ $readmeContent := "" }}
         {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
-          {{ with .Err }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
-            {{ else }}
-              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
-            {{ end }}
-          {{ else with .Value }}
-            {{ $readmeContent = replace .Content "\u200b" "" }}
-          {{ else }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load README for %s" $dir }}
-            {{ else }}
-              {{ warnf "Unable to load README for %s" $dir }}
-            {{ end }}
-          {{ end }}
+        {{ with resources.GetRemote $readmeUrl $readmeOpts }}
+          {{ $readmeContent = replace .Content "\u200b" "" }}
+        {{ else }}
+          {{ warnf "Unable to load README for %s" $dir }}
         {{ end }}
-  
+
         {{ $page := dict
           "kind" "section"
           "path" (printf "wg/%s" $slug)
@@ -155,18 +112,11 @@
           )
         }}
         {{ $.AddPage $page }}
-  
+
         {{/* Fetch Charter Content */}}
         {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
         {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
-          {{ with .Err }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
-            {{ else }}
-              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
-            {{ end }}
-          {{ else with .Value }}
+        {{ with resources.GetRemote $charterUrl $charterOpts }}
             {{ $charterContent := replace .Content "\u200b" "" }}
             {{ $charterPage := dict
               "kind" "page"
@@ -182,44 +132,27 @@
               )
             }}
             {{ $.AddPage $charterPage }}
-          {{ else }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load charter for %s" $dir }}
-            {{ else }}
-              {{ warnf "Unable to load charter for %s" $dir }}
-            {{ end }}
-          {{ end }}
+        {{ else }}
+          {{ warnf "Unable to load charter for %s" $dir }}
         {{ end }}
       {{ end }}
-  
+
       {{/* Committees */}}
       {{ range .committees }}
         {{ $name := .name }}
         {{ $dir := .dir }}
         {{ $slug := replace $dir "committee-" "" }}
-        
+
         {{/* Fetch README Content */}}
         {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
         {{ $readmeContent := "" }}
         {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
-          {{ with .Err }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
-            {{ else }}
-              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
-            {{ end }}
-          {{ else with .Value }}
-            {{ $readmeContent = replace .Content "\u200b" "" }}
-          {{ else }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load README for %s" $dir }}
-            {{ else }}
-              {{ warnf "Unable to load README for %s" $dir }}
-            {{ end }}
-          {{ end }}
+        {{ with resources.GetRemote $readmeUrl $readmeOpts }}
+          {{ $readmeContent = replace .Content "\u200b" "" }}
+        {{ else }}
+          {{ warnf "Unable to load README for %s" $dir }}
         {{ end }}
-  
+
         {{ $page := dict
           "kind" "section"
           "path" (printf "committees/%s" $slug)
@@ -231,7 +164,7 @@
             "contact" .contact
             "dir" .dir
             "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-            "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+            "remote_charter_url" (cond (hasPrefix .charter_link "http") .charter_link (printf "%s%s/%s" $githubBaseUrl $dir .charter_link))
           )
           "content" (dict
             "mediaType" "text/markdown"
@@ -239,25 +172,18 @@
           )
         }}
         {{ $.AddPage $page }}
-  
-        {{/* Fetch Charter Content */}}
-        {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
+
+        {{ if and .charter_link (not (hasPrefix .charter_link "http")) }}
+        {{ $charterUrl := printf "%s%s/%s" $rawBaseUrl $dir .charter_link }}
         {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
-          {{ with .Err }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
-            {{ else }}
-              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
-            {{ end }}
-          {{ else with .Value }}
+        {{ with resources.GetRemote $charterUrl $charterOpts }}
             {{ $charterContent := replace .Content "\u200b" "" }}
             {{ $charterPage := dict
               "kind" "page"
               "path" (printf "committees/%s/charter" $slug)
               "title" (printf "%s Charter" $name)
               "params" (dict
-                "remote_charter_url" (printf "%s%s/charter.md" $githubBaseUrl $dir)
+                "remote_charter_url" (printf "%s%s/%s" $githubBaseUrl $dir .charter_link)
                 "hide_summary" true
                 "toc_hide" true
               )
@@ -266,21 +192,14 @@
               )
             }}
             {{ $.AddPage $charterPage }}
-          {{ else }}
-            {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load charter for %s" $dir }}
-            {{ else }}
-              {{ warnf "Unable to load charter for %s" $dir }}
-            {{ end }}
-          {{- end -}}
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
+        {{ else }}
+          {{ warnf "Unable to load charter for %s" $dir }}
+        {{ end }}
+        {{ end }}
+      {{ end }}
   {{- else -}}
-    {{- if eq hugo.Environment "production" -}}
-      {{ errorf "Unable to fetch: %s" $sigsUrl }}
-    {{- else -}}
-      {{ warnf "Unable to fetch: %s" $sigsUrl }}
-    {{ end }}
+    {{ errorf "Unable to load sigs.yaml from %s" $sigsUrl }}
   {{- end -}}
+{{- else -}}
+  {{ errorf "Unable to fetch: %s" $sigsUrl }}
 {{- end -}}

--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -14,23 +14,36 @@
 {{- $sigsOpts := merge $globalOpts (dict "key" "sigs-yaml-adapter") -}}
 
 {{- with resources.GetRemote $sigsUrl $sigsOpts -}}
-  {{- with . | transform.Unmarshal -}}
+  {{ with .Err }}
+    {{- if eq hugo.Environment "production" -}}
+      {{ errorf "Unable to load sigs.yaml: %s" . }}
+    {{- else -}}
+      {{ warnf "Unable to load sigs.yaml: %s" . }}
+    {{ end }}
+  {{ else with .Content }}
+    {{ with . | transform.Unmarshal }}
       {{/* SIGs */}}
       {{ range .sigs }}
         {{ $name := .name }}
         {{ $dir := .dir }}
         {{ $slug := replace $dir "sig-" "" }}
-
+        
         {{/* Fetch README Content */}}
         {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
         {{ $readmeContent := "" }}
         {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
         {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
-        {{ else }}
-          {{ warnf "Unable to load README for %s" $dir }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
+          {{ end }}
         {{ end }}
-
+  
         {{ $page := dict
           "kind" "section"
           "path" (printf "sigs/%s" $slug)
@@ -52,11 +65,18 @@
           )
         }}
         {{ $.AddPage $page }}
-
+  
         {{/* Fetch Charter Content */}}
         {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
         {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
         {{ with resources.GetRemote $charterUrl $charterOpts }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else }}
             {{ $charterContent := replace .Content "\u200b" "" }}
             {{ $charterPage := dict
               "kind" "page"
@@ -72,27 +92,32 @@
               )
             }}
             {{ $.AddPage $charterPage }}
-        {{ else }}
-          {{ warnf "Unable to load charter for %s" $dir }}
+          {{ end }}
         {{ end }}
       {{ end }}
-
+  
       {{/* Working Groups */}}
       {{ range .workinggroups }}
         {{ $name := .name }}
         {{ $dir := .dir }}
         {{ $slug := replace $dir "wg-" "" }}
-
+        
         {{/* Fetch README Content */}}
         {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
         {{ $readmeContent := "" }}
         {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
         {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
-        {{ else }}
-          {{ warnf "Unable to load README for %s" $dir }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
+          {{ end }}
         {{ end }}
-
+  
         {{ $page := dict
           "kind" "section"
           "path" (printf "wg/%s" $slug)
@@ -112,11 +137,18 @@
           )
         }}
         {{ $.AddPage $page }}
-
+  
         {{/* Fetch Charter Content */}}
         {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
         {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-        {{ with resources.GetRemote $charterUrl $charterOpts }}
+        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else with .Value }}
             {{ $charterContent := replace .Content "\u200b" "" }}
             {{ $charterPage := dict
               "kind" "page"
@@ -132,27 +164,38 @@
               )
             }}
             {{ $.AddPage $charterPage }}
-        {{ else }}
-          {{ warnf "Unable to load charter for %s" $dir }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load charter for %s" $dir }}
+            {{ end }}
+          {{ end }}
         {{ end }}
       {{ end }}
-
+  
       {{/* Committees */}}
       {{ range .committees }}
         {{ $name := .name }}
         {{ $dir := .dir }}
         {{ $slug := replace $dir "committee-" "" }}
-
+        
         {{/* Fetch README Content */}}
         {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
         {{ $readmeContent := "" }}
         {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
         {{ with resources.GetRemote $readmeUrl $readmeOpts }}
-          {{ $readmeContent = replace .Content "\u200b" "" }}
-        {{ else }}
-          {{ warnf "Unable to load README for %s" $dir }}
+          {{ with .Err }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
+          {{ else }}
+            {{ $readmeContent = replace .Content "\u200b" "" }}
+          {{ end }}
         {{ end }}
-
+  
         {{ $page := dict
           "kind" "section"
           "path" (printf "committees/%s" $slug)
@@ -164,7 +207,7 @@
             "contact" .contact
             "dir" .dir
             "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-            "remote_charter_url" (cond (hasPrefix .charter_link "http") .charter_link (printf "%s%s/%s" $githubBaseUrl $dir .charter_link))
+            "remote_charter_url" (cond (and .charter_link (hasPrefix .charter_link "http")) .charter_link (printf "%s%s/%s" $githubBaseUrl $dir (or .charter_link "charter.md")))
           )
           "content" (dict
             "mediaType" "text/markdown"
@@ -174,9 +217,9 @@
         {{ $.AddPage $page }}
 
         {{ if and .charter_link (not (hasPrefix .charter_link "http")) }}
-        {{ $charterUrl := printf "%s%s/%s" $rawBaseUrl $dir .charter_link }}
-        {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-        {{ with resources.GetRemote $charterUrl $charterOpts }}
+          {{ $charterUrl := printf "%s%s/%s" $rawBaseUrl $dir .charter_link }}
+          {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
+          {{ with resources.GetRemote $charterUrl $charterOpts }}
             {{ $charterContent := replace .Content "\u200b" "" }}
             {{ $charterPage := dict
               "kind" "page"
@@ -192,14 +235,17 @@
               )
             }}
             {{ $.AddPage $charterPage }}
-        {{ else }}
-          {{ warnf "Unable to load charter for %s" $dir }}
+          {{ else }}
+            {{ warnf "Unable to load charter for %s" $dir }}
+          {{ end }}
         {{ end }}
-        {{ end }}
-      {{ end }}
+      {{- end -}}
+    {{- end -}}
   {{- else -}}
-    {{ errorf "Unable to load sigs.yaml from %s" $sigsUrl }}
+    {{- if eq hugo.Environment "production" -}}
+      {{ errorf "Unable to fetch: %s" $sigsUrl }}
+    {{- else -}}
+      {{ warnf "Unable to fetch: %s" $sigsUrl }}
+    {{ end }}
   {{- end -}}
-{{- else -}}
-  {{ errorf "Unable to fetch: %s" $sigsUrl }}
 {{- end -}}

--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -13,15 +13,15 @@
 
 {{- $sigsOpts := merge $globalOpts (dict "key" "sigs-yaml-adapter") -}}
 
-{{- with resources.GetRemote $sigsUrl $sigsOpts -}}
+{{- with try (resources.GetRemote $sigsUrl $sigsOpts) -}}
   {{ with .Err }}
     {{- if eq hugo.Environment "production" -}}
       {{ errorf "Unable to load sigs.yaml: %s" . }}
     {{- else -}}
       {{ warnf "Unable to load sigs.yaml: %s" . }}
     {{ end }}
-  {{ else with .Content }}
-    {{ with . | transform.Unmarshal }}
+  {{ else with .Value }}
+    {{ with .Content | transform.Unmarshal }}
       {{/* SIGs */}}
       {{ range .sigs }}
         {{ $name := .name }}
@@ -32,15 +32,21 @@
         {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
         {{ $readmeContent := "" }}
         {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-        {{ with resources.GetRemote $readmeUrl $readmeOpts }}
+        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
           {{ with .Err }}
             {{ if eq hugo.Environment "production" }}
               {{ errorf "Unable to load README for %s: %s" $dir .Err }}
             {{ else }}
               {{ warnf "Unable to load README for %s: %s" $dir .Err }}
             {{ end }}
-          {{ else }}
+          {{ else with .Value }}
             {{ $readmeContent = replace .Content "\u200b" "" }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+            {{ end }}
           {{ end }}
         {{ end }}
   
@@ -69,14 +75,14 @@
         {{/* Fetch Charter Content */}}
         {{ $charterUrl := printf "%s%s/charter.md" $rawBaseUrl $dir }}
         {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-        {{ with resources.GetRemote $charterUrl $charterOpts }}
+        {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
           {{ with .Err }}
             {{ if eq hugo.Environment "production" }}
               {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
             {{ else }}
               {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
             {{ end }}
-          {{ else }}
+          {{ else with .Value }}
             {{ $charterContent := replace .Content "\u200b" "" }}
             {{ $charterPage := dict
               "kind" "page"
@@ -92,6 +98,12 @@
               )
             }}
             {{ $.AddPage $charterPage }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load charter from %s" $charterUrl }}
+            {{ else }}
+              {{ warnf "Unable to load charter from %s" $charterUrl }}
+            {{ end }}
           {{ end }}
         {{ end }}
       {{ end }}
@@ -106,15 +118,21 @@
         {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
         {{ $readmeContent := "" }}
         {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-        {{ with resources.GetRemote $readmeUrl $readmeOpts }}
+        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
           {{ with .Err }}
             {{ if eq hugo.Environment "production" }}
               {{ errorf "Unable to load README for %s: %s" $dir .Err }}
             {{ else }}
               {{ warnf "Unable to load README for %s: %s" $dir .Err }}
             {{ end }}
-          {{ else }}
+          {{ else with .Value }}
             {{ $readmeContent = replace .Content "\u200b" "" }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s" $dir }}
+            {{ end }}
           {{ end }}
         {{ end }}
   
@@ -184,18 +202,29 @@
         {{ $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $dir }}
         {{ $readmeContent := "" }}
         {{ $readmeOpts := merge $globalOpts (dict "key" (printf "readme-%s" $dir)) }}
-        {{ with resources.GetRemote $readmeUrl $readmeOpts }}
+        {{ with try (resources.GetRemote $readmeUrl $readmeOpts) }}
           {{ with .Err }}
             {{ if eq hugo.Environment "production" }}
               {{ errorf "Unable to load README for %s: %s" $dir .Err }}
             {{ else }}
               {{ warnf "Unable to load README for %s: %s" $dir .Err }}
             {{ end }}
-          {{ else }}
+          {{ else with .Value }}
             {{ $readmeContent = replace .Content "\u200b" "" }}
+          {{ else }}
+            {{ if eq hugo.Environment "production" }}
+              {{ errorf "Unable to load README for %s" $dir }}
+            {{ else }}
+              {{ warnf "Unable to load README for %s" $dir }}
+            {{ end }}
           {{ end }}
         {{ end }}
   
+        {{ $charterLink := .charter_link }}
+        {{ $remoteCharterUrl := printf "%s%s/%s" $githubBaseUrl $dir (or $charterLink "charter.md") }}
+        {{ if and $charterLink (hasPrefix $charterLink "http") }}
+          {{ $remoteCharterUrl = $charterLink }}
+        {{ end }}
         {{ $page := dict
           "kind" "section"
           "path" (printf "committees/%s" $slug)
@@ -207,7 +236,7 @@
             "contact" .contact
             "dir" .dir
             "remote_readme_url" (printf "%s%s/README.md" $githubBaseUrl $dir)
-            "remote_charter_url" (cond (and .charter_link (hasPrefix .charter_link "http")) .charter_link (printf "%s%s/%s" $githubBaseUrl $dir (or .charter_link "charter.md")))
+            "remote_charter_url" $remoteCharterUrl
           )
           "content" (dict
             "mediaType" "text/markdown"
@@ -216,28 +245,40 @@
         }}
         {{ $.AddPage $page }}
 
-        {{ if and .charter_link (not (hasPrefix .charter_link "http")) }}
-          {{ $charterUrl := printf "%s%s/%s" $rawBaseUrl $dir .charter_link }}
+        {{ if and $charterLink (not (hasPrefix $charterLink "http")) }}
+          {{ $charterUrl := printf "%s%s/%s" $rawBaseUrl $dir $charterLink }}
           {{ $charterOpts := merge $globalOpts (dict "key" (printf "charter-%s" $dir)) }}
-          {{ with resources.GetRemote $charterUrl $charterOpts }}
-            {{ $charterContent := replace .Content "\u200b" "" }}
-            {{ $charterPage := dict
-              "kind" "page"
-              "path" (printf "committees/%s/charter" $slug)
-              "title" (printf "%s Charter" $name)
-              "params" (dict
-                "remote_charter_url" (printf "%s%s/%s" $githubBaseUrl $dir .charter_link)
-                "hide_summary" true
-                "toc_hide" true
-              )
-              "content" (dict              "mediaType" "text/markdown"
-                "value" $charterContent
-              )
-            }}
-            {{ $.AddPage $charterPage }}
-          {{ else }}
-            {{ warnf "Unable to load charter for %s" $dir }}
-          {{ end }}
+          {{ with try (resources.GetRemote $charterUrl $charterOpts) }}
+            {{ with .Err }}
+              {{ if eq hugo.Environment "production" }}
+                {{ errorf "Unable to load charter for %s: %s" $dir .Err }}
+              {{ else }}
+                {{ warnf "Unable to load charter for %s: %s" $dir .Err }}
+              {{ end }}
+            {{ else with .Value }}
+              {{ $charterContent := replace .Content "\u200b" "" }}
+              {{ $charterPage := dict
+                "kind" "page"
+                "path" (printf "committees/%s/charter" $slug)
+                "title" (printf "%s Charter" $name)
+                "params" (dict
+                  "remote_charter_url" (printf "%s%s/%s" $githubBaseUrl $dir $charterLink)
+                  "hide_summary" true
+                  "toc_hide" true
+                )
+                "content" (dict              "mediaType" "text/markdown"
+                  "value" $charterContent
+                )
+              }}
+              {{ $.AddPage $charterPage }}
+            {{ else }}
+              {{ if eq hugo.Environment "production" }}
+                {{ errorf "Unable to load charter for %s" $dir }}
+              {{ else }}
+                {{ warnf "Unable to load charter for %s" $dir }}
+              {{ end }}
+            {{- end -}}
+          {{- end -}}
         {{ end }}
       {{- end -}}
     {{- end -}}

--- a/content/en/events/2024/kcseu/faq.md
+++ b/content/en/events/2024/kcseu/faq.md
@@ -59,7 +59,7 @@ Kubernetes Orgs:
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
 <li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
-<li><a href=“https://github.com/etcd-io” rel="noopener noreferrer" target=“_blank”>etcd-io</a></li>
+<li><a href="https://github.com/etcd-io" rel="noopener noreferrer" target="_blank">etcd-io</a></li>
 </ul>
 
 

--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -10,33 +10,10 @@
 
 {{/* Fetch remote KEP data */}}
 {{- $kepDataOpts := merge $globalOpts (dict "key" "keps-json-data") -}}
-{{- with try (resources.GetRemote $kepDataSourceUrl $kepDataOpts ) -}}
-  {{- with .Err -}}
-    {{- if eq hugo.Environment "production" -}}
-      {{- errorf "Unable to load KEP data: %s" . -}}
-    {{- else -}}
-      {{- warnf "Cannot load KEP data: %s" . -}}
-    {{- end -}}
-  {{- else with .Value -}}
-    {{- with try (.Content | transform.Unmarshal) -}}
-      {{- with .Err -}}
-        {{- if eq hugo.Environment "production" -}}
-          {{- errorf "Unable to load KEP data: %s" . -}}
-        {{- else -}}
-          {{- warnf "Cannot load KEP data: %s" . -}}
-        {{- end -}}
-      {{- end -}}
-      {{- with .Value -}}
-        {{- $kepData = . -}}
-      {{- end -}}
-    {{- end -}}
-  {{- else -}}
-    {{- if eq hugo.Environment "production" -}}
-      {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
-    {{- else -}}
-      {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
-    {{- end -}}
-  {{- end -}}
+{{- with resources.GetRemote $kepDataSourceUrl $kepDataOpts -}}
+  {{- $kepData = .Content | transform.Unmarshal -}}
+{{- else -}}
+  {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
 {{- end -}}
 
 {{/* Define stages that are "beyond provisional" */}}
@@ -78,48 +55,32 @@
     {{- $readmeUrl := printf "%s%s/%s/README.md" $rawBaseUrl $kep.owningSig $kep.name -}}
     {{- $readmeContent := "" -}}
     {{- $readmeOpts := merge $globalOpts (dict "key" (printf "kep-readme-%s" $kep.kepNumber)) -}}
-    
-    {{- $resourceFetchAttempt := try (resources.GetRemote $readmeUrl $readmeOpts ) -}}
-    
-    {{- /* Fallback to README.MD if README.md fetch fails or response is nil */ -}}
-    {{- $needsFallback := false -}}
-    {{- if not $resourceFetchAttempt.Value -}}
-      {{- $needsFallback = true -}}
-    {{- else if $resourceFetchAttempt.Err -}}
-      {{- $needsFallback = true -}}
-    {{- end -}}
 
-    {{- if $needsFallback -}}
+    {{- $resource := resources.GetRemote $readmeUrl $readmeOpts -}}
+
+    {{- if not $resource -}}
       {{- $readmeUrlUpper := printf "%s%s/%s/README.MD" $rawBaseUrl $kep.owningSig $kep.name -}}
       {{- $readmeOptsUpper := merge $globalOpts (dict "key" (printf "kep-readme-%s-upper" $kep.kepNumber)) -}}
-      {{- $resourceFetchAttempt = try (resources.GetRemote $readmeUrlUpper $readmeOptsUpper) -}}
+      {{- $resource = resources.GetRemote $readmeUrlUpper $readmeOptsUpper -}}
     {{- end -}}
 
-    {{- with $resourceFetchAttempt -}}
-      {{- with .Err -}}
-        {{- warnf "Unable to load README for KEP %s (tried .md and .MD): %s" $kep.kepNumber . -}}
-      {{- end -}}
-      {{- with .Value -}}
-        {{- /* Fix common markdown link errors in KEP READMEs to avoid build failures */ -}}
-        {{- $readmeContent = replace .Content "]((http" "](http" -}}
-        {{- $readmeContent = replace $readmeContent "/))" "/)" -}}
-        {{- $readmeContent = replace $readmeContent "((http" "(http" -}}
-        
-        {{- /* Fix relative image and link paths to point to GitHub */ -}}
-        {{- $repoBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
-        {{- $kepDirUrl := printf "%skeps/%s/%s/" $repoBaseUrl $kep.owningSig $kep.name -}}
-        
-        {{- /* 1. Fix absolute-looking paths (starting with /) */ -}}
-        {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
-        
-        {{- /* 2. Fix relative paths (not starting with http, #, or / and not containing :) */ -}}
-        {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
-      {{- else -}}
-        {{- warnf "Unable to load README for KEP %s" -}}
-      {{- end -}}
+    {{- with $resource -}}
+      {{- $readmeContent = .Content -}}
+      {{- $readmeContent = replace $readmeContent "]((http" "](http" -}}
+      {{- $readmeContent = replace $readmeContent "/))" "/)" -}}
+      {{- $readmeContent = replace $readmeContent "((http" "(http" -}}
+
+      {{- $repoBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
+      {{- $kepDirUrl := printf "%skeps/%s/%s/" $repoBaseUrl $kep.owningSig $kep.name -}}
+
+      {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
+      {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
+
+      {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
+      {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
+      {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
+    {{- else -}}
+      {{- warnf "Unable to load README for KEP %s" $kep.kepNumber -}}
     {{- end -}}
 
     {{/* Build page path: /resources/keps/{kepNumber}/ */}}

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -1,20 +1,12 @@
 {{- $kepDataSourceUrl := "https://storage.googleapis.com/k8s-keps/keps.json" -}}
 {{- $kepData := "" -}}
-{{- with try (resources.GetRemote $kepDataSourceUrl ) -}}
-  {{- with .Err -}}
-    {{- if eq hugo.Environment "production" }}
-      {{ errorf "Unable to load KEP data from %s: %s" $kepDataSourceUrl . -}}
-    {{- else -}}
-      {{- warnf "Cannot load KEP data from %s: %s" $kepDataSourceUrl . -}}
-    {{- end -}}
-  {{- else with .Value -}}
-    {{- $kepData = .Content | transform.Unmarshal -}}
+{{- with resources.GetRemote $kepDataSourceUrl -}}
+  {{- $kepData = .Content | transform.Unmarshal -}}
+{{- else -}}
+  {{- if eq hugo.Environment "production" -}}
+    {{ errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
   {{- else -}}
-    {{- if eq hugo.Environment "production" }}
-      {{- errorf "Unable to load KEP data from %s" $kepDataSourceUrl -}}
-    {{- else -}}
-      {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
-    {{- end -}}
+    {{- warnf "Cannot load KEP data from %s" $kepDataSourceUrl -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/shortcodes/sigs-list.html
+++ b/layouts/shortcodes/sigs-list.html
@@ -15,16 +15,8 @@
 {{- $cacheOpts := dict "key" "sigs-yaml" -}}
 {{- $opts = merge $opts $cacheOpts -}}
 
-{{- with try (resources.GetRemote $sigsUrl $opts) -}}
-  {{- with .Err -}}
-    {{ if eq hugo.Environment "production" }}
-      {{ errorf "Unable to load sigs.yaml: %s" . }}
-    {{ else }}
-      {{ warnf "Unable to load sigs.yaml: %s" . }}
-    {{ end }}
-  {{- end -}}
-  {{- with .Value -}}
-    {{- with .Content | transform.Unmarshal -}}
+{{- with resources.GetRemote $sigsUrl $opts -}}
+  {{- with . | transform.Unmarshal -}}
 <div class="sigs-container my-4">
   <div class="row">
     <!-- Sticky Header Wrapper -->
@@ -443,5 +435,4 @@
   </div>
 </div>
     {{- end -}}
-  {{- end -}}
 {{- end -}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,7 +219,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -663,6 +662,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -985,6 +985,7 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }


### PR DESCRIPTION
The href and target attributes on the etcd-io list item in events/2024/kcseu/faq.md used curly typographic quotes (U+201C/U+201D) instead of standard straight quotes. Browsers do not recognize curly quotes as HTML attribute delimiters, so both href and target were ignored, making the link completely non-functional.

This complements the kubernetes-csi link fixes in PR #735.

Refs #679