### PR TITLE
Upgrade Docsy from 0.9.1 to 0.10.0

### DIFF
--- a/assets/scss/_navbar.scss
+++ b/assets/scss/_navbar.scss
@@ -6,6 +6,13 @@
   transition: background-color 0.3s ease;
 }
 
+@media (min-width: 768px) {
+  .td-navbar-cover {
+    // Improve navbar contrast over the landing page hero image.
+    background: rgba($dark, 0.85) !important;
+  }
+}
+
 .td-navbar.scrolled {
   background-color: rgba($primary, 0.95) !important; // overrides Docsy's navbar background
 

--- a/assets/scss/_navbar.scss
+++ b/assets/scss/_navbar.scss
@@ -6,21 +6,19 @@
   transition: background-color 0.3s ease;
 }
 
-@media (min-width: 768px) {
-  .td-navbar-cover {
-    // Improve navbar contrast over the landing page hero image.
-    background: rgba($dark, 0.85) !important;
-  }
+.td-navbar-cover {
+  // Improve navbar contrast over the landing page hero image.
+  background: rgba($dark, 0.85) !important;
 }
 
 .td-navbar.scrolled {
   background-color: rgba($primary, 0.95) !important; // overrides Docsy's navbar background
 
-  // Use Bootstrap navbar CSS variables so the brand and navigation links
-  // inherit the correct colors without overriding individual selectors
-  --bs-navbar-color: var(--bs-white);
-  --bs-navbar-hover-color: var(--bs-white);
-  --bs-navbar-active-color: var(--bs-white);
-  --bs-navbar-brand-color: var(--bs-white);
-  --bs-navbar-brand-hover-color: var(--bs-white);
+  // Distinguish inactive, hover, and active navigation links.
+  --bs-navbar-color: rgba(255, 255, 255, 0.55);
+}
+
+.td-navbar .td-search__input:focus {
+  background-color: $white;
+  color: $dark;
 }

--- a/assets/scss/_navbar.scss
+++ b/assets/scss/_navbar.scss
@@ -8,4 +8,12 @@
 
 .td-navbar.scrolled {
   background-color: rgba($primary, 0.95) !important; // overrides Docsy's navbar background
+
+  // Use Bootstrap navbar CSS variables so the brand and navigation links
+  // inherit the correct colors without overriding individual selectors
+  --bs-navbar-color: var(--bs-white);
+  --bs-navbar-hover-color: var(--bs-white);
+  --bs-navbar-active-color: var(--bs-white);
+  --bs-navbar-brand-color: var(--bs-white);
+  --bs-navbar-brand-hover-color: var(--bs-white);
 }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -76,6 +76,8 @@ frontmatter:
 
 # Everything below this are Site Params
 params:
+  mermaid:
+    version: 10.8.0
   # This is used instead of the built-in top level `copyright` to utilize
   # Docsy's partial which adds the copyright year automatically
   copyright: The Kubernetes Authors
@@ -86,7 +88,7 @@ params:
     # Enable to show the sidebar menu in its compact state.
     sidebar_menu_compact: true
     # Set to true to disable the About link in the site footer
-    footer_about_disable: false
+    footer_about_enable: true
 
     # Adds an H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
     # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -87,7 +87,7 @@ params:
   ui:
     # Enable to show the sidebar menu in its compact state.
     sidebar_menu_compact: true
-    # Set to true to disable the About link in the site footer
+    # Set to true to enable the About link in the site footer
     footer_about_enable: true
 
     # Adds an H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.

--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -1,8 +1,8 @@
 {{ $version := .Site.Params.mermaid.version | default "latest" -}}
 {{ $cdnurl := printf "https://cdn.jsdelivr.net/npm/mermaid@%s/dist/mermaid.esm.min.mjs" $version -}}
-{{ $remote := resources.GetRemote $cdnurl }}
-{{ if not $remote }}
-  {{ errorf "Invalid Mermaid version %s, could not retrieve this version from CDN." $version }}
+{{ $remote := try (resources.GetRemote $cdnurl) }}
+{{ with $remote.Err }}
+  {{ errorf "Invalid Mermaid version %q, could not retrieve Mermaid from CDN: %s" $version . }}
 {{ end }}
 <script type="module" async>
 import mermaid from "{{ $cdnurl }}";

--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -1,8 +1,9 @@
 {{ $version := .Site.Params.mermaid.version | default "latest" -}}
 {{ $cdnurl := printf "https://cdn.jsdelivr.net/npm/mermaid@%s/dist/mermaid.esm.min.mjs" $version -}}
-{{ $remote := try (resources.GetRemote $cdnurl) }}
-{{ with $remote.Err }}
-  {{ errorf "Invalid Mermaid version %q, could not retrieve Mermaid from CDN: %s" $version . }}
+{{ with try (resources.GetRemote $cdnurl) }}
+  {{ with .Err }}
+    {{ errorf "Invalid Mermaid version %q, could not retrieve Mermaid from CDN: %s" $version . }}
+  {{ end }}
 {{ end }}
 <script type="module" async>
 import mermaid from "{{ $cdnurl }}";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^6.6.0",
         "autoprefixer": "^10.4.20",
-        "docsy": "github:google/docsy#semver:0.9.1",
+        "docsy": "github:google/docsy#semver:0.10.0",
         "postcss-cli": "^10.1.0"
       }
     },
@@ -68,7 +68,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "dev": true,
-      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -167,9 +166,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
-      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "dev": true,
       "funding": [
         {
@@ -181,9 +180,8 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
-      "license": "MIT",
       "peerDependencies": {
-        "@popperjs/core": "^2.11.6"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/braces": {
@@ -337,14 +335,14 @@
       }
     },
     "node_modules/docsy": {
-      "version": "0.9.1",
-      "resolved": "git+ssh://git@github.com/google/docsy.git#6195793c0f576b7d5c9c52537668e3c7d9d89458",
+      "version": "0.10.0",
+      "resolved": "git+ssh://git@github.com/google/docsy.git#712aa05897c1abe239786522131e83d69e5e1b4e",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "6.5.1",
-        "bootstrap": "5.2.3"
+        "@fortawesome/fontawesome-free": "6.5.2",
+        "bootstrap": "5.3.3"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.6.0",
     "autoprefixer": "^10.4.20",
-    "docsy": "github:google/docsy#semver:0.9.1",
+    "docsy": "github:google/docsy#semver:0.10.0",
     "postcss-cli": "^10.1.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
This PR begins the incremental upgrade of Docsy from 0.9.1 to 0.10.0, following the staged upgrade path toward newer Docsy releases and support for features such as dark mode.

## Changes
- Upgrade Docsy from 0.9.1 to 0.10.0.
- Update npm dependencies and package-lock.json.
- Pin the Mermaid version via params.mermaid.version.
- Update the Mermaid partial to use try (resources.GetRemote) with proper error handling for CDN retrieval failures.

## Current Status
 This is a PR and is still under active development.

## Related
 Ref: https://github.com/kubernetes/contributor-site/issues/745
 
### AI Disclosure
An AI assistant was used to help identify and fix issues during regression testing. All changes were reviewed and validated before submission.

