### PR TITLE
fix: add meta descriptions to blog and doc posts (batch 2)

### DIFF
--- a/content/en/blog/2022/community-meeting-february-2022.md
+++ b/content/en/blog/2022/community-meeting-february-2022.md
@@ -3,8 +3,8 @@ layout: blog
 title: "February 2022 Community Meeting Highlights"
 date: 2022-05-05
 slug: community-meeting-februrary-2022
+description: "We just had our first contributor community meeting this year, and it was awesome to be back with you in that format. These meetings will be..."
 ---
-
 **Author:** Nigel Brown (VMware)
 
 We just had our first contributor community meeting this year, and it was awesome to be back with you 

--- a/content/en/blog/2022/enhancements-process-update.md
+++ b/content/en/blog/2022/enhancements-process-update.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Enhancements Opt-in Process Change for v1.26"
 date: 2022-09-09
 slug: enhancements-opt-in
+description: "Since the inception of the Kubernetes release team, we have used a spreadsheet to keep track of enhancements for the release. The project has..."
 ---
-
 **Author:** Grace Nguyen
 
 ## Context and Motivations

--- a/content/en/blog/2022/enhancing-kubernetes-one-kep-at-a-time.md
+++ b/content/en/blog/2022/enhancing-kubernetes-one-kep-at-a-time.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Enhancing Kubernetes one KEP at a Time"
 date: 2022-08-11
 slug: enhancing-kubernetes-one-kep-at-a-time
+description: "Did you know that Kubernetes v1.24 has 46 enhancements? That's a lot of new functionality packed into a 4-month release cycle. The Kubernetes..."
 ---
-
 **Author:** Ryler Hockenbury (Mastercard)
 
 Did you know that Kubernetes v1.24 has [46 enhancements](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/)? That's a lot of new functionality packed into a 4-month release cycle. The Kubernetes release team coordinates the logistics of the release, from remediating test flakes to publishing updated docs. It's a ton of work, but they always deliver.

--- a/content/en/blog/2022/meet-our-contributors-APAC-China-region-03.md
+++ b/content/en/blog/2022/meet-our-contributors-APAC-China-region-03.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Meet Our Contributors - APAC (China region)"
 date: 2022-08-15
 slug: meet-our-contributors-china-ep-03
+description: "Hello, everyone 👋"
 ---
