### PR TITLE
fix: add meta descriptions to blog and doc posts (batch 4)

### DIFF
--- a/content/en/blog/2023/sig-contribex-spotlight.md
+++ b/content/en/blog/2023/sig-contribex-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG ContribEx"
 date: 2023-08-14
 slug: sig-contribex-spotlight-2023
 author: Fyka Ansari
+description: "Welcome to the world of Kubernetes and its vibrant contributor community! In this blog post, we'll be shining a spotlight on the [Special Interest..."
 ---
-
 **Author**: Fyka Ansari
 
 Welcome to the world of Kubernetes and its vibrant contributor

--- a/content/en/blog/2023/sig-instrumentation-spotlight.md
+++ b/content/en/blog/2023/sig-instrumentation-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Instrumentation"
 slug: sig-instrumentation-spotlight-2023
 date: 2023-02-03
 author: "Imran Noor Mohamed (Delivery Hero)"
+description: "Observability requires the right data at the right time for the right consumer (human or piece of software) to make the right decision. In the..."
 ---
-
 Observability requires the right data at the right time for the right consumer (human or piece of software) to make the right decision. In the context of Kubernetes, having best practices for cluster observability across all Kubernetes components is crucial.
 
 SIG Instrumentation helps to address this issue by providing best practices and tools that all other SIGs use to instrument Kubernetes components-like the *API server*, *scheduler*, *kubelet* and *kube-controller-manager*.

--- a/content/en/blog/2023/sig-network-blixt-ebpf-rust-in-kubernetes.md
+++ b/content/en/blog/2023/sig-network-blixt-ebpf-rust-in-kubernetes.md
@@ -4,8 +4,8 @@ title: Blixt - A load-balancer written in Rust, using eBPF, born from Gateway AP
 date: 2024-01-08
 slug: blixt-load-balancer-rust-ebpf-gateway-api
 author: "Shane Utt (Kong), Andrew Stoycos (Red Hat)"
+description: "In [SIG Network][signet] we now have a layer 4 (“L4”) load balancer named [Blixt][blixt]. This project started as a fun experiment using emerging..."
 ---
-
 In [SIG Network][signet] we now have a layer 4 (“L4”) load balancer named [Blixt][blixt]. This
 project started as a fun experiment using emerging technologies and is intended
 to become a utility for CI and testing to help facilitate the continued

--- a/content/en/blog/2023/sig-network-spotlight.md
+++ b/content/en/blog/2023/sig-network-spotlight.md
@@ -5,8 +5,8 @@ slug: sig-network-spotlight
 date: 2023-05-09
 slug: sig-network-spotlight-2023
 author: "Sujay Dey"
+description: "Networking is one of the core pillars of Kubernetes, and the Special Interest Group for Networking (SIG Network) is responsible for developing and..."
 ---
-
 Networking is one of the core pillars of Kubernetes, and the Special Interest
 Group for Networking (SIG Network) is responsible for developing and maintaining
 the networking features of Kubernetes. It covers all aspects to ensure

--- a/content/en/blog/2023/sig-testing-spotlight.md
+++ b/content/en/blog/2023/sig-testing-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Testing"
 slug: sig-testing-spotlight-2023
 date: 2023-11-24
 author: "Sandipan Panda"
+description: "Welcome to another edition of the SIG spotlight blog series, where we highlight the incredible work being done by various Special Interest Groups..."
 ---
-
 Welcome to another edition of the _SIG spotlight_ blog series, where we
 highlight the incredible work being done by various Special Interest
 Groups (SIGs) within the Kubernetes project. In this edition, we turn

--- a/content/en/blog/2024/cncf-dhhwg/cncf-dhhwg-spotlight.md
+++ b/content/en/blog/2024/cncf-dhhwg/cncf-dhhwg-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on CNCF Deaf and Hard-of-hearing Working Group (DHHWG)"
 slug: cncf-deaf-and-hard-of-hearing-working-group-spotlight
 date: 2024-09-30
 author: "Sandeep Kanabar"
+description: "In recognition of Deaf Awareness Month and the importance of inclusivity in the tech community, we are spotlighting Catherine Paganini,..."
 ---
