### PR TITLE
cleanups: Add alt text to images in event pages

### DIFF
--- a/content/en/events/2020/kcc/faq.md
+++ b/content/en/events/2020/kcc/faq.md
@@ -115,7 +115,7 @@ everything. If you need assistance, join the `#help` channel.
 
 ### What is this YAGPDB.xyz and why is it messaging me?
 
-<img align="left" src="/events/past-events/2020/kcc2020/yagpdb.png" width="40" height="40">
+<img align="left" src="/events/past-events/2020/kcc2020/yagpdb.png" width="40" height="40" alt="YAGPDB Discord Bot logo">
 
 [YAGPDB] (Yet Another General Purpose Discord Bot) is a verified discord bot
 that we use to manage a variety of services within discord, from verification
@@ -133,19 +133,19 @@ overlays. A few examples of what this would look like:
 
 1 ) To do so, click the server dropdown (Top Left)
 
-<img align="center" src="/events/past-events/2020/kcc2020/server.png" width="40%">
+<img align="center" src="/events/past-events/2020/kcc2020/server.png" width="40%" alt="Discord server list showing Kubernetes server">
 <br>
 <br>
 2 ) Select “Change Nickname”
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/nickname.png" width="40%">
+<img align="center" src="/events/past-events/2020/kcc2020/nickname.png" width="40%" alt="Discord edit nickname interface">
 <br>
 <br>
 3 ) Then follow the template of “nickname (pro/noun)” like so:
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/name.png" width="40%">
+<img align="center" src="/events/past-events/2020/kcc2020/name.png" width="40%" alt="Discord user settings name field">
 
 
 ### What are the `#<channel>-info` channels for?

--- a/content/en/events/2020/kcc/how-to-join.md
+++ b/content/en/events/2020/kcc/how-to-join.md
@@ -57,7 +57,7 @@ For instructions on creating an account and installing the client, see the
    symbol) on the left side of the application. 
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/add-server.png" width="40%">
+   <img align="center" src="/events/past-events/2020/kcc2020/add-server.png" width="40%" alt="Discord add server button">
    <br>
    <br>
    A menu should pop up asking if you'd like to create or join a server. Select
@@ -68,7 +68,7 @@ For instructions on creating an account and installing the client, see the
    email, and paste it in the **Invite link** text box.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/join-server.png" width="40%">
+   <img align="center" src="/events/past-events/2020/kcc2020/join-server.png" width="40%" alt="Discord join server input dialog">
    <br> 
    <br> 
 3) Two things will happen: You will be directed to the `#instructions-to-connect`
@@ -77,7 +77,7 @@ For instructions on creating an account and installing the client, see the
    the server.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/instructions-to-connect.png" width="100%">
+   <img align="center" src="/events/past-events/2020/kcc2020/instructions-to-connect.png" width="100%" alt="Discord connection instructions and prompt">
    <br>
    <br> 
 4) The bot will dm you a unique link where you will need to complete a captcha.
@@ -87,14 +87,14 @@ For instructions on creating an account and installing the client, see the
    (`@YAGPDB.xyz`), and select **message**. That will take you to the correct
    prompt.
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/dm-from-bot.png" width="100%">
+   <img align="center" src="/events/past-events/2020/kcc2020/dm-from-bot.png" width="100%" alt="Direct message received from Discord verification bot">
    <br>
    <br>
    If you do not complete the captcha within 10 minutes, you will be booted from
    the server (you will still be able to reconnect).
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/verification.png" width="100%">
+   <img align="center" src="/events/past-events/2020/kcc2020/verification.png" width="100%" alt="Discord verification channel input">
    <br>
    <br>
 5) After completing the captcha, navigate to the `#code-of-conduct` channel.
@@ -103,10 +103,10 @@ For instructions on creating an account and installing the client, see the
    channels within the server.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/coc.png" width="100%">
+   <img align="center" src="/events/past-events/2020/kcc2020/coc.png" width="100%" alt="Code of Conduct agreement message in Discord">
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/coc-emoji.png" width="100%">
+   <img align="center" src="/events/past-events/2020/kcc2020/coc-emoji.png" width="100%" alt="Reacting with thumbs up to agree to Code of Conduct">
    <br> 
    <br>
    Once you accept the Code of conduct, you will see a list of categories and
@@ -115,7 +115,7 @@ For instructions on creating an account and installing the client, see the
    collapse that entire section in the sidebar.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/channels.png" width="100%">
