### PR TITLE
fix: repair archived contributor celebration links and assets

### DIFF
--- a/content/en/events/2020/kcc/_index.md
+++ b/content/en/events/2020/kcc/_index.md
@@ -12,8 +12,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
 {{% /alert %}}
 
 <img align="center" alt="you're invited" style="max-width:50%;" src="/events/2020/kcc/invited.png">
@@ -43,4 +42,3 @@ of conduct question, please see the [faq].
 [faq]: ./faq
 [Registration Form]: https://forms.gle/51tqQgxuHxLaeU1P8
 [Code of Conduct]: /resources/code-of-conduct
-

--- a/content/en/events/2020/kcc/activities.md
+++ b/content/en/events/2020/kcc/activities.md
@@ -8,8 +8,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
 {{% /alert %}}
 
 **NOTE:** This list is not complete or final, there will be room for more :)

--- a/content/en/events/2020/kcc/faq.md
+++ b/content/en/events/2020/kcc/faq.md
@@ -8,8 +8,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
 {{% /alert %}}
 
 - [General Information](#general-information)
@@ -115,7 +114,7 @@ everything. If you need assistance, join the `#help` channel.
 
 ### What is this YAGPDB.xyz and why is it messaging me?
 
-<img align="left" src="/events/past-events/2020/kcc2020/yagpdb.png" width="40" height="40" alt="YAGPDB Discord Bot logo">
+<img align="left" src="/events/2020/kcc/yagpdb.png" width="40" height="40" alt="YAGPDB Discord Bot logo">
 
 [YAGPDB] (Yet Another General Purpose Discord Bot) is a verified discord bot
 that we use to manage a variety of services within discord, from verification
@@ -133,19 +132,19 @@ overlays. A few examples of what this would look like:
 
 1 ) To do so, click the server dropdown (Top Left)
 
-<img align="center" src="/events/past-events/2020/kcc2020/server.png" width="40%" alt="Discord server list showing Kubernetes server">
+<img align="center" src="/events/2020/kcc/server.png" width="40%" alt="Discord server list showing Kubernetes server">
 <br>
 <br>
 2 ) Select “Change Nickname”
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/nickname.png" width="40%" alt="Discord edit nickname interface">
+<img align="center" src="/events/2020/kcc/nickname.png" width="40%" alt="Discord edit nickname interface">
 <br>
 <br>
 3 ) Then follow the template of “nickname (pro/noun)” like so:
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/name.png" width="40%" alt="Discord user settings name field">
+<img align="center" src="/events/2020/kcc/name.png" width="40%" alt="Discord user settings name field">
 
 
 ### What are the `#<channel>-info` channels for?

--- a/content/en/events/2020/kcc/how-to-join.md
+++ b/content/en/events/2020/kcc/how-to-join.md
@@ -9,8 +9,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
 {{% /alert %}}
 
 
@@ -57,7 +56,7 @@ For instructions on creating an account and installing the client, see the
    symbol) on the left side of the application. 
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/add-server.png" width="40%" alt="Discord add server button">
+   <img align="center" src="/events/2020/kcc/add-server.png" width="40%" alt="Discord add server button">
    <br>
    <br>
    A menu should pop up asking if you'd like to create or join a server. Select
@@ -68,7 +67,7 @@ For instructions on creating an account and installing the client, see the
    email, and paste it in the **Invite link** text box.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/join-server.png" width="40%" alt="Discord join server input dialog">
+   <img align="center" src="/events/2020/kcc/join-server.png" width="40%" alt="Discord join server input dialog">
    <br> 
    <br> 
 3) Two things will happen: You will be directed to the `#instructions-to-connect`
@@ -77,7 +76,7 @@ For instructions on creating an account and installing the client, see the
    the server.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/instructions-to-connect.png" width="100%" alt="Discord connection instructions and prompt">
+   <img align="center" src="/events/2020/kcc/instructions-to-connect.png" width="100%" alt="Discord connection instructions and prompt">
    <br>
    <br> 
 4) The bot will dm you a unique link where you will need to complete a captcha.
@@ -87,14 +86,14 @@ For instructions on creating an account and installing the client, see the
    (`@YAGPDB.xyz`), and select **message**. That will take you to the correct
    prompt.
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/dm-from-bot.png" width="100%" alt="Direct message received from Discord verification bot">
+   <img align="center" src="/events/2020/kcc/dm-from-bot.png" width="100%" alt="Direct message received from Discord verification bot">
    <br>
    <br>
    If you do not complete the captcha within 10 minutes, you will be booted from
    the server (you will still be able to reconnect).
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/verification.png" width="100%" alt="Discord verification channel input">
+   <img align="center" src="/events/2020/kcc/verification.png" width="100%" alt="Discord verification channel input">
    <br>
    <br>
 5) After completing the captcha, navigate to the `#code-of-conduct` channel.
@@ -103,10 +102,10 @@ For instructions on creating an account and installing the client, see the
    channels within the server.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/coc.png" width="100%" alt="Code of Conduct agreement message in Discord">
+   <img align="center" src="/events/2020/kcc/coc.png" width="100%" alt="Code of Conduct agreement message in Discord">
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/coc-emoji.png" width="100%" alt="Reacting with thumbs up to agree to Code of Conduct">
+   <img align="center" src="/events/2020/kcc/coc-emoji.png" width="100%" alt="Reacting with thumbs up to agree to Code of Conduct">
    <br> 
    <br>
    Once you accept the Code of conduct, you will see a list of categories and
