### PR TITLE
cleanups: Shift heading levels in docs and blogs

### DIFF
--- a/content/en/blog/2021/contributor-celebration.md
+++ b/content/en/blog/2021/contributor-celebration.md
@@ -2,20 +2,21 @@
 title: "Announcing the Kubernetes Contributor Celebration 2021"
 linkTitle: "Contributor Celebration 2021"
 date: 2021-12-07
+author: "Debabrata Panigrahi"
 ---
 
 By [Debabrata Panigrahi](https://twitter.com/debaelopedev)
 
-# Contributor Celebration 2021
+## Contributor Celebration 2021
 
 It's that time of the year again, Yayy!!
 
 Like last year, this year also we are back with Kubernetes Contributor Celebration, the annual end of the year celebration, to recognize our achievements and have some fun! It’s a time for us to relax, chat and do something fun with your fellow contributors!
 
-### Registration
+## Registration
 To register, please fill out the [Registration Form](https://docs.google.com/forms/d/e/1FAIpQLSdRIboKulEPf7jVgRH3iTVwS4PEk6k0htcOs1eSG2OBmkxEjg/viewform).
 More details on [how to join](/events/2021/kcc/how-to-join/) the event.
-### Events and Activities
+## Events and Activities
 1. [**DevOps Party Games**](/events/2021/kcc/activities/#most-extreme-kubernetes-challenge---devops-party-game)
     
     "DevOps Party Games takes the idea of "online party games" and tilts it on its head by adding DevOps-inspired content to existing games, and then streams it live via Twitch for a worldwide audience to watch, comment, and hopefully be entertained. In addition, the hosts (Matt Stratton, Jeremy Meiss, and Dan Maher) will provide color commentary, much like a modern day Cotton McKnight and Pepper Brooks (announcers from Dodgeball)." There will be a Kubernetes slant for this edition of DevOps Party Games.
@@ -37,10 +38,10 @@ More details on [how to join](/events/2021/kcc/how-to-join/) the event.
 4. **[krafternetes](/events/2021/kcc/activities/#krafternetes)**
     A series of "studio sessions" by contributors, to showcase the art forms they are working on be it through live or recorded sessions, followed by a discussion on the same. Interested folks could join the #krafternetes channel on kubernetes slack. 
 
-### Schedule
+## Schedule
 The event is scheduled from 16th-19th December 2021.
 More Information about the schedule could be found [here](/events/2021/kcc/schedule/).
 
 
-### See you all at the event 
+## See you all at the event 
 If you have any questions or concerns, please see the [faq](/events/2021/kcc/faq/). Also don't forget to [register if you're interested](https://forms.gle/oAppmLDggEEGx5tz5) as well as bookmark the 2021 [Kubernetes Contributor Celebration landing page](https://k8s.dev/celebration) for updated details between now and the celebration.

--- a/content/en/blog/2021/non-code-contribution.md
+++ b/content/en/blog/2021/non-code-contribution.md
@@ -2,6 +2,7 @@
 title: "How to choose a SIG as a non-code Kubernetes contributor"
 linkTitle: "How to choose a SIG as a non-code Kubernetes contributor"
 date: 2021-07-09
+author: "Chris Short"
 ---
 By [Chris Short](https://twitter.com/ChrisShort)
 
@@ -13,7 +14,7 @@ The SIG you work in depends on your skills and what you want to do with your (or
 
 I’ll start with myself as an example.
 
-# How I found my SIG
+## How I found my SIG
 
 I do not code as part of my day-to-day work; I never have. While I have made bits of code into programs here and there, I always had a helping hand. It's also possible my definition of a coder is busted too. But, I consider myself a non-code contributor to Kubernetes.
 
@@ -25,7 +26,7 @@ My philosophy is if things were hard or confusing for me, they'd likely be hard 
 
 I found early on this: continually showing up to SIG meetings is one way to add value to the community. Regular participation gives you growing context in Kubernetes, and it helps in the long run.
 
-# How I contribute
+## How I contribute
 
 For me, contributing to Kubernetes is all about helping other contributors. I love talking to new contributors about why something is the way it is and they come up with some alternatives to doing that task. That thought exercise can be an enormously helpful contribution. That has been a part of what I've done in the community. Asking why something is the way it is can be a potent tool for improving things. I’ve helped with [new contributor workshops](https://git.k8s.io/community/events/2018/05-contributor-summit/new-contributor-workshop.md), which meant showing up and sharing my knowledge. I’ve helped onboard folks into the Kubernetes GitHub organization. I’ve hosted community meetings.
 
@@ -35,7 +36,7 @@ My work now is focusing more on contributing to our [Contributor Marketing](http
 
 None of those things required me to write code. Non-code contributors are an essential part of our community.
 
-# Hop into the Kubernetes community
+## Hop into the Kubernetes community
 
 To join the Kubernetes community, I recommend finding a SIG where your skills align, doing things you want to do in your off time. There's a list of [Kubernetes SIGs](/community/community-groups/) with a lot of great options. If you’re not sure where to go, start with [Contributor Experience](https://git.k8s.io/community/sig-contributor-experience). We’re here to help.
 

--- a/content/en/blog/2024/sig-node-spotlight/sig-node-spotlight.md
+++ b/content/en/blog/2024/sig-node-spotlight/sig-node-spotlight.md
@@ -217,7 +217,7 @@ In addition to the Sidecar KEP, there are many other areas where SIG Node needs 
   function as intended across a variety of scenarios.
 
 
-# Conclusion
+## Conclusion
 
 In conclusion, SIG Node stands as a cornerstone in Kubernetes' journey, ensuring its reliability and
 adaptability in the ever-changing landscape of cloud-native computing. With dedicated members like

--- a/content/en/docs/onboarding/01-starting-out.md
+++ b/content/en/docs/onboarding/01-starting-out.md
@@ -6,13 +6,13 @@ description: |
     Begin your journey to become a contributing member of the Kubernetes project!
 ---
 
-# Welcome to Kubernetes!
+## Welcome to Kubernetes!
 
 Welcome to the New Contributor course for Kubernetes!
 
 ---
 
-# Section 1: Starting Out
+## Section 1: Starting Out
 
 Each unit of this course consists of a slideshow and links to resources. Take your time reading the materials, and feel free to reach out to the community with questions.
 
@@ -20,7 +20,7 @@ We look forward to your contributions!
 
 ---
 
-# What you are about to learn
+## What you are about to learn
 
 This first unit is all about starting out in the Kubernetes community. By the end of this unit, you will:
 
@@ -30,7 +30,7 @@ This first unit is all about starting out in the Kubernetes community. By the en
 
 ---
 
-# Who exactly is a contributor?
+## Who exactly is a contributor?
 
 Kubernetes contributors bring a wide range of talents, skills, services, and ideas to the community. They:
 
@@ -44,7 +44,7 @@ Everybody's contributions are welcome in the Kubernetes community!
 
 ---
 
-# What are the core values of the Kubernetes community?
+## What are the core values of the Kubernetes community?
 
 The Kubernetes community adheres to the following principles:
 
@@ -58,7 +58,7 @@ The Kubernetes community adheres to the following principles:
 
 ---
 
-# What behavior is expected of contributors?
+## What behavior is expected of contributors?
 
 The Kubernetes community strives to be safe, respectful and inclusive. We expect all contributors to:
 
@@ -70,7 +70,7 @@ The Kubernetes community strives to be safe, respectful and inclusive. We expect
 
 ---
 
-# What is the CNCF Code of Conduct?
+## What is the CNCF Code of Conduct?
 
 _"The Kubernetes Code of Conduct is in effect, so please be excellent to each other." — Jorge Castro, 2020 SIG ContribEx co-chair_
 
@@ -80,7 +80,7 @@ The Code of Conduct serves as a set of rules used by the Kubernetes community to
 
 ---
 
-# Who oversees and enforces the Code of Conduct?
+## Who oversees and enforces the Code of Conduct?
 
 The Code of Conduct Committee oversees and handles all incidents and responses regarding code of conduct issues and violations.
 
@@ -88,7 +88,7 @@ The Code of Conduct Committee oversees and handles all incidents and responses r
 
 ---
 
-# How is the Kubernetes community organized?
+## How is the Kubernetes community organized?
 
 Most community activity is organized into three areas:
 
@@ -98,7 +98,7 @@ Most community activity is organized into three areas:
 
 ---
 
-# What are Special Interest Groups?
+## What are Special Interest Groups?
 
 We are organized primarily into Special Interest Groups, or SIGs. Each SIG is composed of members from multiple companies and organizations. In addition, each SIG:
 
@@ -107,7 +107,7 @@ We are organized primarily into Special Interest Groups, or SIGs. Each SIG is co
 
 ---
 
-# What is a working group?
+## What is a working group?
 
 A working group facilitates topics of discussion that cross SIG lines. They are a vehicle for consensus building. A working group:
 
@@ -117,7 +117,7 @@ A working group facilitates topics of discussion that cross SIG lines. They are 
 
 ---
 
-# What is a committee?
+## What is a committee?
 
 Some topics, such as Security or Code of Conduct, require discretion. Committees do not have open membership and do not always operate in the open. 
 
@@ -127,7 +127,7 @@ Some topics, such as Security or Code of Conduct, require discretion. Committees
 
 ---
 
-# Where can I learn more?
+## Where can I learn more?
 
 The [Kubernetes Community Resources page](/community/) has links to documents that describe our community structure and governance.
 

--- a/content/en/docs/onboarding/02-getting-into-github.md
+++ b/content/en/docs/onboarding/02-getting-into-github.md
@@ -7,11 +7,11 @@ description: |
     with repositories there.
 ---
 
-# Section 2: Getting Into GitHub
+## Section 2: Getting Into GitHub
 
 ---
 
-# What you're about to learn
+## What you're about to learn
 
 The first step to being a Kubernetes contributor is getting into GitHub! After this unit, you will:
 
@@ -21,7 +21,7 @@ The first step to being a Kubernetes contributor is getting into GitHub! After t
 
 ---
 
-# What is GitHub?
+## What is GitHub?
 
 * GitHub is a web service for managing software development with Git.
 * It provides bug tracking, task management, hosted development environments, continuous integration, and [other important features](https://github.com/about).
@@ -31,7 +31,7 @@ Working with GitHub is straightforward, but if you are new to it, it can seem co
 
 ---
 
-# How does Kubernetes use GitHub?
+## How does Kubernetes use GitHub?
 
 As one of the largest open source projects with thousands of contributors, Kubernetes relies on GitHub for organization and sharing information.
 
@@ -42,7 +42,7 @@ As one of the largest open source projects with thousands of contributors, Kuber
 
 ---
 
-# How do I set up my GitHub account?
+## How do I set up my GitHub account?
 
 You _probably_ already have a GitHub account, but just in case:
 
@@ -51,7 +51,7 @@ You _probably_ already have a GitHub account, but just in case:
 
 ---
 
-# Which GitHub features will I use as a contributor?
+## Which GitHub features will I use as a contributor?
 
 Now it's time to learn all of these extra GitHub features.
 
@@ -63,7 +63,7 @@ Now it's time to learn all of these extra GitHub features.
 
 ---
 
-# What is a Contributor License Agreement (CLA)?
+## What is a Contributor License Agreement (CLA)?
 
 Once you are ready to contribute, you will have to jump through one small legal hoop, but we make it as easy as possible.
 
@@ -73,14 +73,14 @@ Once you are ready to contribute, you will have to jump through one small legal 
 
 ---
 
-# How do I sign a CLA?
+## How do I sign a CLA?
 
 * After you make your first pull request, a GitHub bot will walk you through the process.
 * The process is [outlined in the Community repository](https://github.com/kubernetes/community/blob/main/CLA.md).
 
 ---
 
-# Okay, you are ready to make your first pull request!
+## Okay, you are ready to make your first pull request!
 
 1. Visit the [Kubernetes Contributor Playground repository](https://github.com/kubernetes-sigs/contributor-playground).
 2. Use the "Fork" button in the upper right corner to fork the repository to your own account.

--- a/content/en/docs/onboarding/03-pull-requests.md
+++ b/content/en/docs/onboarding/03-pull-requests.md
@@ -7,11 +7,11 @@ description: |
   Kubernetes repositories.
 ---
 
-# Section 3: Pull Requests
+## Section 3: Pull Requests
 
 ---
 
-## Objectives
+### Objectives
 
 This unit will teach you all about how to submit and manage pull requests for the different Kubernetes repositories. By the end of this unit, you will be able to:
 
@@ -21,7 +21,7 @@ This unit will teach you all about how to submit and manage pull requests for th
 
 ---
 
-## What is a pull request?
+### What is a pull request?
 
 Before we start teaching you how to use pull requests, we should tell you what they are!
 
@@ -32,7 +32,7 @@ Before we start teaching you how to use pull requests, we should tell you what t
 
 ---
 
-## Where do I make a pull request?
+### Where do I make a pull request?
 
 Before creating a pull request, you should:
 
@@ -43,7 +43,7 @@ Before creating a pull request, you should:
 
 ---
 
-## How do I open a pull request?
+### How do I open a pull request?
 
 You’ll want to review the basic pull request process you learned at the end of [Unit 2](../02-getting-into-github/).
 
@@ -53,7 +53,7 @@ You’ll want to review the basic pull request process you learned at the end of
 
 ---
 
-## How does Kubernetes use pull requests?
+### How does Kubernetes use pull requests?
 
 Kubernetes generally follows the standard GitHub pull request process, but there is a layer of additional Kubernetes specific (and sometimes SIG specific) differences.
 
@@ -63,7 +63,7 @@ Kubernetes generally follows the standard GitHub pull request process, but there
 
 ---
 
-## How does the pull request review process work?
+### How does the pull request review process work?
 
 * Anyone can review a documentation pull request. Code pull requests require approved reviewers.
 * In addition to code-related concerns, pull request reviews also look at:
@@ -75,7 +75,7 @@ You can respond to comments from reviewers through comments or additional change
 
 ---
 
-## When are my pull requests run through tests?
+### When are my pull requests run through tests?
 
 * A bot runs your PR through a few pre-commit tests automatically.
 * The results of these tests will be posted to your pull request’s discussion automatically.
@@ -83,7 +83,7 @@ You can respond to comments from reviewers through comments or additional change
 
 ---
 
-## What do I do if my test fails?
+### What do I do if my test fails?
 
 * The test results should give some indication of what went wrong.
 * Make changes, push them to your branch, and [continue iterating through the pull request process](/docs/guide/pull-requests/).

--- a/content/en/docs/onboarding/04-issues-management.md
+++ b/content/en/docs/onboarding/04-issues-management.md
@@ -7,11 +7,11 @@ description: |
     and organized.
 ---
 
-# Section 4: Issues Management/Triage
+## Section 4: Issues Management/Triage
 
 ---
 
-# What you're about to learn
+## What you're about to learn
 
 This unit will help you get started with issue management across the Kubernetes GitHub repositories. By the end, you'll:
 
@@ -22,7 +22,7 @@ This unit will help you get started with issue management across the Kubernetes 
 
 ---
 
-# How does Kubernetes use GitHub issues?
+## How does Kubernetes use GitHub issues?
 
 Contributors and end users use issues for a variety of reasons:
 
@@ -35,7 +35,7 @@ You can identify different types of issues with their labels (AKA tags).
 
 ---
 
-# What are labels?
+## What are labels?
 
 * Labels are a GitHub feature used to organize issues and pull requests.
 * They allow you to quickly identify at a glance what type of issue or pull request you are looking at.
@@ -44,7 +44,7 @@ You can identify different types of issues with their labels (AKA tags).
 
 ---
 
-# Where can I find all of the Kubernetes issues?
+## Where can I find all of the Kubernetes issues?
 
 Issues are managed in many of the different Kubernetes GitHub repositories, and can be accessed via the _Issues_ tab. Here are the most common:
 
@@ -54,7 +54,7 @@ Issues are managed in many of the different Kubernetes GitHub repositories, and 
 
 ---
 
-# What are some common labels?
+## What are some common labels?
 
 There are [A LOT of different labels](https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md), and both issues and pull requests (PRs) can have their own labels. Here are a few you will run into frequently.
 
@@ -105,7 +105,7 @@ There are [A LOT of different labels](https://github.com/kubernetes/test-infra/b
 
 ---
 
-# Which labels will you have to worry about?
+## Which labels will you have to worry about?
 
 That list of labels is really long, but you won't need to worry about most of them at the beginning.
 
@@ -115,7 +115,7 @@ That list of labels is really long, but you won't need to worry about most of th
 
 ---
 
-# What is triaging?
+## What is triaging?
 
 * Triaging is the process where new issues and requests are reviewed and organized.
 * Factors considered include priority/urgency, SIG ownership of the issue, and the kind of issue (bug, feature, etc.).
@@ -126,7 +126,7 @@ Triaging is critical for keeping track of new issues, bugs, and problems. [Read 
 
 ---
 
-# How are issues prioritized?
+## How are issues prioritized?
 
 Each SIG is responsible for triaging and deciding on the priority of issues that affect their area.
 
@@ -135,7 +135,7 @@ Each SIG is responsible for triaging and deciding on the priority of issues that
 
 ---
 
-# What is the Security Response Committee?
+## What is the Security Response Committee?
 
 * The Security Response Committee (SRC) is responsible for triaging and handling the security issues for Kubernetes.
 * The SRC is also responsible for disclosing vulnerabilities to the public.

--- a/content/en/docs/onboarding/05-development.md
+++ b/content/en/docs/onboarding/05-development.md
@@ -7,11 +7,11 @@ description: |
 ---
 
 
-# Section 5: Getting Started with Kubernetes Development
+## Section 5: Getting Started with Kubernetes Development
 
 ---
 
-# What you’re about to learn
+## What you’re about to learn
 
 It’s time to set up a development environment so you can build Kubernetes. By end of this unit, you will:
 
@@ -20,7 +20,7 @@ It’s time to set up a development environment so you can build Kubernetes. By 
 
 ---
 
-# What are your options for a development environment?
+## What are your options for a development environment?
 
 There are three primary options, all with their own benefits and drawbacks.
 
@@ -30,7 +30,7 @@ There are three primary options, all with their own benefits and drawbacks.
 
 ---
 
-# Why build with Docker?
+## Why build with Docker?
 
 This method uses a containerized build environment. There are some good reasons to use it:
 
@@ -42,7 +42,7 @@ Read more about this method in [Building Kubernetes](https://github.com/kubernet
 
 ---
 
-# Why build using a local OS?
+## Why build using a local OS?
 
 This method takes the most effort to set up. But it has its own advantages:
 
@@ -53,7 +53,7 @@ To set this method up, [follow the steps from the Development Guide](https://git
 
 ---
 
-# Why build using GitHub Codespaces?
+## Why build using GitHub Codespaces?
 
 The newest method takes advantage of [GitHub Codespaces](https://github.com/features/codespaces) to provide a container-based development environment.
 
@@ -64,7 +64,7 @@ To build Kubernetes with Codespaces, follow the steps in this document.
 
 ---
 
-# What are the next steps?
+## What are the next steps?
 
 Once you have a working development environment, you will be ready to develop and run tests against Kubernetes.
 

--- a/content/en/docs/onboarding/06-testing.md
+++ b/content/en/docs/onboarding/06-testing.md
@@ -6,13 +6,13 @@ description: |
     Learn about the different types of tests in the Kubernetes project and how to run them.
 ---
 
-# Section 6: Testing
+## Section 6: Testing
 
 This unit is all about the various types of tests, both automated and manual, in the Kubernetes project. 
 
 ---
 
-# What you're about to learn
+## What you're about to learn
 
 By the time you're done with this unit, you'll:
 
@@ -23,7 +23,7 @@ Testing Kubernetes is pretty complicated. We will try to make it easy for you, b
 
 ---
 
-# What are the different types of tests?
+## What are the different types of tests?
 
 In the course of developing Kubernetes, you will interact with three different test types:
 
@@ -35,7 +35,7 @@ Let's learn about each type of test!
 
 ---
 
-# Unit tests
+## Unit tests
 
 **Unit tests** run against the smallest possible components of code, like an individual function or API calls.
 
@@ -44,7 +44,7 @@ Let's learn about each type of test!
 
 ---
 
-# Integration tests
+## Integration tests
 
 **Integration tests** make sure that components work together flawlessly as a group.
 
@@ -54,7 +54,7 @@ Let's learn about each type of test!
 
 ---
 
-# End-to-End tests
+## End-to-End tests
 
 **End-to-end (E2E) tests** emulate an entire execution path across the entire application, from start to end.
 
@@ -64,7 +64,7 @@ Let's learn about each type of test!
 
 ---
 
-# Who is responsible for Kubernetes tests?
+## Who is responsible for Kubernetes tests?
 
 *"Developers! Developers! Developers!" — Steve Ballmer*
 
@@ -74,7 +74,7 @@ Let's learn about each type of test!
 
 ---
 
-# What is presubmission verification?
+## What is presubmission verification?
 
 Presubmission is the phase before a pull request is created—the steps that you, the contributor, can take to maximize your PR's chance of success.
 
@@ -84,7 +84,7 @@ Presubmission is the phase before a pull request is created—the steps that you
 
 ---
 
-# How do I interact with unit tests?
+## How do I interact with unit tests?
 
 Pull requests need to pass **all** unit tests.
 
@@ -94,7 +94,7 @@ Pull requests need to pass **all** unit tests.
 
 ---
 
-# How do I interact with integration tests?
+## How do I interact with integration tests?
 
 Pull requests also need to pass **all** integration tests.
 
@@ -104,7 +104,7 @@ Pull requests also need to pass **all** integration tests.
 
 ---
 
-# How do I interact with end-to-end (E2E) tests?
+## How do I interact with end-to-end (E2E) tests?
 
 E2E tests build test binaries, spin up a test cluster, run the tests, and then tear the cluster down.
 
@@ -114,7 +114,7 @@ You will not need to run E2E tests for every pull request. [The End-to-End Testi
 
 ---
 
-# How does testing affect my pull request?
+## How does testing affect my pull request?
 
 You should run tests locally or in your development environment before submitting a pull request, because it will speed up the process.
 
@@ -126,7 +126,7 @@ You should run tests locally or in your development environment before submittin
 
 ---
 
-# Testing Resources
+## Testing Resources
 
 We've covered a lot of ground in this unit, and if you want to go deeper, here is a collection of all the resources we used.
 

--- a/content/en/docs/onboarding/07-code-review.md
+++ b/content/en/docs/onboarding/07-code-review.md
@@ -7,11 +7,11 @@ description: |
     what to do when you need a reviewer.
 ---
 
-# Section 7: Code Review
+## Section 7: Code Review
 
 ---
 
-# What you're about to learn
+## What you're about to learn
 
 In this unit, you will learn everything about getting your code contributions to Kubernetes reviewed. By the end of this unit, you will be able to:
 
@@ -20,7 +20,7 @@ In this unit, you will learn everything about getting your code contributions to
 
 ---
 
-# What is a code review?
+## What is a code review?
 
 A code review is when other developers examine proposed changes and additions to source code.
 
@@ -29,7 +29,7 @@ A code review is when other developers examine proposed changes and additions to
 
 ---
 
-# Why are code reviews important?
+## Why are code reviews important?
 
 Like testing, code reviews help make sure Kubernetes remains stable, reliable, and bug-free.
 
@@ -39,7 +39,7 @@ Like testing, code reviews help make sure Kubernetes remains stable, reliable, a
 
 ---
 
-# Where does a code review fit into the process?
+## Where does a code review fit into the process?
 
 To understand code reviews, you need to understand pull requests first. Make sure you've finished that unit!
 
@@ -48,7 +48,7 @@ To understand code reviews, you need to understand pull requests first. Make sur
 
 ---
 
-# Who can review my code?
+## Who can review my code?
 
 Anybody can review your code, but only approved reviewers can add the `lgtm` label to your PR, which marks it as ready for merging.
 
@@ -58,7 +58,7 @@ Anybody can review your code, but only approved reviewers can add the `lgtm` lab
 
 ---
 
-# How can I make sure my changes pass review?
+## How can I make sure my changes pass review?
 
 There are a number of points to keep in mind while preparing your pull request for review.
 
@@ -72,7 +72,7 @@ The Contributor Guide has [more guidelines and tips for passing reviews](https:/
 
 ---
 
-# Help! My pull request isn't getting any reviews!
+## Help! My pull request isn't getting any reviews!
 
 If you need help finding reviewers for your pull request, try one of the following:
 

--- a/content/en/docs/onboarding/08-community.md
+++ b/content/en/docs/onboarding/08-community.md
@@ -7,11 +7,11 @@ description: |
     project. Learn how we do it!
 ---
 
-# Section 8: Community
+## Section 8: Community
 
 ---
 
-# What you’re about to learn
+## What you’re about to learn
 
 It’s time to learn about communication and community among Kubernetes contributors. By the end of this unit, you will:
 
@@ -22,7 +22,7 @@ It’s time to learn about communication and community among Kubernetes contribu
 
 ---
 
-# How big is the Kubernetes contributor community?
+## How big is the Kubernetes contributor community?
 
 The Kubernetes community has _thousands_ of active contributors.
 
@@ -30,7 +30,7 @@ The Kubernetes community has _thousands_ of active contributors.
 
 ---
 
-# Is every contributor a developer?
+## Is every contributor a developer?
 
 No! Kubernetes contributors take on all kinds of responsibilities and roles, including:
 
@@ -60,7 +60,7 @@ No! Kubernetes contributors take on all kinds of responsibilities and roles, inc
 
 ---
 
-# What is the best way to communicate with my fellow contributors?
+## What is the best way to communicate with my fellow contributors?
 
 Every SIG, working group, and committee will have its preferred method of communication, but globally, the community uses:
 
@@ -70,7 +70,7 @@ Every SIG, working group, and committee will have its preferred method of commun
 
 ---
 
-# What do I need to know about the mailing lists?
+## What do I need to know about the mailing lists?
 
 Community-wide notifications and discussions are always sent to the [Kubernetes dev mailing list](https://groups.google.com/a/kubernetes.io/g/dev). 
 
@@ -78,7 +78,7 @@ Community-wide notifications and discussions are always sent to the [Kubernetes 
 
 ---
 
-# How do I join the Kubernetes Slack community?
+## How do I join the Kubernetes Slack community?
 
 The Kubernetes Slack server has over 500 channels! 
 
@@ -87,7 +87,7 @@ The Kubernetes Slack server has over 500 channels!
 
 ---
 
-# What is the best way to communicate with each SIG?
+## What is the best way to communicate with each SIG?
 
 Each SIG and Working Group has its favored method of communication. You can start in their Slack channel and ask around.
 
@@ -97,7 +97,7 @@ Each SIG and Working Group has its favored method of communication. You can star
 
 ---
 
-# How does the community use GitHub Issues and email to communicate?
+## How does the community use GitHub Issues and email to communicate?
 
 Slack is excellent for most discussion and questions.
 
@@ -106,7 +106,7 @@ Slack is excellent for most discussion and questions.
 
 ---
 
-# How do I find out more about KubeCon and other in-person events?
+## How do I find out more about KubeCon and other in-person events?
 
 While KubeCon is organized by the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/), we like to host a Contributor Summit alongside KubeCon.
 
@@ -115,7 +115,7 @@ While KubeCon is organized by the [Cloud Native Computing Foundation (CNCF)](htt
 
 ---
 
-# Where can I learn more about communication in the community?
+## Where can I learn more about communication in the community?
 
 We have extensive guidelines and policies around our various communication channels.
 

--- a/content/en/docs/onboarding/09-documentation.md
+++ b/content/en/docs/onboarding/09-documentation.md
@@ -7,11 +7,11 @@ description: |
     contribute to it.
 ---
 
-# Section 9: Documentation
+## Section 9: Documentation
 
 ---
 
-# What you're about to learn
+## What you're about to learn
 
 This unit is about documentation, and by the end, you will:
 
@@ -23,7 +23,7 @@ This unit is about documentation, and by the end, you will:
 
 ---
 
-# How is the Kubernetes documentation organized?
+## How is the Kubernetes documentation organized?
 
 The documentation for the Kubernetes project can be divided into a number of categories.
 
@@ -33,7 +33,7 @@ The documentation for the Kubernetes project can be divided into a number of cat
 
 ---
 
-# What is the user-facing Kubernetes documentation?
+## What is the user-facing Kubernetes documentation?
 
 The user-facing documentation deals with how to install, configure, and operate Kubernetes and its subsystems.
 
@@ -42,7 +42,7 @@ The user-facing documentation deals with how to install, configure, and operate 
 
 ---
 
-# What is the community documentation?
+## What is the community documentation?
 
 The [community documentation](https://www.kubernetes.dev/) is an informal collection of docs maintained by contributors. It consists of:
 
@@ -52,7 +52,7 @@ The [community documentation](https://www.kubernetes.dev/) is an informal collec
 
 ---
 
-# What is the SIG documentation?
+## What is the SIG documentation?
 
 Each SIG is in control of some aspect of Kubernetes development, infrastructure, or community.
 
@@ -64,7 +64,7 @@ Each SIG is in control of some aspect of Kubernetes development, infrastructure,
 
 ---
 
-# Is the documentation available in other languages?
+## Is the documentation available in other languages?
 
 Kubernetes is used by developers and DevOps people _all over the world._ It is important that the documentation is available in other languages.
 
@@ -74,13 +74,13 @@ Kubernetes is used by developers and DevOps people _all over the world._ It is i
 
 ---
 
-# Who is responsible for the documentation?
+## Who is responsible for the documentation?
 
 YOU ARE! <!-- .element: class="r-fit-text" -->
 
 ---
 
-# No, seriously!
+## No, seriously!
 
 All of the contributors are responsible for documentation.
 
@@ -92,7 +92,7 @@ When you make a change, document it.
 
 ---
 
-# What is the process for updating the documentation?
+## What is the process for updating the documentation?
 
 Documentation updates follow the same process as any other contribution.
 
@@ -102,7 +102,7 @@ Documentation updates follow the same process as any other contribution.
 
 ---
 
-# Where can I find documentation and Style guidance?
+## Where can I find documentation and Style guidance?
 
 When writing or updating documentation, follow the project guidance.
 
@@ -111,7 +111,7 @@ When writing or updating documentation, follow the project guidance.
 
 ---
 
-# How do we keep the documentation useful and consistent?
+## How do we keep the documentation useful and consistent?
 
 Of course the last slide is the million dollar question.
 

--- a/content/en/docs/onboarding/10-architecture.md
+++ b/content/en/docs/onboarding/10-architecture.md
@@ -7,11 +7,11 @@ description: |
     and how to change it.
 ---
 
-# Section 10: Architecture and Enhancements
+## Section 10: Architecture and Enhancements
 
 ---
 
-# What you’re about to learn
+## What you’re about to learn
 
 We’re getting into the guts of Kubernetes now! After this module, you will:
 
@@ -21,7 +21,7 @@ We’re getting into the guts of Kubernetes now! After this module, you will:
 
 ---
 
-# Where are the architecture documents?
+## Where are the architecture documents?
 
 The good news is that the Kubernetes architecture is very well documented.
 
@@ -30,7 +30,7 @@ The good news is that the Kubernetes architecture is very well documented.
 
 ---
 
-# What are the components of a Kubernetes cluster?
+## What are the components of a Kubernetes cluster?
 
 A Kubernetes deployment is called a cluster. So what is it made of?
 
@@ -42,7 +42,7 @@ You can also learn [how they communicate with each other](https://kubernetes.io/
 
 ---
 
-# How are new features added to Kubernetes?
+## How are new features added to Kubernetes?
 
 New features are added through a process that begins with a [Kubernetes Enhancement Proposal](https://github.com/kubernetes/enhancements/blob/master/keps/README.md).
 
@@ -55,7 +55,7 @@ KEPs are required for most non-trivial changes. Specifically:
 
 ---
 
-# Who manages the Kubernetes Enhancement Proposal process?
+## Who manages the Kubernetes Enhancement Proposal process?
 
 First, we call it KEP for short. And second, the KEP process is managed by the Architecture Special Interest Group (SIG Architecture).
 

--- a/content/en/events/2022/kcseu/social.md
+++ b/content/en/events/2022/kcseu/social.md
@@ -4,7 +4,7 @@ type: docs
 weight: 5
 ---
 
-# Contributor Social at La Casa Del Mar
+## Contributor Social at La Casa Del Mar
 
 <img align="right" src="/events/2022/kcseu/casadelmar.jpg" width="30%" alt="La Casa de la Mar venue">
 


### PR DESCRIPTION
Shift Markdown heading levels in onboarding guides and blog posts to avoid duplicate H1 tags, improving semantic structure and search accessibility. Refs: #685