### PR TITLE
fix: add meta descriptions to blog and doc posts (batch 3)

### DIFF
--- a/content/en/blog/2023/2023-03-01-introducing-kwok/index.md
+++ b/content/en/blog/2023/2023-03-01-introducing-kwok/index.md
@@ -3,8 +3,8 @@ layout: blog
 title: "Introducing KWOK: Kubernetes WithOut Kubelet"
 date: 2023-03-01
 slug: introducing-kwok
+description: "Have you ever wondered how to set up a cluster of thousands of nodes just in seconds, how to simulate real nodes with a low resource footprint,..."
 ---
-
 **Author:** Shiming Zhang (DaoCloud), Wei Huang (Apple), Yibo Zhuang (Apple)
 
 <img style="float: right; display: inline-block; margin-left: 2em; max-width: 15em;" src="/blog/2023/03/01/introducing-kwok/kwok.svg" alt="KWOK logo" />

--- a/content/en/blog/2023/2023-10-02-steering-committee-results-2023.md
+++ b/content/en/blog/2023/2023-10-02-steering-committee-results-2023.md
@@ -4,8 +4,8 @@ title: "Announcing the 2023 Steering Committee Election Results"
 date: 2023-10-02
 slug: steering-committee-results-2023
 author: "Kaslin Fields"
+description: "The 2023 Steering Committee Election is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in..."
 ---
-
 The [2023 Steering Committee Election](https://github.com/kubernetes/community/tree/master/events/elections/2023) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2023. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
 This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/main/charter.md).

--- a/content/en/blog/2023/2023-10-20-kcs-shanghai/index.md
+++ b/content/en/blog/2023/2023-10-20-kcs-shanghai/index.md
@@ -4,8 +4,8 @@ title: "A Quick Recap of 2023 China Kubernetes Contributor Summit"
 slug: kcs-shanghai
 date: 2023-10-20
 author: "Paco Xu and Michael Yao (DaoCloud)"
+description: "On September 26, 2023, the first day of KubeCon + CloudNativeCon + Open Source Summit China 2023, nearly 50 contributors gathered in Shanghai for..."
 ---
-
 On September 26, 2023, the first day of
 [KubeCon + CloudNativeCon + Open Source Summit China 2023](https://www.lfasiallc.com/kubecon-cloudnativecon-open-source-summit-china/),
 nearly 50 contributors gathered in Shanghai for the Kubernetes Contributor Summit.

--- a/content/en/blog/2023/contextual-logging-in-kubernetes-1-29.md
+++ b/content/en/blog/2023/contextual-logging-in-kubernetes-1-29.md
@@ -4,8 +4,8 @@ title: "Contextual logging in Kubernetes 1.29: Better troubleshooting and enhanc
 slug: contextual-logging
 date: 2023-12-20T09:30:00-08:00
 author: Mengjiao Liu and Patrick Ohly
+description: "On behalf of the Structured Logging Working Group and SIG Instrumentation, we are pleased to announce that the contextual logging feature..."
 ---
-
 On behalf of the [Structured Logging Working Group](https://github.com/kubernetes/community/blob/master/wg-structured-logging/README.md) 
 and [SIG Instrumentation](https://github.com/kubernetes/community/tree/master/sig-instrumentation#readme), 
 we are pleased to announce that the contextual logging feature

--- a/content/en/blog/2023/e2e-testing-best-practices.md
+++ b/content/en/blog/2023/e2e-testing-best-practices.md
@@ -4,8 +4,8 @@ title: "E2E Testing Best Practices, Reloaded"
 date: 2023-04-12
 slug: e2e-testing-best-practices-reloaded
 author: "Patrick Ohly (Intel)"
+description: "End-to-end (E2E) testing in Kubernetes is how the project validates functionality with real clusters. Contributors sooner or later encounter it..."
 ---
-
 End-to-end (E2E) testing in Kubernetes is how the project validates
 functionality with real clusters. Contributors sooner or later encounter it
 when asked to write E2E tests for new features or to help with debugging test

--- a/content/en/blog/2023/from-zero-to-subproject-lead.md
+++ b/content/en/blog/2023/from-zero-to-subproject-lead.md
@@ -4,8 +4,8 @@ title: "From Zero to Kubernets Subproject Lead"
 date: 2023-03-29
 slug: from-zero-to-k8s-subproject-lead
 author: "Ala Dewberry (VMware)"
+description: "Getting started in any open-source community can be daunting, especially if it’s a big one like Kubernetes. I wrote this post to share my..."
 ---
-
 Getting started in any open-source community can be daunting, especially if it’s a big one like
 Kubernetes. I wrote this post to share my experience and encourage others to join up. All
 it takes is some curiosity and a willingness to show up!

--- a/content/en/blog/2023/kcseu2023-spotlight/index.md
+++ b/content/en/blog/2023/kcseu2023-spotlight/index.md
@@ -4,8 +4,8 @@ title: "Kubernetes Contributor Summit: Behind-the-scenes"
 slug: k8s-contributor-summit-behind-the-scenes
 date: 2023-11-03
 author: "Frederico Muñoz (SAS Institute)"
+description: "Every year, just before the official start of KubeCon+CloudNativeCon, there's a special event that has a very special place in the hearts of those..."
 ---
-
 Every year, just before the official start of KubeCon+CloudNativeCon, there's a special event that
 has a very special place in the hearts of those organizing and participating in it: the Kubernetes
 Contributor Summit. To find out why, and to provide a behind-the-scenes perspective, we interview

--- a/content/en/blog/2023/sig-architecture-conformance-spotlight.md
+++ b/content/en/blog/2023/sig-architecture-conformance-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Architecture: Conformance"
 slug: sig-architecture-conformance-spotlight-2023
 date: 2023-10-05
 author: "Frederico Muñoz (SAS Institute)"
+description: "This is the first interview of a SIG Architecture Spotlight series that will cover the different subprojects. We start with the SIG Architecture:..."
 ---
-
 _This is the first interview of a SIG Architecture Spotlight series
 that will cover the different subprojects. We start with the SIG
 Architecture: Conformance subproject_

--- a/content/en/blog/2023/sig-architecture-prod-readiness-spotlight.md
+++ b/content/en/blog/2023/sig-architecture-prod-readiness-spotlight.md
@@ -5,8 +5,8 @@ slug: sig-architecture-production-readiness-spotlight-2023
 date: 2023-11-02
 canonicalUrl: https://www.k8s.dev/blog/2023/24/05/sig-architecture-prod-readiness-spotlight-2023/
 author: "Frederico Muñoz (SAS Institute)"
+description: "This is the second interview of a SIG Architecture Spotlight series that will cover the different subprojects. In this blog, we will cover the..."
 ---
-
 _This is the second interview of a SIG Architecture Spotlight series that will cover the different
 subprojects. In this blog, we will cover the [SIG Architecture: Production Readiness
 subproject](https://github.com/kubernetes/community/blob/master/sig-architecture/README.md#production-readiness-1)_.

--- a/content/en/blog/2023/sig-cli-spotlight.md
+++ b/content/en/blog/2023/sig-cli-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG CLI"
 date: 2023-07-20
 slug: sig-cli-spotlight-2023
 author: "Arpit Agrawal"
+description: "In the world of Kubernetes, managing containerized applications at scale requires powerful and efficient tools. The command-line interface (CLI)..."
 ---
-
 In the world of Kubernetes, managing containerized applications at
 scale requires powerful and efficient tools. The command-line
 interface (CLI) is an integral part of any developer or operator’s


### PR DESCRIPTION
Add descriptive meta fields to frontmatter of blog and documentation files to improve SEO.