### PR TITLE
fix: upgrade http to https in blog/ links

### DIFF
--- a/content/en/blog/2026/announcing-checkpoint-restore-wg.md
+++ b/content/en/blog/2026/announcing-checkpoint-restore-wg.md
@@ -40,5 +40,5 @@ Following our presentation about [transparent checkpointing](https://sched.co/1t
 If you are interested in contributing to Kubernetes or CRIU, there are several ways to participate:
 
 - Join our meeting every second Thursday at 17:00 UTC via the Zoom link in our [meeting notes](https://docs.google.com/document/d/1ZMtHBibXfTw4cQerM4O4DJonzVs3W7Hp2K5ml6pTufs/edit); recordings of our prior meetings are available [here](https://www.youtube.com/playlist?list=PL69nYSiGNLP1P7F40IMVL3NsNiIm5AGos).
-- Chat with us on the [Kubernetes Slack](http://slack.k8s.io/): [#wg-checkpoint-restore](https://kubernetes.slack.com/messages/wg-checkpoint-restore)
+- Chat with us on the [Kubernetes Slack](https://slack.k8s.io/): [#wg-checkpoint-restore](https://kubernetes.slack.com/messages/wg-checkpoint-restore)
 - Email us at the [wg-checkpoint-restore mailing list](https://groups.google.com/a/kubernetes.io/g/wg-checkpoint-restore)

--- a/content/en/blog/2026/image-signature-routing.md
+++ b/content/en/blog/2026/image-signature-routing.md
@@ -145,6 +145,6 @@ This work is tracked in
 [kubernetes-sigs/promo-tools#1762](https://github.com/kubernetes-sigs/promo-tools/issues/1762).
 If you are interested in contributing to
 [SIG Release](https://www.kubernetes.dev/community/community-groups/sigs/release/),
-join our [weekly meeting](http://bit.ly/k8s-sig-release-meeting) or reach out on
+join our [weekly meeting](https://bit.ly/k8s-sig-release-meeting) or reach out on
 the [#sig-release](https://kubernetes.slack.com/messages/sig-release) Slack
 channel.

--- a/content/en/events/2024/kcseu/faq.md
+++ b/content/en/events/2024/kcseu/faq.md
@@ -59,7 +59,7 @@ Kubernetes Orgs:
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
 <li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
-<li><a href=“https://github.com/etcd-io” rel="noopener noreferrer" target=“_blank”>etcd-io</a></li>
+<li><a href="https://github.com/etcd-io" rel="noopener noreferrer" target="_blank">etcd-io</a></li>
 </ul>
 
 


### PR DESCRIPTION
Upgrades http:// to https:// in two blog posts for consistency and security best practices.

Changes:
- blog/2026/announcing-checkpoint-restore-wg.md: slack.k8s.io
- blog/2026/image-signature-routing.md: bit.ly/k8s-sig-release-meeting

Refs #679