### PR TITLE
fix: remove duplicate slug from SIG Network spotlight

### DIFF
--- a/content/en/blog/2023/sig-network-spotlight.md
+++ b/content/en/blog/2023/sig-network-spotlight.md
@@ -1,7 +1,6 @@
 ---
 layout: blog
 title: "Spotlight on SIG Network"
-slug: sig-network-spotlight
 date: 2023-05-09
 slug: sig-network-spotlight-2023
 author: "Sujay Dey"


### PR DESCRIPTION
Fixes a duplicate `slug` key in `content/en/blog/2023/sig-network-spotlight.md`.

Current Hugo trips on this with `mapping key "slug" already defined`, so a normal local build can fail, yep.

Repro:
1. Use Hugo `v0.161.0` or newer-ish.
2. Build a tiny site with the original file, or run Hugo against that page.
3. Build fails on the duplicate `slug` key.

After this patch the build passes. On the pinned Hugo `v0.144.2`, the output path stays the same: `/blog/2023/05/09/sig-network-spotlight-2023/`.
