### PR TITLE
fix: remove obsolete Hugo cache keys

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -30,12 +30,6 @@ caches:
   assets:
     dir: ':cacheDir/_gen'
     maxAge: -1
-  getcsv:
-    dir: ':cacheDir/:project'
-    maxAge: 60s
-  getjson:
-    dir: ':cacheDir/:project'
-    maxAge: 60s
   getresource:
     dir: ':cacheDir/:project'
     maxAge: 2h


### PR DESCRIPTION
This removes legacy `caches.getcsv` and `caches.getjson` entries from `hugo.yaml`.

With current Hugo, local builds fail right away:
`ERROR failed to create config from result: failed to decode "caches": "getcsv" is not a valid cache name`

This repo does not use `getCSV` or `getJSON` anymore, so dropping those keys keeps `getresource` caching in place and lets `make render` move again. pretty much it.

How to repro
1. Install Hugo `v0.161.0` or newer.
2. Run `npm ci`
3. Run `make render`

Before this patch it fails on the invalid cache key.
After this patch Hugo gets past config parsing and starts the build.
