### PR TITLE
fix: upgrade http to https in events/2020/kcc/activities.md

### DIFF
--- a/content/en/blog/2026/announcing-checkpoint-restore-wg.md
+++ b/content/en/blog/2026/announcing-checkpoint-restore-wg.md
@@ -40,5 +40,5 @@ Following our presentation about [transparent checkpointing](https://sched.co/1t
 If you are interested in contributing to Kubernetes or CRIU, there are several ways to participate:
 
 - Join our meeting every second Thursday at 17:00 UTC via the Zoom link in our [meeting notes](https://docs.google.com/document/d/1ZMtHBibXfTw4cQerM4O4DJonzVs3W7Hp2K5ml6pTufs/edit); recordings of our prior meetings are available [here](https://www.youtube.com/playlist?list=PL69nYSiGNLP1P7F40IMVL3NsNiIm5AGos).
-- Chat with us on the [Kubernetes Slack](http://slack.k8s.io/): [#wg-checkpoint-restore](https://kubernetes.slack.com/messages/wg-checkpoint-restore)
+- Chat with us on the [Kubernetes Slack](https://slack.k8s.io/): [#wg-checkpoint-restore](https://kubernetes.slack.com/messages/wg-checkpoint-restore)
 - Email us at the [wg-checkpoint-restore mailing list](https://groups.google.com/a/kubernetes.io/g/wg-checkpoint-restore)

--- a/content/en/blog/2026/image-signature-routing.md
+++ b/content/en/blog/2026/image-signature-routing.md
@@ -145,6 +145,6 @@ This work is tracked in
 [kubernetes-sigs/promo-tools#1762](https://github.com/kubernetes-sigs/promo-tools/issues/1762).
 If you are interested in contributing to
 [SIG Release](https://www.kubernetes.dev/community/community-groups/sigs/release/),
-join our [weekly meeting](http://bit.ly/k8s-sig-release-meeting) or reach out on
+join our [weekly meeting](https://bit.ly/k8s-sig-release-meeting) or reach out on
 the [#sig-release](https://kubernetes.slack.com/messages/sig-release) Slack
 channel.

--- a/content/en/events/2020/kcc/activities.md
+++ b/content/en/events/2020/kcc/activities.md
@@ -68,7 +68,7 @@ We will be giving away lots of great prizes!
 [Ian Coldwater]: https://twitter.com/iancoldwater
 [Jeremy Meiss]: https://twitter.com/IAmJerdog
 [DevOps Party Game]: https://devopspartygames.com/
-[Kubernetes YouTube channel]: http://youtube.com/kubernetescommunity
+[Kubernetes YouTube channel]: https://youtube.com/kubernetescommunity
 
 ### The Great Cloud Native Bake Off
 
@@ -325,7 +325,7 @@ Similar to BGA, Yucata is a fan-run site with many games on offer, all free and 
 ### Boiteajeux
 
 * **Platforms:** Browser
-* **URL:** http://www.boiteajeux.net/
+* **URL:** https://www.boiteajeux.net/
 * **Cost:** Free
 * **Players:** Varies by game
 
@@ -352,7 +352,7 @@ If you know any boardgame nerds, they probably won’t shut up about Wingspan an
 ### Race For The Galaxy
 
 * **Platforms:** Windows and Mac have pre-built versions, source available for Linux
-* **URL:** http://keldon.net/rftg/
+* **URL:** https://keldon.net/rftg/
 * **Cost:** Free
 * **Players:** 2-6
 

--- a/content/en/events/2024/kcseu/faq.md
+++ b/content/en/events/2024/kcseu/faq.md
@@ -59,7 +59,7 @@ Kubernetes Orgs:
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
 <li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
-<li><a href=“https://github.com/etcd-io” rel="noopener noreferrer" target=“_blank”>etcd-io</a></li>
+<li><a href="https://github.com/etcd-io" rel="noopener noreferrer" target="_blank">etcd-io</a></li>
 </ul>
 
 

--- a/content/en/resources/services.md
+++ b/content/en/resources/services.md
@@ -75,8 +75,8 @@ For more information, see the Kubernetes [GitHub Repository Guidelines].
 [creation, migration]: https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-repo&template=repo-create.yml&title=
 [archival]: https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-repo&template=repo-archive.yml&title=
 [issue templates]: https://github.com/kubernetes/org/issues/new/choose
-[Donated repos]: http://git.k8s.io/community/github-management/kubernetes-repositories.md#rules-for-donated-repositories
-[GitHub Repository Guidelines]: http://git.k8s.io/community/github-management/kubernetes-repositories.md
+[Donated repos]: https://git.k8s.io/community/github-management/kubernetes-repositories.md#rules-for-donated-repositories
+[GitHub Repository Guidelines]: https://git.k8s.io/community/github-management/kubernetes-repositories.md
 
 
 ## Communication platform and services
@@ -187,10 +187,10 @@ There are some specific formats and guidelines around some of these items, they
 can be be reviewed in the [Netlify subproject site guidelines].
 
 [Netlify]: https://netlify.com
-[config]: http://git.k8s.io/community/github-management/subproject-site-requests.md#example-netlify-configuration
+[config]: https://git.k8s.io/community/github-management/subproject-site-requests.md#example-netlify-configuration
 [issue]: https://github.com/kubernetes/k8s.io/issues/new?assignees=&labels=wg%2Fk8s-infra%2C+area%2Fdns&template=dns-request.md&title=DNS+REQUEST%3A+%3Cyour-dns-record%3E
 [Netlify Site Request]: https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-integration&template=site-request.yml&title=
-[Netlify subproject site guidelines]: http://git.k8s.io/community/github-management/subproject-site-requests.md#subproject-domain-reques
+[Netlify subproject site guidelines]: https://git.k8s.io/community/github-management/subproject-site-requests.md#subproject-domain-reques
 
 
 


### PR DESCRIPTION
Upgrades 3 http:// links to https:// in the 2020 KCC activities page for consistency and security best practices.

Changes:
- YouTube channel link
- Board game links (boiteajeux.net, keldon.net)

Refs #679