### PR TITLE
Upgrade Docsy from 0.8.0 to 0.9.1

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -13,6 +13,13 @@ $display-font-sizes: (
 
 $display-font-weight: $font-weight-bold;
 
+
+// Docsy 0.9.0+ underlines links by default (google/docsy#1815).
+// Restore the pre-0.9.0 appearance but show underlines on hover.
+$link-decoration: none;
+$link-hover-decoration: underline;
+
+
 // Neutral ramp — shared text, border and surface greys
 $slate-50:  #f8fafc;
 $slate-100: #f1f5f9;

--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -1,0 +1,35 @@
+{{ $version := .Site.Params.mermaid.version | default "latest" -}}
+{{ $cdnurl := printf "https://cdn.jsdelivr.net/npm/mermaid@%s/dist/mermaid.esm.min.mjs" $version -}}
+{{ $remote := resources.GetRemote $cdnurl }}
+{{ if not $remote }}
+  {{ errorf "Invalid Mermaid version %s, could not retrieve this version from CDN." $version }}
+{{ end }}
+<script type="module" async>
+import mermaid from "{{ $cdnurl }}";
+(function($) {
+    if ($('.mermaid').length == 0)  {
+        mermaid.initialize({startOnLoad: false});
+        return;
+    }
+    var params = {{ .Site.Params.mermaid | jsonify | safeJS }};
+    // Site params are stored with lowercase keys; lookup correct casing
+    // from Mermaid default config.
+    var norm = function(defaultConfig, params) {
+        var result = {};
+        for (const key in defaultConfig) {
+            const keyLower = key.toLowerCase();
+            if (defaultConfig.hasOwnProperty(key) && params.hasOwnProperty(keyLower)) {
+                if (typeof defaultConfig[key] === "object") {
+                    result[key] = norm(defaultConfig[key], params[keyLower]);
+                } else {
+                    result[key] = params[keyLower];
+                }
+            }
+        }
+        return result;
+    };
+    var settings = norm(mermaid.mermaidAPI.defaultConfig, params);
+    settings.startOnLoad = true;
+    mermaid.initialize(settings);
+})(jQuery);
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^6.6.0",
         "autoprefixer": "^10.4.20",
-        "docsy": "github:google/docsy#semver:0.8.0",
+        "docsy": "github:google/docsy#semver:0.9.1",
         "postcss-cli": "^10.1.0"
       }
     },
@@ -219,7 +219,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -338,13 +337,13 @@
       }
     },
     "node_modules/docsy": {
-      "version": "0.8.0",
-      "resolved": "git+ssh://git@github.com/google/docsy.git#6bb4f99d1eab4976fb80d1488c81ba12b1715c05",
+      "version": "0.9.1",
+      "resolved": "git+ssh://git@github.com/google/docsy.git#6195793c0f576b7d5c9c52537668e3c7d9d89458",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "6.4.0",
+        "@fortawesome/fontawesome-free": "6.5.1",
         "bootstrap": "5.2.3"
       },
       "engines": {
@@ -663,6 +662,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -985,6 +985,7 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.6.0",
     "autoprefixer": "^10.4.20",
-    "docsy": "github:google/docsy#semver:0.8.0",
+    "docsy": "github:google/docsy#semver:0.9.1",
     "postcss-cli": "^10.1.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Upgrade Docsy from 0.8.0 to 0.9.1 as the first step towards enabling dark mode support on contributor-site.

## Changes
- Bump Docsy from v0.8.0 to v0.9.1
- Regenerate and update package-lock.json to align with the upgraded dependency tree
- Add a local mermaid.html partial override to address a Mermaid rendering/build issue introduced during the upgrade
- Rebase onto the latest master and reconcile upgrade-related template changes
- Validate KEP listing and detail page rendering against recent upstream KEP layout and accessibility updates
- Exclude TBD milestone values from the KEP release filter generation logic

## Testing
- Ran make server
- Verified successful local site build
- Validated KEP listing and detail page rendering
- Spot-checked page rendering after the upgrade

## Related

Ref: #745

### AI Disclosure 
An AI assistant was used to help investigate the Resource.Err compatibility issue. All proposed changes were reviewed, tested, and validated by me before submission.
