### PR TITLE
fix: add trailing slashes to onboarding nav links for consistency

### DIFF
--- a/content/en/docs/onboarding/01-starting-out.md
+++ b/content/en/docs/onboarding/01-starting-out.md
@@ -135,5 +135,5 @@ The [Kubernetes Community Resources page](/community/) has links to documents th
 * [The governance document](https://github.com/kubernetes/community/blob/master/governance.md) drills down into more of the specifics.
 
 <div class="bottom-nav">
-    <a href="/docs/onboarding">Onboarding Index</a> | <a href="../02-getting-into-github">Next Section</a>
+    <a href="/docs/onboarding">Onboarding Index</a> | <a href="../02-getting-into-github/">Next Section</a>
 </div>

--- a/content/en/docs/onboarding/03-pull-requests.md
+++ b/content/en/docs/onboarding/03-pull-requests.md
@@ -71,7 +71,7 @@ Kubernetes generally follows the standard GitHub pull request process, but there
     * Content
     * Potential website changes
 
-You can respond to comments from reviewers through comments or additional changes that you push to your development branch. [We will cover code review in a later unit.](../07-code-review)
+You can respond to comments from reviewers through comments or additional changes that you push to your development branch. [We will cover code review in a later unit.](../07-code-review/)
 
 ---
 


### PR DESCRIPTION
This PR resolves broken relative navigation links in the onboarding guide by appending missing trailing slashes.

Fixes #679