### PR TITLE
fix: show fallback message on KEP pages with missing README

### DIFF
--- a/layouts/keps/single.html
+++ b/layouts/keps/single.html
@@ -152,6 +152,12 @@
   <div class="kep-content mt-4">
     {{ .Content }}
   </div>
+  {{ else }}
+  <div class="alert alert-info mt-4" role="status">
+    The detailed KEP content is not available on this page because the upstream README could not be loaded.
+    You can search the Kubernetes enhancements repo for KEP-{{ .Params.kepNumber }} on
+    <a href="https://github.com/kubernetes/enhancements/search?q={{ .Params.kepNumber }}&type=code" target="_blank" rel="noopener">GitHub</a>.
+  </div>
   {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
Some KEP pages on the live site show the header and metadata block, then just stop there.
This adds a small fallback notice with a GitHub search link, so users dont land on a blank dead end page.

How to repro

1. Open `https://www.kubernetes.dev/resources/keps/2328/`
2. The page renders KEP metadata only, no README body.
3. Check the same page on this branch.
4. It now shows a short fallback note and a link out, so its still useful.

This is triggerable today on the live site. `KEP-2328` is one example.