@@ -115,7 +114,7 @@ For instructions on creating an account and installing the client, see the
    collapse that entire section in the sidebar.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/channels.png" width="100%" alt="List of available text and voice channels in Discord">
+   <img align="center" src="/events/2020/kcc/channels.png" width="100%" alt="List of available text and voice channels in Discord">
    <br> 
    <br>
    **Note:** Unlike Slack you can see every channel, and every user on the server!
@@ -138,7 +137,7 @@ and some might be too soft. If you’re expecting to play with a group for a lon
 time this can help tremendously:
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/user-volume.png" width="100%" alt="Right-click user volume slider in Discord">
+<img align="center" src="/events/2020/kcc/user-volume.png" width="100%" alt="Right-click user volume slider in Discord">
 <br> 
 <br>
 
@@ -149,7 +148,7 @@ Once you’ve joined a voice channel you can use the widgets at the bottom left
 of the screen to share your own screen and to use video if you want:
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/voice-video.png" width="40%" alt="Discord voice and video connection settings">
+<img align="center" src="/events/2020/kcc/voice-video.png" width="40%" alt="Discord voice and video connection settings">
 <br> 
 <br>
 The _Voice connected_ text and signal meter will change depending on your
@@ -166,14 +165,14 @@ video settings.
    corner:
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/settings-cog.png" width="100%" alt="Discord user settings gear icon">
+   <img align="center" src="/events/2020/kcc/settings-cog.png" width="100%" alt="Discord user settings gear icon">
    <br> 
    <br>
 2) Navigate to the **Voice & Video** section of the User Settings to adjust your
    inputs and outputs.
    <br>
    <br>
-   <img align="center" src="/events/past-events/2020/kcc2020/voice-video-settings.png" width="100%" alt="Discord Voice and Video settings panel">
+   <img align="center" src="/events/2020/kcc/voice-video-settings.png" width="100%" alt="Discord Voice and Video settings panel">
    <br> 
    <br>
 
@@ -194,4 +193,4 @@ If you're problem was not covered in the [FAQ], you can reach out for help in
 the **#Help** channel under the **Info and Announcements** Category.
 <br>
 <br>
-<img align="center" src="/events/past-events/2020/kcc2020/help-channel.png" width="40%" alt="Discord help-desk channel">
+<img align="center" src="/events/2020/kcc/help-channel.png" width="40%" alt="Discord help-desk channel">

--- a/content/en/events/2020/kcc/schedule.md
+++ b/content/en/events/2020/kcc/schedule.md
@@ -8,8 +8,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP0MPeiM9oAffsxtrUgUAu1g).
 {{% /alert %}}
 
 Thursday December 10th, the doors will open and members will be invited to discord. 

--- a/content/en/events/2021/kcc/_index.md
+++ b/content/en/events/2021/kcc/_index.md
@@ -10,8 +10,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
 {{% /alert %}}
 
 {{% alert title="Congrats!"  %}}
@@ -47,4 +46,3 @@ of conduct question, please see the [faq].
 [faq]: ./faq
 [Registration Form]: https://forms.gle/oAppmLDggEEGx5tz5
 [Code of Conduct]: /resources/code-of-conduct
-

--- a/content/en/events/2021/kcc/activities.md
+++ b/content/en/events/2021/kcc/activities.md
@@ -8,8 +8,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
 {{% /alert %}}
 
 **NOTE:** This list is not complete or final, there will be room for more :)

--- a/content/en/events/2021/kcc/faq.md
+++ b/content/en/events/2021/kcc/faq.md
@@ -8,8 +8,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
 {{% /alert %}}
 
 - [General Information](#general-information)

--- a/content/en/events/2021/kcc/how-to-join.md
+++ b/content/en/events/2021/kcc/how-to-join.md
@@ -9,8 +9,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
 {{% /alert %}}
 
 

--- a/content/en/events/2021/kcc/schedule.md
+++ b/content/en/events/2021/kcc/schedule.md
@@ -8,8 +8,7 @@ type: docs
 ---
 
 {{% alert title="Notice" color="warning" %}}
-This event has passed. Recordings from the event can be found on the
-[Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
+This event has passed. Recordings from the event can be found on the [Kubernetes Community YouTube Channel](https://youtube.com/playlist?list=PL69nYSiGNLP1nRmC5ks6szxfDN69ZZFcS).
 {{% /alert %}}
 
 {{% schedule


### PR DESCRIPTION
pretty small fix for a couple of busted archived event pages.

what broke
- the notice link on 2020 and 2021 KCC pages renders malformed HTML on prod, so the YouTube link comes out wonky
- 2020 KCC `how-to-join` and `faq` still point at `/events/past-events/2020/kcc2020/*`, those image URLs 404

what changed
- replace the notice markdown link with a raw anchor in the affected KCC pages
- repoint the 2020 KCC images to `/events/2020/kcc/*`, where the files already live

how to repro
1. open `https://www.kubernetes.dev/events/2020/kcc/how-to-join/`
2. inspect the notice link. on prod it renders as `href="..." <p>target=...`
3. open `https://www.kubernetes.dev/events/past-events/2020/kcc2020/add-server.png`
4. it returns `404`

related
- #259
- #735
