### PR TITLE
fix: rewrite root-relative sig/wg/committee links from remote READMEs

### DIFF
--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -41,16 +41,19 @@
             {{ end }}
           {{ else with .Value }}
             {{ $readmeContent = replace .Content "\u200b" "" }}
+            {{ $readmeContent = replaceRE `\(/sig-([^\)\s]+)` `(/community/community-groups/sigs/$1/` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/wg-([^\)\s]+)` `(/community/community-groups/wg/$1/` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/committee-([^\)\s]+)` `(/community/community-groups/committees/$1/` $readmeContent }}
             {{ $readmeContent = replaceRE `^[\s\S]*?(##[\s\S]*)` `$1` $readmeContent }}
           {{ else }}
             {{ if eq hugo.Environment "production" }}
-              {{ errorf "Unable to load README for %s: %s" $dir .Err }}
+              {{ errorf "Unable to load README for %s" $dir }}
             {{ else }}
-              {{ warnf "Unable to load README for %s: %s" $dir .Err }}
+              {{ warnf "Unable to load README for %s" $dir }}
             {{ end }}
           {{ end }}
         {{ end }}
-  
+
         {{ $page := dict
           "kind" "section"
           "path" (printf "sigs/%s" $slug)
@@ -129,6 +132,9 @@
             {{ end }}
           {{ else with .Value }}
             {{ $readmeContent = replace .Content "\u200b" "" }}
+            {{ $readmeContent = replaceRE `\(/sig-([^\)\s]+)` `(/community/community-groups/sigs/$1/` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/wg-([^\)\s]+)` `(/community/community-groups/wg/$1/` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/committee-([^\)\s]+)` `(/community/community-groups/committees/$1/` $readmeContent }}
             {{ $readmeContent = replaceRE `^[\s\S]*?(##[\s\S]*)` `$1` $readmeContent }}
           {{ else }}
             {{ if eq hugo.Environment "production" }}
@@ -214,6 +220,9 @@
             {{ end }}
             {{ else with .Value }}
               {{ $readmeContent = replace .Content "\u200b" "" }}
+            {{ $readmeContent = replaceRE `\(/sig-([^\)\s]+)` `(/community/community-groups/sigs/$1/` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/wg-([^\)\s]+)` `(/community/community-groups/wg/$1/` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/committee-([^\)\s]+)` `(/community/community-groups/committees/$1/` $readmeContent }}
               {{ $readmeContent = replaceRE `^[\s\S]*?(##[\s\S]*)` `$1` $readmeContent }}
             {{ else }}
               {{ if eq hugo.Environment "production" }}

--- a/content/en/community/community-groups/_content.gotmpl
+++ b/content/en/community/community-groups/_content.gotmpl
@@ -41,9 +41,9 @@
             {{ end }}
           {{ else with .Value }}
             {{ $readmeContent = replace .Content "\u200b" "" }}
-            {{ $readmeContent = replaceRE `\(/sig-([^\)\s]+)` `(/community/community-groups/sigs/$1/` $readmeContent }}
-            {{ $readmeContent = replaceRE `\(/wg-([^\)\s]+)` `(/community/community-groups/wg/$1/` $readmeContent }}
-            {{ $readmeContent = replaceRE `\(/committee-([^\)\s]+)` `(/community/community-groups/committees/$1/` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/sig-([^\)\s#]+)(#[^\)\s]*)?\)` `(/community/community-groups/sigs/$1/$2)` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/wg-([^\)\s#]+)(#[^\)\s]*)?\)` `(/community/community-groups/wg/$1/$2)` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/committee-([^\)\s#]+)(#[^\)\s]*)?\)` `(/community/community-groups/committees/$1/$2)` $readmeContent }}
             {{ $readmeContent = replaceRE `^[\s\S]*?(##[\s\S]*)` `$1` $readmeContent }}
           {{ else }}
             {{ if eq hugo.Environment "production" }}
@@ -132,9 +132,9 @@
             {{ end }}
           {{ else with .Value }}
             {{ $readmeContent = replace .Content "\u200b" "" }}
-            {{ $readmeContent = replaceRE `\(/sig-([^\)\s]+)` `(/community/community-groups/sigs/$1/` $readmeContent }}
-            {{ $readmeContent = replaceRE `\(/wg-([^\)\s]+)` `(/community/community-groups/wg/$1/` $readmeContent }}
-            {{ $readmeContent = replaceRE `\(/committee-([^\)\s]+)` `(/community/community-groups/committees/$1/` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/sig-([^\)\s#]+)(#[^\)\s]*)?\)` `(/community/community-groups/sigs/$1/$2)` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/wg-([^\)\s#]+)(#[^\)\s]*)?\)` `(/community/community-groups/wg/$1/$2)` $readmeContent }}
+            {{ $readmeContent = replaceRE `\(/committee-([^\)\s#]+)(#[^\)\s]*)?\)` `(/community/community-groups/committees/$1/$2)` $readmeContent }}
             {{ $readmeContent = replaceRE `^[\s\S]*?(##[\s\S]*)` `$1` $readmeContent }}
           {{ else }}
             {{ if eq hugo.Environment "production" }}
@@ -220,9 +220,9 @@
             {{ end }}
             {{ else with .Value }}
               {{ $readmeContent = replace .Content "\u200b" "" }}
-            {{ $readmeContent = replaceRE `\(/sig-([^\)\s]+)` `(/community/community-groups/sigs/$1/` $readmeContent }}
-            {{ $readmeContent = replaceRE `\(/wg-([^\)\s]+)` `(/community/community-groups/wg/$1/` $readmeContent }}
-            {{ $readmeContent = replaceRE `\(/committee-([^\)\s]+)` `(/community/community-groups/committees/$1/` $readmeContent }}
+              {{ $readmeContent = replaceRE `\(/sig-([^\)\s#]+)(#[^\)\s]*)?\)` `(/community/community-groups/sigs/$1/$2)` $readmeContent }}
+              {{ $readmeContent = replaceRE `\(/wg-([^\)\s#]+)(#[^\)\s]*)?\)` `(/community/community-groups/wg/$1/$2)` $readmeContent }}
+              {{ $readmeContent = replaceRE `\(/committee-([^\)\s#]+)(#[^\)\s]*)?\)` `(/community/community-groups/committees/$1/$2)` $readmeContent }}
               {{ $readmeContent = replaceRE `^[\s\S]*?(##[\s\S]*)` `$1` $readmeContent }}
             {{ else }}
               {{ if eq hugo.Environment "production" }}


### PR DESCRIPTION
Root-relative links (/sig-node) in remote READMEs now 404. Rewrites
them to correct paths (/community/community-groups/sigs/node/).

Pages to test on deploy preview:
- https://deploy-preview-780--kubernetes-contributor.netlify.app/community/community-groups/wg/device-management/
- https://deploy-preview-780--kubernetes-contributor.netlify.app/community/community-groups/wg/batch/
- https://deploy-preview-780--kubernetes-contributor.netlify.app/community/community-groups/sigs/node/

Refs: #779