### PR TITLE
fix: replace curly quotes with straight quotes in etcd-io link

### DIFF
--- a/content/en/events/2024/kcseu/faq.md
+++ b/content/en/events/2024/kcseu/faq.md
@@ -59,7 +59,7 @@ Kubernetes Orgs:
 <li><a href="https://github.com/kubernetes-client" rel="noopener noreferrer" target="_blank">kubernetes-client</a></li>
 <li><a href="https://github.com/kubernetes-csi" rel="noopener noreferrer" target="_blank">kubernetes-csi</a></li>
 <li><a href="https://github.com/kubernetes-sigs" rel="noopener noreferrer" target="_blank">kubernetes-sigs</a></li>
-<li><a href=“https://github.com/etcd-io” rel="noopener noreferrer" target=“_blank”>etcd-io</a></li>
+<li><a href="https://github.com/etcd-io" rel="noopener noreferrer" target="_blank">etcd-io</a></li>
 </ul>
 
 


### PR DESCRIPTION
Fixes curly typographic quotes (U+201C/U+201D) in the etcd-io link on events/2024/kcseu/faq.md. Browsers don't recognize curly quotes as HTML attribute delimiters, so both href and target were ignored, making the link non-functional.

Refs #679