-
 **Authors & Interviewers:** [Avinesh Tripathi](https://github.com/AvineshTripathi), [Debabrata Panigrahi](https://github.com/Debanitrkl), [Jayesh Srivastava](https://github.com/jayesh-srivastava), [Priyanka Saggu](https://github.com/Priyankasaggu11929/), [Purneswar Prasad](https://github.com/PurneswarPrasad), [Vedant Kakde](https://github.com/vedant-kakde)
 
 ---

--- a/content/en/blog/2022/meet-our-contributors-APAC-India-region-01.md
+++ b/content/en/blog/2022/meet-our-contributors-APAC-India-region-01.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Meet Our Contributors - APAC (India region)"
 date: 2022-01-10
 slug: meet-our-contributors-india-ep-01
+description: "Good day, everyone 👋"
 ---
-
 **Authors & Interviewers:** [Anubhav Vardhan](https://github.com/anubha-v-ardhan), [Atharva Shinde](https://github.com/Atharva-Shinde), [Avinesh Tripathi](https://github.com/AvineshTripathi), [Debabrata Panigrahi](https://github.com/Debanitrkl), [Kunal Verma](https://github.com/verma-kunal), [Pranshu Srivastava](https://github.com/PranshuSrivastava), [Pritish Samal](https://github.com/CIPHERTron), [Purneswar Prasad](https://github.com/PurneswarPrasad), [Vedant Kakde](https://github.com/vedant-kakde)
 
 **Editor:** [Priyanka Saggu](https://psaggu.com)

--- a/content/en/blog/2022/meet-our-contributors-APAC-au-nz-region-02.md
+++ b/content/en/blog/2022/meet-our-contributors-APAC-au-nz-region-02.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Meet Our Contributors - APAC (Aus-NZ region)"
 date: 2022-03-14
 slug: meet-our-contributors-au-nz-ep-02
+description: "Good day, everyone 👋"
 ---
-
 **Authors & Interviewers:** [Anubhav Vardhan](https://github.com/anubha-v-ardhan), [Atharva Shinde](https://github.com/Atharva-Shinde), [Avinesh Tripathi](https://github.com/AvineshTripathi), [Brad McCoy](https://github.com/bradmccoydev), [Debabrata Panigrahi](https://github.com/Debanitrkl), [Jayesh Srivastava](https://github.com/jayesh-srivastava), [Kunal Verma](https://github.com/verma-kunal), [Pranshu Srivastava](https://github.com/PranshuSrivastava), [Priyanka Saggu](https://github.com/Priyankasaggu11929), [Purneswar Prasad](https://github.com/PurneswarPrasad), [Vedant Kakde](https://github.com/vedant-kakde)
 
 ---

--- a/content/en/blog/2022/prow-and-tide-for-kubernetes-contributors/prow-and-tide-for-kubernetes-contributors.md
+++ b/content/en/blog/2022/prow-and-tide-for-kubernetes-contributors/prow-and-tide-for-kubernetes-contributors.md
@@ -3,8 +3,8 @@ layout: blog
 title: Prow and Tide for Kubernetes Contributors
 date: 2022-12-12
 slug: prow-and-tide-for-kubernetes-contributors
+description: "In my work in the Kubernetes world, I look up a label or Prow command often. The systems behind the scenes (Prow and Tide) are here to help..."
 ---
-
 **Authors:** [Chris Short](https://github.com/chris-short), [Frederico Muñoz](https://github.com/fsmunoz)
 
 ---

--- a/content/en/blog/2022/sig-multicluster-spotlight-blog.md
+++ b/content/en/blog/2022/sig-multicluster-spotlight-blog.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Spotlight on SIG Multicluster"
 date: 2022-02-04
 slug: sig-multicluster-spotlight-2022
+description: "SIG Multicluster is the Special Interest Group (SIG) focused on how Kubernetes concepts are expanded and used beyond the cluster boundary...."
 ---
-
 **Authors:** Dewan Ahmed (Aiven) and Chris Short (AWS)
 
 ## Introduction

--- a/content/en/blog/2022/sig-storage-spotlight.md
+++ b/content/en/blog/2022/sig-storage-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Storage"
 date: 2022-08-22
 slug: sig-storage-spotlight-2022
 author: "Frederico Muñoz (SAS)"
+description: "Since the very beginning of Kubernetes, the topic of persistent data and how to address the requirement of stateful applications has been an..."
 ---
-
 Since the very beginning of Kubernetes, the topic of persistent data and how to address the requirement of stateful applications has been an important topic. Support for stateless deployments was natural, present from the start, and garnered attention, becoming very well-known. Work on better support for stateful applications was also present from early on, with each release increasing the scope of what could be run on Kubernetes.
 
 Message queues, databases, clustered filesystems: these are some examples of the solutions that have different storage requirements and that are, today, increasingly deployed in Kubernetes. Dealing with ephemeral and persistent storage, local or remote, file or block, from many different vendors, while considering how to provide the needed resiliency and data consistency that users expect, all of this is under SIG Storage's umbrella.

--- a/content/en/blog/2022/sig_docs_spotlight_blog.md
+++ b/content/en/blog/2022/sig_docs_spotlight_blog.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Spotlight on SIG Docs"
 date: 2022-08-02
 slug: sig-docs-spotlight-2022
+description: "The official documentation is the go-to source for any open source project. For Kubernetes, it's an ever-evolving Special Interest Group (SIG)..."
 ---
-
 **Author:** Purneswar Prasad
 
 ## Introduction


### PR DESCRIPTION
Add descriptive meta fields to frontmatter of blog and documentation files to improve SEO.