-
 _In recognition of Deaf Awareness Month and the importance of inclusivity in the tech community, we are spotlighting [Catherine Paganini](https://www.linkedin.com/in/catherinepaganini/), facilitator and one of the founding members of [CNCF Deaf and Hard-of-Hearing Working Group](https://contribute.cncf.io/about/deaf-and-hard-of-hearing/) (DHHWG). In this interview, [Sandeep Kanabar](https://www.linkedin.com/in/sandeepkanabar/), a deaf member of the DHHWG and part of the Kubernetes [SIG ContribEx Communications team](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/README.md#contributor-comms), sits down with Catherine to explore the impact of the DHHWG on cloud native projects like Kubernetes._
 
 _Sandeep’s journey is a testament to the power of inclusion. Through his involvement in the DHHWG, he connected with members of the Kubernetes community who encouraged him to join [SIG ContribEx](https://github.com/kubernetes/community/blob/master/sig-contributor-experience/README.md) - the group responsible for sustaining the Kubernetes contributor experience. In an ecosystem where open-source projects are actively seeking contributors and maintainers, this story highlights how important it is to create pathways for underrepresented groups, including those with disabilities, to contribute their unique perspectives and skills._

--- a/content/en/blog/2024/go-workspaces.md
+++ b/content/en/blog/2024/go-workspaces.md
@@ -4,8 +4,8 @@ title: Using Go workspaces in Kubernetes
 slug: go-workspaces-in-kubernetes
 date: 2024-03-19T08:30:00-08:00
 author: "Tim Hockin (Google)"
+description: "The Go programming language has played a huge role in the success of Kubernetes. As Kubernetes has grown, matured, and pushed the bounds of what..."
 ---
-
 The [Go programming language](https://go.dev/) has played a huge role in the
 success of Kubernetes. As Kubernetes has grown, matured, and pushed the bounds
 of what "regular" projects do, the Go project team has also grown and evolved

--- a/content/en/blog/2024/introducing-hydrophone.md
+++ b/content/en/blog/2024/introducing-hydrophone.md
@@ -4,8 +4,8 @@ title: "Introducing Hydrophone"
 slug: introducing-hydrophone
 date: 2024-05-23
 author: "Ricky Sadowski (ICR)"
+description: "In the ever-changing landscape of Kubernetes, ensuring that clusters operate as intended is essential. This is where conformance testing becomes..."
 ---
-
 In the ever-changing landscape of Kubernetes, ensuring that clusters operate as intended is
 essential. This is where conformance testing becomes crucial, verifying that a Kubernetes cluster
 meets the required standards set by the community. Today, we're thrilled to introduce

--- a/content/en/blog/2024/k8s-upstream-training-japan-spotlight/k8s-upstream-training-japan-spotlight.md
+++ b/content/en/blog/2024/k8s-upstream-training-japan-spotlight/k8s-upstream-training-japan-spotlight.md
@@ -6,8 +6,8 @@ date: 2024-10-28
 author: >
   [Junya Okabe](https://github.com/Okabe-Junya) (University of Tsukuba) / 
   Organizing team of Kubernetes Upstream Training in Japan
+description: "We are organizers of Kubernetes Upstream Training in Japan. Our team is composed of members who actively contribute to Kubernetes, including..."
 ---
-
 We are organizers of [Kubernetes Upstream Training in Japan](https://github.com/kubernetes-sigs/contributor-playground/tree/master/japan).
 Our team is composed of members who actively contribute to Kubernetes, including individuals who hold roles such as member, reviewer, approver, and chair.
 

--- a/content/en/blog/2024/kube-proxy-non-privileged.md
+++ b/content/en/blog/2024/kube-proxy-non-privileged.md
@@ -4,9 +4,8 @@ title: "Kubernetes supports running kube-proxy in an unprivileged container"
 date: 2024-01-05
 slug: kube-proxy-non-privileged
 author: Lars Ekman
+description: "This post describes how the --init-only flag to kube-proxy can be used to run the main kube-proxy container in a stricter securityContext, by..."
 ---
-
-
 This post describes how the `--init-only` flag to `kube-proxy` can be
 used to run the main kube-proxy container in a stricter
 `securityContext`, by performing the configuration that requires


### PR DESCRIPTION
Add descriptive meta fields to frontmatter of blog and documentation files to improve SEO.