### PR TITLE
feat: use path field from keps.json for KEP README URLs

### DIFF
--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -75,7 +75,8 @@
     -}}
 
     {{/* Fetch README Content */}}
-    {{- $readmeUrl := printf "%s%s/%s/README.md" $rawBaseUrl $kep.owningSig $kep.name -}}
+    {{- $kepPath := default (printf "%s/%s" $kep.owningSig $kep.name) $kep.path -}}
+    {{- $readmeUrl := printf "%s%s/README.md" $rawBaseUrl $kepPath -}}
     {{- $readmeContent := "" -}}
     {{- $readmeOpts := merge $globalOpts (dict "key" (printf "kep-readme-%s" $kep.kepNumber)) -}}
     

--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -91,7 +91,7 @@
     {{- end -}}
 
     {{- if $needsFallback -}}
-      {{- $readmeUrlUpper := printf "%s%s/%s/README.MD" $rawBaseUrl $kep.owningSig $kep.name -}}
+      {{- $readmeUrlUpper := printf "%s%s/README.MD" $rawBaseUrl $kepPath -}}
       {{- $readmeOptsUpper := merge $globalOpts (dict "key" (printf "kep-readme-%s-upper" $kep.kepNumber)) -}}
       {{- $resourceFetchAttempt = try (resources.GetRemote $readmeUrlUpper $readmeOptsUpper) -}}
     {{- end -}}
@@ -108,7 +108,7 @@
         
         {{- /* Fix relative image and link paths to point to GitHub */ -}}
         {{- $repoBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
-        {{- $kepDirUrl := printf "%skeps/%s/%s/" $repoBaseUrl $kep.owningSig $kep.name -}}
+        {{- $kepDirUrl := printf "%skeps/%s/" $repoBaseUrl $kepPath -}}
         
         {{- /* 1. Fix absolute-looking paths (starting with /) */ -}}
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $repoBaseUrl) $readmeContent -}}


### PR DESCRIPTION
Prefers `path` field from `keps.json` over `owningSig/name` for README URLs.

Also fixes two bugs where the fallback `README.MD` URL and relative link/image path resolution still used the old `owningSig/name` pattern instead of `$kepPath` — these were broken for nested KEPs (depth 3+ paths like `sig-cloud-provider/azure/2328-ccm-instance-metadata`).

Depends on: https://github.com/kubernetes/enhancements/pull/6225

**Pages to test:**

Verify these render correctly on the deploy preview:

| Page | Type | Path pattern | Expected |
|------|------|-------------|----------|
| [https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/1040/](https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/1040/) | Non-nested (depth 2) | `sig-api-machinery/1040-priority-and-fairness` | README loads (no regression) |
| [https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/2328/](https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/2328/) | Nested (depth 3) | `sig-cloud-provider/azure/2328-ccm-instance-metadata` | README loads (was broken, now fixed) |
| [https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/2500/](https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/2500/) | Nested (depth 3) | `sig-cluster-lifecycle/kubeadm/2500-kubeadm-join-control-plane-workflow` | README loads (was broken, now fixed) |
| [https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/586/](https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/586/) | Nested with images | `sig-cloud-provider/azure/586-azure-availability-zones` | Relative images/links resolve correctly |
| [https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/667/](https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/667/) | Nested with images | `sig-cloud-provider/azure/667-out-of-tree-azure` | Relative images/links resolve correctly |
| [https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/](https://deploy-preview-804--kubernetes-contributor.netlify.app/resources/keps/) | KEP listing | — | All 649 KEPs listed with correct links |

Note: Maximum nesting depth in `keps.json` is 3 (`sig/subdir/kep-name`). No depth 4+ KEPs exist in the current data.

Deploy preview: https://deploy-preview-804--kubernetes-contributor.netlify.app