### PR TITLE
fix: add meta descriptions to blog and doc posts (batch 7)

### DIFF
--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -4,5 +4,5 @@ linkTitle: "Blog"
 menu:
   main:
     weight: 20
+description: "Kubernetes contributor documentation and community blog post."
 ---
-

--- a/content/en/docs/code/cri-api-dev-policies.md
+++ b/content/en/docs/code/cri-api-dev-policies.md
@@ -2,8 +2,8 @@
 content_type: "reference"
 title: Kubernetes feature development and container runtimes
 weight: 55
+description: "CRI is a plugin interface which enables the kubelet to use a wide variety of container runtimes, without the need to recompile. CRI consists of a..."
 ---
-
 CRI is a plugin interface which enables the kubelet to use a wide variety of container runtimes,
 without the need to recompile. CRI consists of a protocol buffers and gRPC API.
 Read more about CRI API at [kubernetes docs](https://kubernetes.io/docs/concepts/architecture/cri/).

--- a/content/en/docs/code/cri-api-version-skew-policy.md
+++ b/content/en/docs/code/cri-api-version-skew-policy.md
@@ -2,8 +2,8 @@
 content_type: "reference"
 title: CRI API version skew policy
 weight: 51
+description: "CRI is a plugin interface which enables the kubelet to use a wide variety of container runtimes, without the need to recompile. CRI consists of a..."
 ---
-
 CRI is a plugin interface which enables the kubelet to use a wide variety of container runtimes,
 without the need to recompile. CRI consists of a protocol buffers and gRPC API.
 Read more about CRI API at [kubernetes docs](https://kubernetes.io/docs/concepts/architecture/cri/).


### PR DESCRIPTION
Add descriptive meta fields to frontmatter of blog and documentation files to improve SEO.