### PR TITLE
fix: add meta descriptions to blog and doc posts (batch 6)

### DIFF
--- a/content/en/blog/2025/pqc-in-k8s/pqc-in-k8s.md
+++ b/content/en/blog/2025/pqc-in-k8s/pqc-in-k8s.md
@@ -5,8 +5,8 @@ slug: pqc-in-k8s
 date: 2025-07-18
 author: "Fabian Kammel (ControlPlane)"
 draft: false
+description: "The world of cryptography is on the cusp of a major shift with the advent of quantum computing. While powerful quantum computers are still largely..."
 ---
-
 The world of cryptography is on the cusp of a major shift with the advent of
 quantum computing. While powerful quantum computers are still largely
 theoretical for many applications, their potential to break current

--- a/content/en/blog/2025/sig-apps-spotlight.md
+++ b/content/en/blog/2025/sig-apps-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG Apps"
 slug: sig-apps-spotlight-2025
 date: 2025-03-12
 author: "Sandipan Panda (DevZero)"
+description: "In our ongoing SIG Spotlight series, we dive into the heart of the Kubernetes project by talking to the leaders of its various Special Interest..."
 ---
-
 In our ongoing SIG Spotlight series, we dive into the heart of the Kubernetes project by talking to
 the leaders of its various Special Interest Groups (SIGs). This time, we focus on 
 **[SIG Apps](https://github.com/kubernetes/community/tree/master/sig-apps#apps-special-interest-group)**,

--- a/content/en/blog/2025/sig-etcd-spotlight/sig-etcd-spotlight.md
+++ b/content/en/blog/2025/sig-etcd-spotlight/sig-etcd-spotlight.md
@@ -4,8 +4,8 @@ title: "Spotlight on SIG etcd"
 slug: sig-etcd-spotlight
 date: 2025-03-04
 author: "Frederico Muñoz (SAS Institute)"
+description: "In this SIG etcd spotlight we talked with James Blair, [Marek Siarkowicz](https://github.com/serathius), Wenjia Zhang, and Benjamin Wang to learn..."
 ---
-
 In this SIG etcd spotlight we talked with [James Blair](https://github.com/jmhbnz), [Marek
 Siarkowicz](https://github.com/serathius), [Wenjia Zhang](https://github.com/wenjiaswe), and
 [Benjamin Wang](https://github.com/ahrtr) to learn a bit more about this Kubernetes Special Interest

--- a/content/en/blog/2025/steering-committee-results-2025.md
+++ b/content/en/blog/2025/steering-committee-results-2025.md
@@ -4,8 +4,8 @@ title: "Announcing the 2025 Steering Committee Election Results"
 date: 2025-11-09T15:10:00-05:00
 slug: steering-committee-results-2025
 author: "Arujjwal Negi"
+description: "The 2025 Steering Committee Election is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in..."
 ---
-
 The [2025 Steering Committee Election](https://github.com/kubernetes/community/tree/master/elections/steering/2025) is now complete. The Kubernetes Steering Committee consists of 7 seats, 4 of which were up for election in 2025. Incoming committee members serve a term of 2 years, and all members are elected by the Kubernetes Community.
 
 The Steering Committee oversees the governance of the entire Kubernetes project. With that great power comes great responsibility. You can learn more about the steering committee’s role in their [charter](https://github.com/kubernetes/steering/blob/main/charter.md).

--- a/content/en/blog/2025/wg-policy-spotlight-2025.md
+++ b/content/en/blog/2025/wg-policy-spotlight-2025.md
@@ -4,8 +4,8 @@ title: "Spotlight on Policy Working Group"
 slug: wg-policy-spotlight-2025
 date: 2025-10-18
 author: "Arujjwal Negi"
----  
-
+description: "(Note: The Policy Working Group has completed its mission and is no longer active. This article reflects its work, accomplishments, and insights..."
+---
 *(Note: The Policy Working Group has completed its mission and is no longer active. This article reflects its work, accomplishments, and insights into how a working group operates.)*
 
 In the complex world of Kubernetes, policies play a crucial role in managing and securing clusters. But have you ever wondered how these policies are developed, implemented, and standardized across the Kubernetes ecosystem? To answer that, let's take a look back at the work of the Policy Working Group.

--- a/content/en/blog/2026/announcing-ai-gateway-wg.md
+++ b/content/en/blog/2026/announcing-ai-gateway-wg.md
@@ -7,8 +7,8 @@ author: >
   [Nir Rozenbaum](https://github.com/nirrozenbaum),
   [Morgan Foster](https://github.com/usize),
   [Flynn](https://github.com/kflynn)
+description: "The community around Kubernetes includes a number of Special Interest Groups (SIGs) and Working Groups (WGs) facilitating discussions on important..."
 ---
-
 The community around Kubernetes includes a number of Special Interest Groups (SIGs) and Working Groups (WGs) facilitating discussions on important topics between interested contributors. Today, we're excited to announce the formation of the [AI Gateway Working Group](https://github.com/kubernetes-sigs/wg-ai-gateway), a new initiative focused on developing standards and best practices for networking infrastructure that supports AI workloads in Kubernetes environments.
 
 ## What is an AI Gateway?

--- a/content/en/blog/2026/announcing-checkpoint-restore-wg.md
+++ b/content/en/blog/2026/announcing-checkpoint-restore-wg.md
@@ -7,8 +7,8 @@ author: >
   [Viktória Spišaková](https://github.com/viktoriaas),
   [Adrian Reber](https://github.com/adrianreber),
   [Peter Hunt](https://github.com/haircommander)
+description: "The community around Kubernetes includes a number of Special Interest Groups (SIGs) and Working Groups (WGs) facilitating discussions on important..."
 ---
-
 The community around Kubernetes includes a number of Special Interest Groups (SIGs) and Working Groups (WGs) facilitating discussions on important topics between interested contributors. Today we would like to announce the new [Kubernetes Checkpoint Restore WG](https://github.com/kubernetes/community/tree/master/wg-checkpoint-restore) focusing on the integration of Checkpoint/Restore functionality into Kubernetes.
 
 ## Motivation and use cases

--- a/content/en/blog/2026/image-signature-routing.md
+++ b/content/en/blog/2026/image-signature-routing.md
@@ -5,8 +5,8 @@ date: 2026-06-05
 slug: image-signature-routing
 author: >
   Sascha Grunert (Red Hat)
+description: "The image promoter rewrite laid the groundwork for simplifying how Kubernetes delivers container image signatures. One of the rewrite phases..."
 ---
-
 The [image promoter rewrite](https://kubernetes.io/blog/2026/03/17/image-promoter-rewrite/) laid the
 groundwork for simplifying how Kubernetes delivers container image signatures.
 One of the rewrite phases (Phase 6) separated image signing from signature

--- a/content/en/blog/2026/sig-arch-api-spotlight.md
+++ b/content/en/blog/2026/sig-arch-api-spotlight.md
@@ -5,8 +5,8 @@ slug: sig-architecture-api
 date: 2026-02-12
 draft: false
 author: "Frederico Muñoz (SAS Institute)"
+description: "This is the fifth interview of a SIG Architecture Spotlight series that covers the different subprojects, and we will be covering [SIG..."
 ---
-
 _This is the fifth interview of a SIG Architecture Spotlight series that covers the different
 subprojects, and we will be covering [SIG Architecture: API
 Governance](https://github.com/kubernetes/community/blob/master/sig-architecture/README.md#architecture-and-api-governance-1)._

--- a/content/en/blog/2026/sig-storage-spotlight-2026.md
+++ b/content/en/blog/2026/sig-storage-spotlight-2026.md
@@ -5,8 +5,8 @@ slug: sig-storage-spotlight-2026
 date: 2026-04-15
 draft: true
 author: "Darshan Murthy (Apple)"
+description: "In our ongoing SIG Spotlight series, we shine a light on the groups that keep the Kubernetes project moving forward. This time, we catch up with..."
 ---
-
 In our ongoing SIG Spotlight series, we shine a light on the groups that keep the Kubernetes project
 moving forward. This time, we catch up with **[SIG
 Storage](https://github.com/kubernetes/community/tree/master/sig-storage)**, the group responsible


### PR DESCRIPTION
Add descriptive meta fields to frontmatter of blog and documentation files to improve SEO.