### PR TITLE
fix: prevent horizontal overflow on KEP detail pages

### DIFF
--- a/assets/scss/_kep_page.scss
+++ b/assets/scss/_kep_page.scss
@@ -188,7 +188,7 @@
 
   .kep-people-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(0, 1fr));
     gap: 0.75rem;
   }
 
@@ -200,6 +200,8 @@
     align-items: center;
     gap: 6px;
     transition: all 0.2s ease;
+    min-width: 0;
+    overflow-wrap: anywhere;
 
     i {
       color: $slate-400;
@@ -228,14 +230,17 @@
         color: $slate-700;
         text-decoration: none;
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         gap: 8px;
         transition: all 0.2s ease;
+        min-width: 0;
+        overflow-wrap: anywhere;
 
         i {
           font-size: 0.7rem;
           color: $slate-400;
           line-height: 1;
+          flex-shrink: 0;
         }
 
         &:hover {
@@ -266,6 +271,9 @@
     padding: 0;
     margin-bottom: 3rem;
     line-height: 1.7;
+
+    // Wrap long inline tokens (URLs, inline code) so prose can't widen the page
+    overflow-wrap: break-word;
 
     // Hide duplicate KEP title from README if present
     h1:first-of-type {
@@ -347,6 +355,8 @@
       border-radius: 8px;
       font-size: 0.9rem;
       margin: 2rem 0;
+      max-width: 100%;
+      overflow-x: auto;
     }
   }
 
@@ -358,7 +368,10 @@
     border-radius: 8px;
     margin-top: 4rem;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    // #{} interpolation keeps the CSS min() literal so LibSass doesn't try to
+    // evaluate it (px vs % are incompatible at Sass compile time). This lets the
+    // column collapse below 300px on narrow screens to prevent horizontal overflow.
+    grid-template-columns: repeat(auto-fit, minmax(#{"min(300px, 100%)"}, 1fr));
     gap: 2rem;
 
     h2 {

--- a/assets/scss/_kep_page.scss
+++ b/assets/scss/_kep_page.scss
@@ -188,7 +188,7 @@
 
   .kep-people-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
     gap: 0.75rem;
   }
 
@@ -201,7 +201,6 @@
     gap: 6px;
     transition: all 0.2s ease;
     min-width: 0;
-    overflow-wrap: anywhere;
 
     i {
       color: $slate-400;
@@ -234,7 +233,7 @@
         gap: 8px;
         transition: all 0.2s ease;
         min-width: 0;
-        overflow-wrap: anywhere;
+        overflow-wrap: break-word;
 
         i {
           font-size: 0.7rem;


### PR DESCRIPTION
Fixes horizontal scroll on KEP detail pages when viewed on narrow/mobile widths. Closes: https://github.com/kubernetes/contributor-site/issues/747

The overflow came from the metadata banner. The "Related Enhancements" links render long unbreakable paths (e.g. `/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen`) inside a flex anchor with no `min-width: 0` or wrapping rule, so the link kept its full intrinsic width and pushed the page past the viewport. The author handles and the people/metadata grids had the same class of issue on very narrow screens.

CSS only, scoped to `.kep-page` in `assets/scss/_kep_page.scss`. No markup or content changes.

Changes:
- Let the Related Enhancements links and author handles wrap (`min-width: 0` + `overflow-wrap`), and keep the leading icon from being squeezed.
- Relax the people grid (`minmax(0, 1fr)`) and metadata grid (`minmax(min(300px, 100%), 1fr)`) so columns collapse instead of overflowing on small screens.
- Allow long inline code/URLs and `<pre>` blocks in the rendered README to wrap or scroll within the column rather than widening the page.

Markdown tables are intentionally left as is. Making them scroll would need a render-hook wrapper, which is a larger markup change better handled separately if wide-table overflow is ever reported.

Pages to test (resize to ~360px or zoom out, confirm no horizontal scrollbar):
- https://deploy-preview-793--kubernetes-contributor.netlify.app/resources/keps/5975/
- https://deploy-preview-793--kubernetes-contributor.netlify.app/resources/keps/

Verified locally with the pinned Hugo `v0.144.2` (`make container-render`); the SCSS compiles and the KEP pages build. Desktop layout is unchanged.
