### PR TITLE
fix: missing format arg in KEP README warning

### DIFF
--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -118,7 +118,7 @@
         {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
       {{- else -}}
-        {{- warnf "Unable to load README for KEP %s" -}}
+        {{- warnf "Unable to load README for KEP %s URL=%s" $kep.kepNumber $readmeUrl -}}
       {{- end -}}
     {{- end -}}
 


### PR DESCRIPTION
Fix warnf missing %s argument causing %!s(MISSING) output. Adds KEP number and URL to warning.

https://deploy-preview-803--kubernetes-contributor.netlify.app/resources/keps/