+   <img align="center" src="/events/past-events/2020/kcc2020/channels.png" width="100%" alt="List of available text and voice channels in Discord">
    <br> 
    <br>
    **Note:** Unlike Slack you can see every channel, and every user on the server!
@@ -138,7 +138,7 @@ and some might be too soft. If you’re expecting to play with a group for a lon
 time this can help tremendously:
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/user-volume.png" width="100%">
+<img align="center" src="/events/past-events/2020/kcc2020/user-volume.png" width="100%" alt="Right-click user volume slider in Discord">
 <br> 
 <br>
 
@@ -149,7 +149,7 @@ Once you’ve joined a voice channel you can use the widgets at the bottom left
 of the screen to share your own screen and to use video if you want:
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/voice-video.png" width="40%">
+<img align="center" src="/events/past-events/2020/kcc2020/voice-video.png" width="40%" alt="Discord voice and video connection settings">
 <br> 
 <br>
 The _Voice connected_ text and signal meter will change depending on your
@@ -166,14 +166,14 @@ video settings.
    corner:
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/settings-cog.png" width="100%">
+   <img align="center" src="/events/past-events/2020/kcc2020/settings-cog.png" width="100%" alt="Discord user settings gear icon">
    <br> 
    <br>
 2) Navigate to the **Voice & Video** section of the User Settings to adjust your
    inputs and outputs.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/voice-video-settings.png" width="100%">
+   <img align="center" src="/events/past-events/2020/kcc2020/voice-video-settings.png" width="100%" alt="Discord Voice and Video settings panel">
    <br> 
    <br>
 
@@ -194,4 +194,4 @@ If you're problem was not covered in the [FAQ], you can reach out for help in
 the **#Help** channel under the **Info and Announcements** Category.
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/help-channel.png" width="40%">
+<img align="center" src="/events/past-events/2020/kcc2020/help-channel.png" width="40%" alt="Discord help-desk channel">

--- a/content/en/events/2021/kcc/faq.md
+++ b/content/en/events/2021/kcc/faq.md
@@ -114,7 +114,7 @@ everything. If you need assistance, join the `#help` channel.
 
 ### What is this YAGPDB.xyz and why is it messaging me?
 
-<img align="left" src="/events/2021/kcc/yagpdb.png" width="40" height="40">
+<img align="left" src="/events/2021/kcc/yagpdb.png" width="40" height="40" alt="YAGPDB Discord Bot logo">
 
 [YAGPDB] (Yet Another General Purpose Discord Bot) is a verified discord bot
 that we use to manage a variety of services within discord, from verification
@@ -132,19 +132,19 @@ overlays. A few examples of what this would look like:
 
 1 ) To do so, click the server dropdown (Top Left)
 
-<img align="center" src="/events/2021/kcc/server.png" width="40%">
+<img align="center" src="/events/2021/kcc/server.png" width="40%" alt="Discord server list showing Kubernetes server">
 <br>
 <br>
 2 ) Select “Change Nickname”
 <br>
 <br>
-<img align="center" src="/events/2021/kcc/nickname.png" width="40%">
+<img align="center" src="/events/2021/kcc/nickname.png" width="40%" alt="Discord edit nickname interface">
 <br>
 <br>
 3 ) Then follow the template of “nickname (pro/noun)” like so:
 <br>
 <br>
-<img align="center" src="/events/2021/kcc/name.png" width="40%">
+<img align="center" src="/events/2021/kcc/name.png" width="40%" alt="Discord user settings name field">
 
 ### Information on each channel in Discord
 

--- a/content/en/events/2021/kcc/how-to-join.md
+++ b/content/en/events/2021/kcc/how-to-join.md
@@ -56,7 +56,7 @@ For instructions on creating an account and installing the client, see the
    symbol) on the left side of the application. 
    <br>
    <br>
-   <img align="center" src="/events/2021/kcc/add-server.png" width="40%">
+   <img align="center" src="/events/2021/kcc/add-server.png" width="40%" alt="Discord add server button">
    <br>
    <br>
    A menu should pop up asking if you'd like to create or join a server. Select
@@ -67,7 +67,7 @@ For instructions on creating an account and installing the client, see the
    email, and paste it in the **Invite link** text box.
    <br>
    <br>
