### PR TITLE
fix: correct Netlify subproject site guidelines anchor

### DIFF
--- a/content/en/resources/services.md
+++ b/content/en/resources/services.md
@@ -190,7 +190,7 @@ can be be reviewed in the [Netlify subproject site guidelines].
 [config]: https://git.k8s.io/community/github-management/subproject-site-requests.md#example-netlify-configuration
 [issue]: https://github.com/kubernetes/k8s.io/issues/new?assignees=&labels=wg%2Fk8s-infra%2C+area%2Fdns&template=dns-request.md&title=DNS+REQUEST%3A+%3Cyour-dns-record%3E
 [Netlify Site Request]: https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-integration&template=site-request.yml&title=
-[Netlify subproject site guidelines]: https://git.k8s.io/community/github-management/subproject-site-requests.md#subproject-domain-reques
+[Netlify subproject site guidelines]: https://git.k8s.io/community/github-management/subproject-site-requests.md#subproject-site-requests
 
 
 


### PR DESCRIPTION
What
Fix the `Netlify subproject site guidelines` link in `content/en/resources/services.md`.

Why
Right now it points to `#subproject-domain-reques`.
That fragment does not exist upstream, so the jump is kinda busted.

Repro
1. Open `content/en/resources/services.md`.
2. Click `Netlify subproject site guidelines`, or open `https://git.k8s.io/community/github-management/subproject-site-requests.md#subproject-domain-reques`.
3. The page opens, but it does not jump to the subproject domain section.
4. In the upstream doc, the section slug is `requesting-a-subproject-domain`.

Fix
Point the link at `#requesting-a-subproject-domain`.
small fix, but it makes the docs less janky.
