### PR TITLE
fix: KEP page code block contrast and layout

### DIFF
--- a/assets/scss/_kep_page.scss
+++ b/assets/scss/_kep_page.scss
@@ -347,15 +347,44 @@
     }
 
     // Code blocks
-    pre {
-      background-color: #1e1e1e;
-      color: #d4d4d4;
-      padding: 1.5rem;
-      border-radius: 8px;
-      font-size: 0.9rem;
+    .highlight {
       margin: 2rem 0;
-      max-width: 100%;
+      padding: 0;
+      position: relative;
+      background: transparent;
+      border: none;
+      box-shadow: none;
+
+      pre {
+        margin: 0;
+      }
+    }
+
+    pre {
+      font-size: 0.875em;
+      padding: 1rem;
+      border-radius: 0;
       overflow-x: auto;
+      max-width: 100%;
+      word-wrap: normal;
+      background-color: #f8f9fa;
+      border: 1px solid #dee2e6;
+      color: inherit;
+
+      [data-bs-theme="dark"] & {
+        background-color: #1b1f22;
+        border-color: #495057;
+      }
+
+      code {
+        font-size: inherit;
+        color: inherit;
+        word-break: normal;
+      }
+
+      @media (max-width: 575px) {
+        font-size: 0.8rem;
+      }
     }
   }
 

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -16,3 +16,47 @@ Add styles or import other files. */
 
 // Cross-cutting media queries
 @import "base";
+
+/* Chroma syntax highlighting (emacs theme) */
+.chroma {
+  background-color: #f8f8f8;
+
+  [data-bs-theme="dark"] & {
+    background-color: #1b1f22;
+  }
+
+  .k, .kc, .kd, .kn, .kr, .ow { color: #a2f; font-weight: bold; }
+  .kp { color: #a2f; }
+  .kt { color: #0b0; font-weight: bold; }
+  .na, .s, .sa, .sb, .sc, .dl, .s2, .sh, .s1 { color: #b44; }
+  .nb, .nd { color: #a2f; }
+  .nc { color: #00f; }
+  .no { color: #800; }
+  .ni { color: #999; font-weight: bold; }
+  .ne { color: #d2413a; font-weight: bold; }
+  .nf { color: #00a000; }
+  .nl { color: #a0a000; }
+  .nn { color: #00f; font-weight: bold; }
+  .nt { color: #008000; font-weight: bold; }
+  .nv, .ss { color: #b8860b; }
+  .sd { color: #b44; font-style: italic; }
+  .se { color: #b62; font-weight: bold; }
+  .si { color: #b68; font-weight: bold; }
+  .sx { color: #008000; }
+  .sr { color: #b68; }
+  .m, .mb, .mf, .mh, .mi, .il, .mo, .o { color: #666; }
+  .c, .ch, .cm, .c1, .cp, .cpf { color: #080; font-style: italic; }
+  .cs { color: #080; font-weight: bold; }
+  .gd { color: #a00000; }
+  .ge { font-style: italic; }
+  .gr { color: #f00; }
+  .gh { color: #000080; font-weight: bold; }
+  .gi { color: #00a000; }
+  .go { color: #888; }
+  .gp { color: #000080; font-weight: bold; }
+  .gs { font-weight: bold; }
+  .gu { color: #800080; font-weight: bold; }
+  .gt { color: #04d; }
+  .gl { text-decoration: underline; }
+  .w { color: #bbb; }
+}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -65,6 +65,7 @@ markup:
   # Default highlight is tango for Docsy but the website uses emacs (for now)
   highlight:
     style: emacs
+    noClasses: false
 
 frontmatter:
   date:


### PR DESCRIPTION
Fixes KEP page code block contrast and layout. Closes: #738. Netlify preview: https://deploy-preview-785--kubernetes-contributor.netlify.app/resources/keps/5975/

https://github.com/kubernetes/website/blob/main/hugo.toml#L65 this is following the code formatting config from kubernetes/website to use the `emacs` style

<img width="1043" height="303" alt="image" src="https://github.com/user-attachments/assets/869b7391-9173-4318-9699-0e6f79c7a459" />