-   <img align="center" src="/events/2021/kcc/join-server.png" width="40%">
+   <img align="center" src="/events/2021/kcc/join-server.png" width="40%" alt="Discord join server input dialog">
    <br> 
    <br> 
 3) Two things will happen: You will be directed to the `#instructions-to-connect`
@@ -76,7 +76,7 @@ For instructions on creating an account and installing the client, see the
    the server.
    <br>
    <br>
-   <img align="center" src="/events/2021/kcc/instructions-to-connect.png" width="100%">
+   <img align="center" src="/events/2021/kcc/instructions-to-connect.png" width="100%" alt="Discord connection instructions and prompt">
    <br>
    <br> 
 4) The bot will dm you a unique link where you will need to complete a captcha.
@@ -87,14 +87,14 @@ For instructions on creating an account and installing the client, see the
    to the correct prompt. On the web client, you need to click the "Home" server
    in the upper left corner in order to see the bot's message.
    <br>
-   <img align="center" src="/events/2021/kcc/dm-from-bot.png" width="100%">
+   <img align="center" src="/events/2021/kcc/dm-from-bot.png" width="100%" alt="Direct message received from Discord verification bot">
    <br>
    <br>
    If you do not complete the captcha within 10 minutes, you will be booted from
    the server (you will still be able to reconnect).
    <br>
    <br>
-   <img align="center" src="/events/2021/kcc/verification.png" width="100%">
+   <img align="center" src="/events/2021/kcc/verification.png" width="100%" alt="Discord verification channel input">
    <br>
    <br>
 5) After completing the captcha, navigate to the `#code-of-conduct` channel.
@@ -103,10 +103,10 @@ For instructions on creating an account and installing the client, see the
    channels within the server.
    <br>
    <br>
-   <img align="center" src="/events/2021/kcc/coc.png" width="100%">
+   <img align="center" src="/events/2021/kcc/coc.png" width="100%" alt="Code of Conduct agreement message in Discord">
    <br>
    <br>
-   <img align="center" src="/events/2021/kcc/coc-emoji.png" width="100%">
+   <img align="center" src="/events/2021/kcc/coc-emoji.png" width="100%" alt="Reacting with thumbs up to agree to Code of Conduct">
    <br> 
    <br>
    Once you accept the Code of conduct, you will see a list of categories and
@@ -115,7 +115,7 @@ For instructions on creating an account and installing the client, see the
    collapse that entire section in the sidebar.
    <br>
    <br>
-   <img align="center" src="/events/2021/kcc/channels.png" width="100%">
+   <img align="center" src="/events/2021/kcc/channels.png" width="100%" alt="List of available text and voice channels in Discord">
    <br> 
    <br>
    **Note:** Unlike Slack you can see every channel, and every user on the server!
@@ -138,7 +138,7 @@ and some might be too soft. If you’re expecting to play with a group for a lon
 time this can help tremendously:
 <br>
 <br>
-<img align="center" src="/events/2021/kcc/user-volume.png" width="100%">
+<img align="center" src="/events/2021/kcc/user-volume.png" width="100%" alt="Right-click user volume slider in Discord">
 <br> 
 <br>
 
@@ -149,7 +149,7 @@ Once you’ve joined a voice channel you can use the widgets at the bottom left
 of the screen to share your own screen and to use video if you want:
 <br>
 <br>
-<img align="center" src="/events/2021/kcc/voice-video.png" width="40%">
+<img align="center" src="/events/2021/kcc/voice-video.png" width="40%" alt="Discord voice and video connection settings">
 <br> 
 <br>
 The _Voice connected_ text and signal meter will change depending on your
@@ -166,14 +166,14 @@ video settings.
    corner:
    <br>
    <br>
-   <img align="center" src="/events/2021/kcc/settings-cog.png" width="100%">
+   <img align="center" src="/events/2021/kcc/settings-cog.png" width="100%" alt="Discord user settings gear icon">
    <br> 
    <br>
 2) Navigate to the **Voice & Video** section of the User Settings to adjust your
    inputs and outputs.
    <br>
    <br>
-   <img align="center" src="/events/2021/kcc/voice-video-settings.png" width="100%">
+   <img align="center" src="/events/2021/kcc/voice-video-settings.png" width="100%" alt="Discord Voice and Video settings panel">
    <br> 
    <br>
 
@@ -194,4 +194,4 @@ If you're problem was not covered in the [FAQ], you can reach out for help in
 the **#Help** channel under the **Info and Announcements** Category.
 <br>
 <br>
