### PR TITLE
fix: add meta descriptions to blog and doc posts (batch 1)

### DIFF
--- a/content/en/blog/2020/announcing-the-contributor-website.md
+++ b/content/en/blog/2020/announcing-the-contributor-website.md
@@ -2,8 +2,8 @@
 title: "Announcing the Contributor Website"
 linkTitle: "Announcing the Contributor Website"
 date: 2020-08-24
+description: "Welcome to [kubernetes.dev], the Kubernetes Contributor website; built to become the one stop shop for Kubernetes contributor content and news. It..."
 ---
-
 Welcome to [kubernetes.dev], the Kubernetes Contributor website; built to become
 the one stop shop for Kubernetes contributor content and news. It brings
 important documentation scattered throughout the project into **one central

--- a/content/en/blog/2020/contributing-to-the-development-guide/index.md
+++ b/content/en/blog/2020/contributing-to-the-development-guide/index.md
@@ -8,7 +8,6 @@ resources:
 - src: "jorge-castro-code-of-conduct.jpg"
   title: "Jorge Castro announcing the Kubernetes Code of Conduct during a weekly SIG ContribEx meeting."
 ---
-
 When most people think of contributing to an open source project, I suspect they probably think of
 contributing code changes, new features, and bug fixes. As a software engineer and a long-time open
 source user and contributor, that's certainly what I thought. Although I have written a good quantity

--- a/content/en/blog/2021/contributor-story.md
+++ b/content/en/blog/2021/contributor-story.md
@@ -3,8 +3,8 @@ title: "Announcing the Kubernetes Contributor Stories Series"
 linkTitle: "Share your Kubernetes Contributor Story"
 date: 2021-05-14
 slug: contributor-stories-series
+description: "The Kubernetes contributor community is vast. We have tens of thousands of members by any conservative estimate and many hundreds involved..."
 ---
-
 By [Matt Broberg](https://twitter.com/mbbroberg)
 
 The Kubernetes contributor community is vast. We have tens of thousands of members by any conservative estimate and many hundreds involved day-to-day. We are from all around the world, all kinds of backgrounds, all types of expertise, and we are all Kubernetes contributors.

--- a/content/en/blog/2021/improve-with-mermaid-diagrams/mermaid-diagrams.md
+++ b/content/en/blog/2021/improve-with-mermaid-diagrams/mermaid-diagrams.md
@@ -2,8 +2,8 @@
 title: "Improve your documentation with Mermaid.js diagrams"
 linkTitle: "Improve your documentation with Mermaid.js diagrams"
 date: 2021-12-01
+description: "Topics covered in this blog."
 ---
-
 By Chris Metz and Tim Bannister
 
 ---

--- a/content/en/blog/2021/peeyush-contributor-story.md
+++ b/content/en/blog/2021/peeyush-contributor-story.md
@@ -3,8 +3,8 @@ layout: blog
 title: "From Kubernetes for work to Kubernetes for play" 
 date: 2021-06-01
 Slug: peeyush-contributor-story
+description: "Addendum by Matt Broberg on May 26, 2021"
 ---
-
 {{% alert color="primary" %}}
 <i>
 Addendum by <a href="https://twitter.com/mbbroberg">Matt Broberg</a> on May 26, 2021

--- a/content/en/blog/2022/2022-02-16-sig-node-ci-subproject-celebrates/index.md
+++ b/content/en/blog/2022/2022-02-16-sig-node-ci-subproject-celebrates/index.md
@@ -2,9 +2,8 @@
 layout: blog
 title: 'SIG Node CI Subproject Celebrates Two Years of Test Improvements'
 date: 2022-02-16
+description: "Ensuring the reliability of SIG Node upstream code is a continuous effort that takes a lot of behind-the-scenes effort from many contributors...."
 ---
-
-
 **Authors:** Sergey Kanzhelev (Google), Elana Hashman (Red Hat)
 
 

--- a/content/en/blog/2022/2022-03-15-k8s-triage-bot-helper-ci-job/K8s-ci-bot-make-update-helper.md
+++ b/content/en/blog/2022/2022-03-15-k8s-triage-bot-helper-ci-job/K8s-ci-bot-make-update-helper.md
@@ -4,8 +4,8 @@ title: >-
     K8s CI Bot Helper Job: automating "make update"
 date: 2022-04-26
 slug: k8s-ci-bot-helper-job
+description: "If you are contributing to the Kubernetes project and are developing on a Windows PC, it is conceivable that you will encounter certain issues..."
 ---
-
 **Authors:** [Subhasmita Swain](https://github.com/SubhasmitaSw), [Davanum Srinivas](https://github.com/dims) 
 
 ---

--- a/content/en/blog/2022/2022-03-15-k8s-triage-bot-helper-ci-job/index.md
+++ b/content/en/blog/2022/2022-03-15-k8s-triage-bot-helper-ci-job/index.md
@@ -4,8 +4,8 @@ title: >-
   K8s CI Bot Helper Job: automating "make update"
 date: 2022-03-15
 slug: k8s-triage-bot-helper-ci-job
+description: "If you are contributing to the Kubernetes project and are developing on a Windows PC, it is conceivable that you will encounter certain issues..."
 ---
-
 **Authors:** [Subhasmita Swain](https://github.com/SubhasmitaSw), [Davanum Srinivas](https://github.com/dims) 
 
 ---

--- a/content/en/blog/2022/2022-05-25-contextual-logging.md
+++ b/content/en/blog/2022/2022-05-25-contextual-logging.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Contextual Logging in Kubernetes 1.24"
 date: 2022-05-25
 slug: contextual-logging
+description: "The [Structured Logging Working Group](https://github.com/kubernetes/community/blob/master/wg-structured-logging/README.md) has added new..."
 ---
-
  **Authors:** Patrick Ohly (Intel)
 
 The [Structured Logging Working

--- a/content/en/blog/2022/2022-09-12-Implementing-the-Auto-Refreshing-Official-CVE-Feed/index.md
+++ b/content/en/blog/2022/2022-09-12-Implementing-the-Auto-Refreshing-Official-CVE-Feed/index.md
@@ -3,8 +3,8 @@ layout: blog
 title: Implementing the Auto-refreshing Official Kubernetes CVE Feed
 date: 2022-09-12
 slug: k8s-cve-feed-alpha
+description: "Accompanying the release of Kubernetes v1.25, we announced availability of an official CVE feed as an alpha feature. This blog will cover how we..."
 ---
-
 **Author**: Pushkar Joglekar (VMware)
 
 Accompanying the release of Kubernetes v1.25, we announced


### PR DESCRIPTION
Add descriptive meta fields to frontmatter of blog and documentation files to improve SEO.