### PR TITLE
feat: Add native htmltest link and quality checker

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,20 @@
+DirectoryPath: public
+IgnoreDirectoryMissingTrailingSlash: true
+CheckExternal: false
+IgnoreAltMissing: false
+CheckImages: true
+CheckLinks: true
+CheckScripts: true
+CheckMeta: true
+IgnoreInternalEmptyHash: true
+IgnoreEmptyHref: true
+IgnoreDirs:
+  - "community"
+  - "resources/keps"
+  - "docs/guide"
+  - "docs/orientation"
+  - "resources/release"
+  - "events"
+  - "blog"
+  - "docs/comms"
+  - "docs/contributor-cheatsheet"

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ CONTAINER_RUN_TTY		:= $(CONTAINER_ENGINE) run --rm -it
 HUGO_VERSION			:= $(shell grep ^HUGO_VERSION netlify.toml | tail -n 1 | cut -d '=' -f 2 | tr -d " \"\n")
 GIT_TAG					?= v$(HUGO_VERSION)-$(IMAGE_VERSION)
 CONTAINER_IMAGE			:= $(IMAGE_REPO):$(GIT_TAG)
+HTMLTEST_IMAGE			:= wjdp/htmltest@sha256:2215e132582bb1b918981f9920696a5ec2fbffe9a99af6be424f1b90f4bbf0ef
+HTMLTEST_CMD			:= go run github.com/wjdp/htmltest@ec73febdcb639acbeb983089db2df6732e8199bd
 
 # Docker buildx related settings for multi-arch images
 DOCKER_BUILDX ?= docker buildx
@@ -111,7 +113,12 @@ docker-render:
 	$(MAKE) container-render
 
 container-render: ## Build the site using Hugo within a container (equiv to render).
-	$(CONTAINER_RUN_TTY) $(CONTAINER_HUGO_MOUNTS) $(CONTAINER_IMAGE) hugo --logLevel info --ignoreCache --minify
+	mkdir -p public
+	$(CONTAINER_RUN_TTY) $(CONTAINER_HUGO_MOUNTS) \
+		--mount type=bind,source=$(CURDIR)/public,target=/src/public \
+		$(CONTAINER_IMAGE) \
+		hugo --environment development --logLevel info --ignoreCache --minify --noBuildLock
+
 
 docker-server:
 	@echo -e "**** The use of docker-server is deprecated. Use container-server instead. ****" 1>&2
@@ -180,6 +187,10 @@ production-build: ## Builds the production site (this command used only by Netli
 		--logLevel info \
 		--ignoreCache \
 		--minify
+	HUGO_ENV=production $(MAKE) check-headers-file
+	$(MAKE) verify-spelling
+	$(HTMLTEST_CMD)
+
 
 preview-build: ## Builds a deploy preview of the site (this command used only by Netlify).
 	$(BLOCK_STDOUT_CMD)
@@ -192,3 +203,19 @@ preview-build: ## Builds a deploy preview of the site (this command used only by
 		--buildFuture \
 		--ignoreCache \
 		--minify
+
+container-internal-linkcheck: container-render ## Run htmltest link checker inside a container (aligns with kubernetes/website)
+	$(CONTAINER_ENGINE) run -w /test --mount "type=bind,source=$(CURDIR),target=/test" --rm $(HTMLTEST_IMAGE) -c .htmltest.yml -s
+
+
+local-internal-linkcheck: render ## Run htmltest link checker locally on the host
+	$(HTMLTEST_CMD)
+
+check-headers-file: ## Verify Netlify headers file doesn't block search indexing (aligns with kubernetes/website)
+	scripts/check-headers-file.sh
+
+verify-spelling: ## Check spelling in all markdown content files (aligns with kubernetes/website)
+	scripts/verify-spelling.sh
+
+lint: verify-spelling local-internal-linkcheck ## Run all spelling and link checking linters locally
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postcss-cli": "^10.1.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "make lint"
   },
   "repository": {
     "type": "git",

--- a/scripts/.spelling_failures
+++ b/scripts/.spelling_failures
@@ -1,0 +1,1 @@
+content/en/blog/2022/meet-our-contributors-APAC-au-nz-region-02.md content/en/blog/2023/sig-network-spotlight.md content/en/blog/2023/sig-contribex-spotlight.md content/en/blog/2025/pqc-in-k8s/pqc-in-k8s.md content/en/community/awards/2022/index.md

--- a/scripts/check-headers-file.sh
+++ b/scripts/check-headers-file.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "${HUGO_ENV}" = "production" ]; then
+  echo "INFO: Production environment. Checking the _headers file for noindex headers."
+
+  if [ ! -f public/_headers ]; then
+    echo "INFO: No _headers file found in public/. Skipping check."
+    exit 0
+  fi
+
+  if grep -q "noindex" public/_headers; then
+    echo "PANIC: noindex headers were found in the _headers file. This build has failed."
+    exit 1
+  else
+    echo "INFO: noindex headers were not found in the _headers file. All clear."
+    exit 0
+  fi
+else
+  echo "Non-production environment. Skipping the _headers file check."
+  exit 0
+fi

--- a/scripts/verify-spelling.sh
+++ b/scripts/verify-spelling.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TOOL_VERSION="v0.3.4"
+
+LANGUAGE="${1:-en}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${ROOT}"
+
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+# perform go install in a temp dir
+cd "${TMP_DIR}"
+GO111MODULE=on GOBIN="${TMP_DIR}" go install "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
+export PATH="${TMP_DIR}:${PATH}"
+cd "${ROOT}"
+
+# check spelling
+RES=0
+echo "Checking spelling..."
+ERROR_LOG="${TMP_DIR}/errors.log"
+
+skipping_file="${ROOT}/scripts/.spelling_failures"
+if [ -f "${skipping_file}" ]; then
+  failing_packages=$(sed "s| | -e |g" "${skipping_file}")
+  git ls-files -z | grep --null-data "^content/${LANGUAGE}" | grep --null-data -v -e ${failing_packages} | xargs -0 -r misspell > "${ERROR_LOG}"
+else
+  git ls-files -z | grep --null-data "^content/${LANGUAGE}" | xargs -0 -r misspell > "${ERROR_LOG}"
+fi
+
+if [[ -s "${ERROR_LOG}" ]]; then
+  sed 's/^/error: /' "${ERROR_LOG}"
+  echo "Found spelling errors!" >&2
+  RES=1
+fi
+exit "${RES}"


### PR DESCRIPTION
Add .htmltest.yml and Makefile targets to run post-render link checks matching kubernetes/website native linter syntax.