-<img align="center" src="/events/2021/kcc/help-channel.png" width="40%">
+<img align="center" src="/events/2021/kcc/help-channel.png" width="40%" alt="Discord help-desk channel">

--- a/content/en/events/2021/kcsna/location.md
+++ b/content/en/events/2021/kcsna/location.md
@@ -6,7 +6,7 @@ weight: 5
 
 
 ### Marriott 
-<img align="right" src="/events/2021/kcsna/hotel.jpeg" width="15%">
+<img align="right" src="/events/2021/kcsna/hotel.jpeg" width="15%" alt="Westin Bonaventure Hotel">
 
 The North America Summit will take place October 11th, in Los Angeles, California
 alongside <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" rel="noopener noreferrer" target="_blank">KubeCon</a>
@@ -21,7 +21,7 @@ Los Angeles, California 90015 USA
 
 
 ### Lucky Strike
-<img align="right" src="/events/2021/kcsna/lucky-strike.jpg" width="30%">
+<img align="right" src="/events/2021/kcsna/lucky-strike.jpg" width="30%" alt="Lucky Strike bowling alley">
 
 The evening social event will be held at
 <a href="https://www.luckystrikeent.com/locations/los-angeles/" rel="noopener noreferrer" target="_blank">Lucky Strike</a>,
@@ -35,7 +35,7 @@ Los Angeles, CA 90015
 
 
 ### Los Angeles Convention Center (LACC)
-<img align="right" src="/events/2021/kcsna/LACC.jpg" width="20%">
+<img align="right" src="/events/2021/kcsna/LACC.jpg" width="20%" alt="Los Angeles Convention Center">
 
 Registration and badge pick-up will be available at the
 <a href="https://www.lacclink.com/" rel="noopener noreferrer" target="_blank">LACC</a>.

--- a/content/en/events/2022/kcseu/social.md
+++ b/content/en/events/2022/kcseu/social.md
@@ -6,7 +6,7 @@ weight: 5
 
 # Contributor Social at La Casa Del Mar
 
-<img align="right" src="/events/2022/kcseu/casadelmar.jpg" width="30%">
+<img align="right" src="/events/2022/kcseu/casadelmar.jpg" width="30%" alt="La Casa de la Mar venue">
 
 From 6:30 to 8:30pm (and beyond), Kubernetes contributors will be schmoozing,
 eating, playing boardgames, and competing in a pub quiz at [La Casa Del Mar](https://lacasadelamar.com/espacios-patacona/), 

--- a/content/en/events/2022/kcsna/location.md
+++ b/content/en/events/2022/kcsna/location.md
@@ -4,7 +4,7 @@ type: docs
 weight: 4
 ---
 
-<img align="right" src="/events/2022/kcsna/venue-map.png" width="50%">
+<img align="right" src="/events/2022/kcsna/venue-map.png" width="50%" alt="Venue Map">
 
 ### Huntington Place
 

--- a/content/en/events/2022/kcsna/social.md
+++ b/content/en/events/2022/kcsna/social.md
@@ -4,7 +4,7 @@ type: docs
 weight: 5
 ---
 
-<img align="right" src="/events/2022/kcsna/deluxx-fluxx-1.png" width="30%">
+<img align="right" src="/events/2022/kcsna/deluxx-fluxx-1.png" width="30%" alt="Deluxx Fluxx interior view 1">
 Join us at 
 <a href="https://www.deluxxfluxx.com/deluxx-fluxx-detroit" rel="noopener noreferrer" target="_blank">Deluxx Fluxx Detroit</a>
 from 6pm to 9pm for an evening celebration after the Contributor Summit on October 24th!
@@ -22,7 +22,7 @@ Detroit, MI 48226<br>
 
 ## Bringing A Guest
 
-<img align="right" src="/events/2022/kcsna/deluxx-fluxx-2.png" width="20%">
+<img align="right" src="/events/2022/kcsna/deluxx-fluxx-2.png" width="20%" alt="Deluxx Fluxx interior view 2">
 
 Contributors will be able to bring a single family member or  partner to the
 Social. This does not include coworkers or casual friends; our intention is


### PR DESCRIPTION
Add descriptive alt attributes to raw <img> tags on event FAQ, location, and social pages to resolve accessibility issues and improve search indexing. Refs: #685