### PR TITLE
fix: add meta descriptions to blog and doc posts (batch 5)

### DIFF
--- a/content/en/blog/2024/sig-api-machinery-spotlight.md
+++ b/content/en/blog/2024/sig-api-machinery-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG API Machinery"
 slug: sig-api-machinery-spotlight-2024
 date: 2024-08-07
 author: "Frederico Muñoz (SAS Institute)"
+description: "We recently talked with Federico Bongiovanni (Google) and [David Eads](https://github.com/deads2k) (Red Hat), Chairs of SIG API Machinery, to know..."
 ---
-
 We recently talked with [Federico Bongiovanni](https://github.com/fedebongio) (Google) and [David
 Eads](https://github.com/deads2k) (Red Hat), Chairs of SIG API Machinery, to know a bit more about
 this Kubernetes Special Interest Group.

--- a/content/en/blog/2024/sig-arch-code-spotlight.md
+++ b/content/en/blog/2024/sig-arch-code-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Architecture: Code Organization"
 slug: sig-architecture-code-spotlight-2024
 date: 2024-04-11
 author: "Frederico Muñoz (SAS Institute)"
+description: "This is the third interview of a SIG Architecture Spotlight series that will cover the different subprojects. We will cover SIG Architecture: Code..."
 ---
-
 _This is the third interview of a SIG Architecture Spotlight series that will cover the different
 subprojects. We will cover [SIG Architecture: Code Organization](https://github.com/kubernetes/community/blob/e44c2c9d0d3023e7111d8b01ac93d54c8624ee91/sig-architecture/README.md#code-organization)._
 

--- a/content/en/blog/2024/sig-arch-enhancements-spotlight.md
+++ b/content/en/blog/2024/sig-arch-enhancements-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Architecture: Enhancements"
 slug: sig-architecture-enhancements
 date: 2025-01-21
 author: "Frederico Muñoz (SAS Institute)"
+description: "This is the fourth interview of a SIG Architecture Spotlight series that will cover the different subprojects, and we will be covering [SIG..."
 ---
-
 _This is the fourth interview of a SIG Architecture Spotlight series that will cover the different
 subprojects, and we will be covering [SIG Architecture:
 Enhancements](https://github.com/kubernetes/community/blob/master/sig-architecture/README.md#enhancements)._

--- a/content/en/blog/2024/sig-cloud-provider-spotlight.md
+++ b/content/en/blog/2024/sig-cloud-provider-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Cloud Provider"
 slug: sig-cloud-provider-spotlight-2024
 date: 2024-03-01
 author: "Arujjwal Negi"
+description: "One of the most popular ways developers use Kubernetes-related services is via cloud providers, but have you ever wondered how cloud providers can..."
 ---
-
 One of the most popular ways developers use Kubernetes-related services is via cloud providers, but
 have you ever wondered how cloud providers can do that? How does this whole process of integration
 of Kubernetes to various cloud providers happen? To answer that, let's put the spotlight on [SIG

--- a/content/en/blog/2024/sig-release-spotlight/sig-release-spotlight.md
+++ b/content/en/blog/2024/sig-release-spotlight/sig-release-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Release (Release Team Subproject)"
 date: 2024-01-15
 slug: sig-release-spotlight-2023
 author: Nitish Kumar
+description: "The Release Special Interest Group (SIG Release), where Kubernetes sharpens its blade with cutting-edge features and bug fixes every 4 months...."
 ---
-
 The Release Special Interest Group (SIG Release), where Kubernetes sharpens its blade 
 with cutting-edge features and bug fixes every 4 months. Have you ever considered how such a big 
 project like Kubernetes manages its timeline so efficiently to release its new version, or how 

--- a/content/en/blog/2024/sig-scheduling-spotlight.md
+++ b/content/en/blog/2024/sig-scheduling-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Scheduling"
 slug: sig-scheduling-spotlight-2024
 date: 2024-09-24
 author: "Arvind Parekh"
+description: "In this SIG Scheduling spotlight we talked with Kensei Nakada, an approver in SIG Scheduling."
 ---
-
 In this SIG Scheduling spotlight we talked with [Kensei Nakada](https://github.com/sanposhiho/), an
 approver in SIG Scheduling.
 

--- a/content/en/blog/2024/steering-committee-results-2024.md
+++ b/content/en/blog/2024/steering-committee-results-2024.md
@@ -4,8 +4,8 @@ title: "Announcing the 2024 Steering Committee Election Results"
 date: 2024-10-02T15:10:00-05:00
 slug: steering-committee-results-2024
 author: "Bridget Kromhout"
+description: "The 2024 Steering Committee Election is now complete. The Kubernetes Steering Committee consists of 7 seats, 3 of which were up for election in..."
 ---
-
 The [2024 Steering Committee Election](https://github.com/kubernetes/community/tree/master/elections/steering/2024) is now complete. The Kubernetes Steering Committee consists of 7 seats, 3 of which were up for election in 2024. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
 This community body is significant since it oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/main/charter.md).

--- a/content/en/blog/2025/changes-to-slack.md
+++ b/content/en/blog/2025/changes-to-slack.md
@@ -4,8 +4,8 @@ title: "Changes to Kubernetes Slack"
 slug: changes-to-kubernetes-slack-2025
 date: 2025-06-16
 author: "Josh Berkus"
+description: "UPDATE: We’ve received notice from Salesforce that our Slack workspace WILL NOT BE DOWNGRADED on June 20th. Stand by for more details, but for..."
 ---
-
 **UPDATE**: We’ve received notice from Salesforce that our Slack workspace **WILL NOT BE DOWNGRADED** on June 20th. Stand by for more details, but for now, there is no urgency to back up private channels or direct messages.
 
 ~~Kubernetes Slack will lose its special status and will be changing into a standard free Slack on June 20, 2025~~. Sometime later this year, our community may move to a new platform. If you are responsible for a channel or private channel, or a member of a User Group, you will need to take some actions as soon as you can.

--- a/content/en/blog/2025/ingress-nginx-retirement.md
+++ b/content/en/blog/2025/ingress-nginx-retirement.md
@@ -5,8 +5,8 @@ date: 2025-11-12T12:00:00-05:00
 slug: ingress-nginx-retirement
 author: >
   Tabitha Sable (Kubernetes SRC)
+description: "To prioritize the safety and security of the ecosystem, Kubernetes SIG Network and the Security Response Committee are announcing the upcoming..."
 ---
-
 To prioritize the safety and security of the ecosystem, Kubernetes SIG Network and the Security Response Committee are announcing the upcoming retirement of [Ingress NGINX](https://github.com/kubernetes/ingress-nginx/). Best-effort maintenance will continue until March 2026. Afterward, there will be no further releases, no bugfixes, and no updates to resolve any security vulnerabilities that may be discovered. **Existing deployments of Ingress NGINX will continue to function and installation artifacts will remain available.**
 
 We recommend migrating to one of the many alternatives. Consider [migrating to Gateway API](https://gateway-api.sigs.k8s.io/guides/), the modern replacement for Ingress. If you must continue using Ingress, many alternative Ingress controllers are [listed in the Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/). Continue reading for further information about the history and current state of Ingress NGINX, as well as next steps.

--- a/content/en/blog/2025/k8s-steering-spotlight.md
+++ b/content/en/blog/2025/k8s-steering-spotlight.md
@@ -5,8 +5,8 @@ slug: k8s-steering-spotlight-2025
 date: 2025-09-22
 draft: false
 author: "Arpit Agrawal"
+description: "This interview was conducted in August 2024, and due to the dynamic nature of the Steering Committee membership and election process it might not..."
 ---
-
 _This interview was conducted in August 2024, and due to the dynamic nature of the Steering
 Committee membership and election process it might not represent the actual composition accurately.
 The topics covered are, however, overwhelmingly relevant to understand its scope of work. As we


### PR DESCRIPTION
Add descriptive meta fields to frontmatter of blog and documentation files to improve SEO.