### PR TITLE
Add blog post about publishing Kubernetes SIG images to registry.k8s.io

### DIFF
--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/dependency-overview.svg
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/dependency-overview.svg
@@ -36,7 +36,7 @@
     <rect x="40" y="70" width="250" height="70" rx="6" fill="#fff8e1" stroke="#f0b429" stroke-width="1.4"/>
     <text x="165" y="93" text-anchor="middle" class="title">image-owning repo</text>
     <text x="165" y="113" text-anchor="middle" class="body">cloudbuild.yaml</text>
-    <text x="165" y="131" text-anchor="middle" class="body">make release-staging</text>
+    <text x="165" y="131" text-anchor="middle" class="body">image build configuration</text>
 
     <rect x="690" y="70" width="250" height="70" rx="6" fill="#eaf2fd" stroke="#5b8def" stroke-width="1.4"/>
     <text x="815" y="100" text-anchor="middle" class="title">kubernetes/k8s.io</text>

--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/dependency-overview.svg
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/dependency-overview.svg
@@ -1,0 +1,116 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 720" font-family="Arial, Helvetica, sans-serif" font-size="13" role="img" aria-labelledby="dependency-title dependency-desc">
+  <title id="dependency-title">First-time registry.k8s.io image publishing dependencies</title>
+  <desc id="dependency-desc">The image-owning repository provides the Cloud Build configuration and a signed release tag. The tag triggers a kubernetes/test-infra postsubmit job, which pushes a staging image to the staging registry. In kubernetes/k8s.io, the staging Google Group must be created before the staging registry. The staging image and image promoter configuration, with OWNERS validation from Kubernetes organization membership, promote the image to registry.k8s.io.</desc>
+  <defs>
+    <marker id="dep-arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#37474f"/>
+    </marker>
+    <style>
+      .edge { stroke: #37474f; stroke-width: 1.6; fill: none; }
+      .label-box { fill: #ffffff; stroke: #cfd8dc; stroke-width: 1; }
+      .label-text { fill: #37474f; font-size: 11.5px; }
+      .title { fill: #111111; font-weight: 700; }
+      .body { fill: #111111; }
+      .prod-title { fill: #2e7d32; font-weight: 700; }
+      .prod-body { fill: #2e7d32; }
+    </style>
+  </defs>
+  <rect width="980" height="720" fill="#ffffff"/>
+
+  <!-- edges (drawn first, under the boxes) -->
+  <g class="edge">
+    <path d="M165,144 L165,226" marker-end="url(#dep-arrow)"/>                  <!-- APP -> TAG -->
+    <path d="M294,105 L330,105 L330,245 L361,245" marker-end="url(#dep-arrow)"/> <!-- APP -> JOB -->
+    <path d="M815,144 L815,226" marker-end="url(#dep-arrow)"/>                  <!-- GRP -> REG -->
+    <path d="M686,265 L629,265" marker-end="url(#dep-arrow)"/>                  <!-- REG -> JOB -->
+    <path d="M294,265 L361,265" marker-end="url(#dep-arrow)"/>                  <!-- TAG -> JOB -->
+    <path d="M495,304 L495,386" marker-end="url(#dep-arrow)"/>                  <!-- JOB -> STG -->
+    <path d="M495,464 L495,526" marker-end="url(#dep-arrow)"/>                  <!-- STG -> PROM -->
+    <path d="M686,425 L655,425 L655,565 L629,565" marker-end="url(#dep-arrow)"/> <!-- ORG -> PROM -->
+    <path d="M495,604 L495,636" marker-end="url(#dep-arrow)"/>                  <!-- PROM -> PROD -->
+  </g>
+
+  <!-- nodes -->
+  <!-- row 0 -->
+  <g>
+    <rect x="40" y="70" width="250" height="70" rx="6" fill="#fff8e1" stroke="#f0b429" stroke-width="1.4"/>
+    <text x="165" y="93" text-anchor="middle" class="title">image-owning repo</text>
+    <text x="165" y="113" text-anchor="middle" class="body">cloudbuild.yaml</text>
+    <text x="165" y="131" text-anchor="middle" class="body">make release-staging</text>
+
+    <rect x="690" y="70" width="250" height="70" rx="6" fill="#eaf2fd" stroke="#5b8def" stroke-width="1.4"/>
+    <text x="815" y="100" text-anchor="middle" class="title">kubernetes/k8s.io</text>
+    <text x="815" y="121" text-anchor="middle" class="body">staging Google Group</text>
+  </g>
+
+  <!-- row 1 -->
+  <g>
+    <rect x="40" y="230" width="250" height="70" rx="6" fill="#fff8e1" stroke="#f0b429" stroke-width="1.4"/>
+    <text x="165" y="260" text-anchor="middle" class="title">image-owning repo</text>
+    <text x="165" y="281" text-anchor="middle" class="body">signed release tag</text>
+
+    <rect x="365" y="230" width="260" height="70" rx="6" fill="#e9f7fb" stroke="#2f9ab7" stroke-width="1.4"/>
+    <text x="495" y="260" text-anchor="middle" class="title">kubernetes/test-infra</text>
+    <text x="495" y="281" text-anchor="middle" class="body">image-pushing postsubmit job</text>
+
+    <rect x="690" y="230" width="250" height="70" rx="6" fill="#eaf2fd" stroke="#5b8def" stroke-width="1.4"/>
+    <text x="815" y="260" text-anchor="middle" class="title">kubernetes/k8s.io</text>
+    <text x="815" y="281" text-anchor="middle" class="body">staging registry (Terraform)</text>
+  </g>
+
+  <!-- row 2 -->
+  <g>
+    <rect x="365" y="390" width="260" height="70" rx="6" fill="#eceff1" stroke="#90a4ae" stroke-width="1.4"/>
+    <text x="495" y="420" text-anchor="middle" class="title">staging image</text>
+    <text x="495" y="441" text-anchor="middle" class="body">k8s-staging-images</text>
+
+    <rect x="690" y="390" width="250" height="70" rx="6" fill="#eaf2fd" stroke="#5b8def" stroke-width="1.4"/>
+    <text x="815" y="420" text-anchor="middle" class="title">kubernetes/org</text>
+    <text x="815" y="441" text-anchor="middle" class="body">org membership for OWNERS</text>
+  </g>
+
+  <!-- row 3 -->
+  <g>
+    <rect x="365" y="530" width="260" height="70" rx="6" fill="#eaf2fd" stroke="#5b8def" stroke-width="1.4"/>
+    <text x="495" y="553" text-anchor="middle" class="title">kubernetes/k8s.io</text>
+    <text x="495" y="573" text-anchor="middle" class="body">image promoter config</text>
+    <text x="495" y="591" text-anchor="middle" class="body">OWNERS / images.yaml / manifest</text>
+  </g>
+
+  <!-- row 4 -->
+  <g>
+    <rect x="365" y="640" width="260" height="56" rx="6" fill="#e8f5e9" stroke="#43a047" stroke-width="1.4"/>
+    <text x="495" y="664" text-anchor="middle" class="prod-title">registry.k8s.io image</text>
+    <text x="495" y="683" text-anchor="middle" class="prod-body">&lt;project&gt;/&lt;image&gt;:v&lt;version&gt;</text>
+  </g>
+
+  <!-- edge labels -->
+  <g>
+    <rect x="92" y="177" width="146" height="22" rx="4" class="label-box"/>
+    <text x="165" y="192" text-anchor="middle" class="label-text">release target exists</text>
+
+    <rect x="268" y="154" width="124" height="22" rx="4" class="label-box"/>
+    <text x="330" y="169" text-anchor="middle" class="label-text">job runs this build</text>
+
+    <rect x="774" y="177" width="82" height="22" rx="4" class="label-box"/>
+    <text x="815" y="192" text-anchor="middle" class="label-text">create first</text>
+
+    <rect x="593" y="204" width="128" height="22" rx="4" class="label-box"/>
+    <text x="657" y="219" text-anchor="middle" class="label-text">push target exists</text>
+
+    <rect x="268" y="204" width="124" height="22" rx="4" class="label-box"/>
+    <text x="330" y="219" text-anchor="middle" class="label-text">triggers postsubmit</text>
+
+    <rect x="506" y="345" width="132" height="22" rx="4" class="label-box"/>
+    <text x="572" y="360" text-anchor="middle" class="label-text">pushes staging image</text>
+
+    <rect x="401" y="485" width="88" height="22" rx="4" class="label-box"/>
+    <text x="445" y="500" text-anchor="middle" class="label-text">source image</text>
+
+    <rect x="641" y="485" width="122" height="22" rx="4" class="label-box"/>
+    <text x="702" y="500" text-anchor="middle" class="label-text">OWNERS validation</text>
+
+    <rect x="511" y="615" width="72" height="22" rx="4" class="label-box"/>
+    <text x="547" y="630" text-anchor="middle" class="label-text">promotes</text>
+  </g>
+</svg>

--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/ghcr-path-blocked.svg
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/ghcr-path-blocked.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660 150" font-family="Arial, Helvetica, sans-serif" font-size="13" role="img" aria-label="The blocked GHCR path: a tag push triggers GitHub Actions, which pushes the image to ghcr.io, where it cannot be made public.">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#37474f"/>
+    </marker>
+    <marker id="arrowdash" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#c62828"/>
+    </marker>
+  </defs>
+
+  <rect x="10" y="10" width="640" height="130" rx="8" fill="#fafafa" stroke="#bdbdbd" stroke-dasharray="4 3"/>
+  <text x="30" y="32" fill="#616161" font-weight="bold">The ghcr.io approach (blocked)</text>
+
+  <rect x="30" y="60" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+  <text x="95" y="90" text-anchor="middle">tag push</text>
+
+  <rect x="190" y="60" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+  <text x="255" y="90" text-anchor="middle">GitHub Actions</text>
+
+  <rect x="350" y="60" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+  <text x="415" y="90" text-anchor="middle">push to ghcr.io</text>
+
+  <rect x="510" y="60" width="130" height="50" rx="6" fill="#fdecea" stroke="#e57373"/>
+  <text x="575" y="84" text-anchor="middle" fill="#c62828">cannot be made</text>
+  <text x="575" y="100" text-anchor="middle" fill="#c62828">public</text>
+
+  <line x1="164" y1="85" x2="186" y2="85" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="324" y1="85" x2="346" y2="85" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="484" y1="85" x2="506" y2="85" stroke="#c62828" stroke-width="1.5" stroke-dasharray="5 3" marker-end="url(#arrowdash)"/>
+</svg>

--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
@@ -183,16 +183,18 @@ Kubernetes CI jobs:
   failures.
 
 Verify that the promotion jobs complete successfully and that the image is
-available from `registry.k8s.io`. For Cluster Inventory API, the images that
-shipped through this route were:
+available from `registry.k8s.io`.
+
+When that works, publish or update the GitHub release and announce it in the
+related issues and Slack channels.
+
+For Cluster Inventory API, completing these steps made both images publicly
+available:
 
 ```none
 registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
 registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
 ```
-
-When that works, publish or update the GitHub release and announce it in the
-related issues and Slack channels.
 
 ### Where to ask for help
 

--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
@@ -163,9 +163,8 @@ project members approve new images for promotion.
 
 For the first promotion, include the digest and tag entries for the staging
 images in `images.yaml`, and get `/lgtm` from a SIG lead. For later releases,
-[`kpromo`](https://github.com/kubernetes-sigs/promo-tools) generates this PR
-for you (see the routine release steps below). If you are curious how the
-promotion machinery works, see
+follow the routine release steps below to create the promotion PR with
+`kpromo`. If you are curious how the promotion machinery works, see
 [The Invisible Rewrite: Modernizing the Kubernetes Image Promoter](https://kubernetes.io/blog/2026/03/17/image-promoter-rewrite/).
 
 If anyone you plan to list in `OWNERS` is not yet a Kubernetes organization
@@ -213,7 +212,9 @@ Routine releases only touch the image-owning repository and one promotion PR:
 
 1. Push a signed tag, create a draft GitHub release, and confirm the
    postsubmit pushed the staging image, as in step 5 of the first-time setup.
-2. Create the promotion PR with `kpromo pr`, naming the Artifact Registry
+2. Follow the
+   [promotion pull request guide](https://sigs.k8s.io/promo-tools/docs/promotion-pull-requests.md)
+   and create the promotion PR with `kpromo pr`, naming the Artifact Registry
    staging repository explicitly with `--staging-repo`:
 
    ```bash
@@ -247,5 +248,5 @@ pull requests and guiding the infrastructure and promotion changes.
 - [registry.k8s.io: faster, cheaper and Generally Available (GA)](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/)
 - [Managing Kubernetes container registries](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io)
 - [Image pushing jobs](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md)
-- [`kpromo` (promo-tools)](https://github.com/kubernetes-sigs/promo-tools)
+- [Creating promotion pull requests with `kpromo`](https://sigs.k8s.io/promo-tools/docs/promotion-pull-requests.md)
 - [Kubernetes Slack](https://slack.k8s.io/)

--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
@@ -1,0 +1,232 @@
+---
+layout: blog
+title: "Publishing a Kubernetes SIG's Images to registry.k8s.io"
+draft: true
+slug: publishing-images-to-registry-k8s-io
+author: >
+  [Kahiro Okina](https://github.com/kahirokunn) (Craftsman Software, Inc.)
+---
+
+For many Kubernetes SIG projects, shipping container images eventually
+becomes necessary, and `registry.k8s.io` is the official channel for them. I recently published a
+SIG project's first images there. No single step is hard, but the steps live
+in four repositories and have to happen in a particular order, which I mostly
+learned by tripping over them.
+
+This post is the guide I wish I had at the start. The example project is
+`cluster-inventory-api` from
+[SIG Multicluster](https://github.com/kubernetes/community/tree/master/sig-multicluster),
+but nothing in the procedure is specific to that SIG.
+
+## What Cluster Inventory API publishes
+
+Cluster Inventory API helps applications and tools work with multiple
+Kubernetes clusters. It publishes the
+[`secretreader`](https://github.com/kubernetes-sigs/cluster-inventory-api/tree/main/plugins/secretreader/cmd/plugin)
+and
+[`kubeconfig-secretreader`](https://github.com/kubernetes-sigs/cluster-inventory-api/tree/main/plugins/kubeconfig-secretreader/cmd/plugin)
+access-provider plugins as OCI images. Consumers mount these images as
+[image volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/).
+
+## My first plan: ghcr.io
+
+I first tried a common GitHub release pattern: using GitHub Actions to publish
+images to `ghcr.io` on a tag push
+([cluster-inventory-api#40](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/40)).
+The workflow succeeded, but Kubernetes GitHub organizations keep GHCR packages
+private, so GHCR cannot be used for public distribution.
+
+{{< figure src="ghcr-path-blocked.svg" class="text-center" width="660" alt="The blocked GHCR path: a tag push triggers GitHub Actions, which pushes the image to ghcr.io, where it cannot be made public." >}}
+
+As described in the
+[artifacts documentation](https://github.com/kubernetes/k8s.io/tree/main/artifacts#staging-buckets),
+official images take a different route:
+[Prow](https://docs.prow.k8s.io/) (the Kubernetes project's CI/CD system)
+picks up a tag push and runs Google Cloud Build on Kubernetes-owned
+infrastructure to push the image to a staging registry, and the image promoter
+then copies it to `registry.k8s.io`.
+
+{{< figure src="official-publishing-path.svg" class="text-center" width="820" alt="The official publishing path: a tag push triggers a Prow postsubmit job, which runs Cloud Build and pushes to a staging registry. The image promoter then copies the image to registry.k8s.io." >}}
+
+For this project, the images that finally shipped through that route were:
+
+```none
+registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
+```
+
+## The first-time setup, step by step
+
+Besides the image-owning repository, this touches three infrastructure
+repositories: [`kubernetes/k8s.io`](https://github.com/kubernetes/k8s.io),
+[`kubernetes/test-infra`](https://github.com/kubernetes/test-infra), and
+[`kubernetes/org`](https://github.com/kubernetes/org). The pieces depend on
+each other like this:
+
+{{< figure src="dependency-overview.svg" alt="A dependency graph for first-time registry.k8s.io image publishing. The image-owning repository provides cloudbuild.yaml and make release-staging, and a signed release tag triggers the kubernetes/test-infra image-pushing postsubmit job. In kubernetes/k8s.io, a staging Google Group must exist before the staging registry can be created, and that registry is the job's push target. The postsubmit job pushes the staging image. That staging image, together with image promoter config in kubernetes/k8s.io and OWNERS validation through kubernetes/org membership, promotes the image to registry.k8s.io." >}}
+
+### Before you start: choose registry paths, tag policy, and owners
+
+Reading `registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3` from the
+example above: `<project>` is `cluster-inventory-api`, `<image>` is
+`secretreader`, and `v<version>` is `v0.1.3`. For your project, decide:
+
+- `<project>`, which also fixes the staging path
+  `us-central1-docker.pkg.dev/k8s-staging-images/<project>`.
+- `<image>` for each image you ship.
+- The tag policy behind `<version>`.
+- Which SIG owns the project, and who reviews and approves.
+- Who goes in the promotion `OWNERS` file.
+- The staging access group name.
+
+### 1. Make the image-owning repository build images
+
+Set up the repository so that a tag push can build and push a staging image.
+You need:
+
+- a `RELEASE.md` documenting the release steps,
+- a `cloudbuild.yaml` (the `test-infra` job in step 4 invokes this to build
+  and push the image),
+- a Dockerfile and/or Make target to build the image,
+- a release target that pushes to the staging registry (for example
+  `make release-staging`).
+
+References:
+[cluster-inventory-api#53](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/53)
+(moving to the Prow/Cloud Build approach) and
+[cluster-inventory-api#57](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/57)
+(passing the staging repository explicitly to `kpromo`).
+
+### 2. Add a Google Group for staging artifacts
+
+Create the Google Group that will get push access to the staging registry, in
+your SIG's group configuration under `groups/` in `kubernetes/k8s.io`
+([kubernetes/k8s.io#9385](https://github.com/kubernetes/k8s.io/pull/9385)),
+and get approval from your SIG leads or chairs. Keep the group-name suffix
+within the 18-character limit
+([kubernetes/k8s.io#9402](https://github.com/kubernetes/k8s.io/pull/9402)).
+
+### 3. Add a staging registry in kubernetes/k8s.io
+
+Add one entry to the `registries` map in
+`infra/gcp/terraform/k8s-staging-images/registries.tf`, mapping `<project>` to
+the group from step 2. The module gives that group writer access and makes the
+repository publicly readable. Reference:
+[kubernetes/k8s.io#9347](https://github.com/kubernetes/k8s.io/pull/9347).
+
+### 4. Add an image-pushing postsubmit job in kubernetes/test-infra
+
+Add a job under `config/jobs/image-pushing/` that runs the image-owning
+repository's `cloudbuild.yaml` on a tag push and pushes to the staging
+registry. Reference:
+[kubernetes/test-infra#36821](https://github.com/kubernetes/test-infra/pull/36821).
+
+### 5. Push a release tag to build a staging image
+
+With everything above in place, push a
+[signed tag](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags)
+from the image-owning repository:
+
+```bash
+git tag -s v<version>
+git push origin v<version>
+gh release create v<version> --draft --generate-notes --verify-tag
+```
+
+Then verify the staging image:
+
+```bash
+docker manifest inspect us-central1-docker.pkg.dev/k8s-staging-images/<project>/<image>:v<version>
+```
+
+Tag events are not processed retroactively: tags created before the release
+pipeline existed will not produce a staging image.
+
+### 6. Add the image promoter configuration in kubernetes/k8s.io
+
+Open a `kubernetes/k8s.io` PR that adds the promotion configuration for this
+project
+([kubernetes/k8s.io#9499](https://github.com/kubernetes/k8s.io/pull/9499)):
+
+- `registry.k8s.io/images/k8s-staging-<project>/OWNERS`,
+- `registry.k8s.io/images/k8s-staging-<project>/images.yaml` (the promotion
+  target),
+- `registry.k8s.io/manifests/k8s-staging-<project>/promoter-manifest.yaml`.
+
+For the first promotion, include the digest and tag entries for the staging
+images in `images.yaml`, and get `/lgtm` from a SIG lead. For later releases,
+[`kpromo`](https://github.com/kubernetes-sigs/promo-tools) generates this PR
+for you (see the routine release steps below). If you are curious how the
+promotion machinery works, see
+[The Invisible Rewrite: Modernizing the Kubernetes Image Promoter](https://kubernetes.io/blog/2026/03/17/image-promoter-rewrite/).
+
+If anyone you plan to list in `OWNERS` is not yet a Kubernetes organization
+member, submit a membership request first
+([kubernetes/org#6385](https://github.com/kubernetes/org/pull/6385),
+[kubernetes/org#6386](https://github.com/kubernetes/org/pull/6386)).
+
+### 7. Verify the release and publish it
+
+Once the promotion PR merges, run the project's release verification and
+confirm the production image is available:
+
+```bash
+docker manifest inspect registry.k8s.io/<project>/<image>:v<version>
+```
+
+When that works, publish or update the GitHub release and announce it in the
+related issues and Slack channels.
+
+### Where to ask for help
+
+Several of these steps depend on other people: reviewers, approvers, and SIG
+leads. Expect to wait on reviews between steps rather than finishing in one
+sitting. On the [Kubernetes Slack](https://slack.k8s.io/), these channels line
+up with the work:
+
+| Channel | Use it for |
+| --- | --- |
+| `#github-management` | Repository access, GHCR questions, and Kubernetes organization membership |
+| `#sig-k8s-infra` | The staging Google Group and staging registry |
+
+## After the first time, it is much lighter
+
+Routine releases only touch the image-owning repository and one promotion PR:
+
+1. Push a signed tag, create a draft GitHub release, and confirm the
+   postsubmit pushed the staging image, as in step 5 of the first-time setup.
+2. Create the promotion PR with `kpromo pr`, naming the Artifact Registry
+   staging repository explicitly with `--staging-repo`:
+
+   ```bash
+   kpromo pr \
+     --fork <your-github-username> \
+     --project <project> \
+     --tag v<version> \
+     --staging-repo us-central1-docker.pkg.dev/k8s-staging-images/<project>
+   ```
+
+3. Once the promotion PR is reviewed and merged, finish as in step 7 of the
+   first-time setup.
+
+## Acknowledgments
+
+Thanks to [Mike Ng](https://github.com/mikeshng) and
+[Laura Lorenz](https://github.com/lauralorenz) for attending meetings on my
+behalf, connecting me with the right people, and coordinating the work across
+SIG Multicluster; [Jian Qiu](https://github.com/qiujian16) for reviewing the
+implementation;
+[Stephen Kitt](https://github.com/skitt) for reviewing the release process and
+clarifying the publishing rules; and
+[Arnaud M.](https://github.com/ameukam) for reviewing the `kubernetes/k8s.io`
+pull requests and guiding the infrastructure and promotion changes.
+
+## References
+
+- [cluster-inventory-api releases](https://github.com/kubernetes-sigs/cluster-inventory-api/releases)
+- [Using Plugin OCI Images](https://github.com/kubernetes-sigs/cluster-inventory-api/blob/main/docs/plugin-images.md)
+- [Image volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/)
+- [registry.k8s.io: faster, cheaper and Generally Available (GA)](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/)
+- [Publishing official artifact images (`kubernetes/k8s.io/artifacts`)](https://github.com/kubernetes/k8s.io/tree/main/artifacts#staging-buckets)
+- [`kpromo` (promo-tools)](https://github.com/kubernetes-sigs/promo-tools)
+- [Kubernetes Slack](https://slack.k8s.io/)

--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
@@ -239,14 +239,3 @@ implementation;
 clarifying the publishing rules; and
 [Arnaud M.](https://github.com/ameukam) for reviewing the `kubernetes/k8s.io`
 pull requests and guiding the infrastructure and promotion changes.
-
-## References
-
-- [cluster-inventory-api releases](https://github.com/kubernetes-sigs/cluster-inventory-api/releases)
-- [Using Plugin OCI Images](https://github.com/kubernetes-sigs/cluster-inventory-api/blob/main/docs/plugin-images.md)
-- [Image volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/)
-- [registry.k8s.io: faster, cheaper and Generally Available (GA)](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/)
-- [Managing Kubernetes container registries](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io)
-- [Image pushing jobs](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md)
-- [Creating promotion pull requests with `kpromo`](https://sigs.k8s.io/promo-tools/docs/promotion-pull-requests.md)
-- [Kubernetes Slack](https://slack.k8s.io/)

--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
@@ -7,28 +7,23 @@ author: >
   [Kahiro Okina](https://github.com/kahirokunn) (Craftsman Software, Inc.)
 ---
 
-For many Kubernetes SIG projects, shipping container images eventually
-becomes necessary, and `registry.k8s.io` is the official channel for them. I recently published a
-SIG project's first images there. No single step is hard, but the steps live
-in four repositories and have to happen in a particular order, which I mostly
-learned by tripping over them.
+If you're publishing container images for a Kubernetes SIG project, you might
+expect the same publishing workflow used by other container registries to work.
+That was my assumption too. My workflow successfully published the images, but
+they weren't publicly available. Instead, official Kubernetes project images
+are distributed through
+[registry.k8s.io](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io),
+the Kubernetes project's official container image registry.
 
-This post is the guide I wish I had at the start. The example project is
-`cluster-inventory-api` from
-[SIG Multicluster](https://github.com/kubernetes/community/tree/master/sig-multicluster),
-but nothing in the procedure is specific to that SIG.
+No single step was hard, but the steps were spread across multiple repositories
+and had to happen in a particular order, something I mostly learned by tripping
+over them. This post is the guide I wish I had at the start. It walks through
+that workflow end to end using Cluster Inventory API from
+[SIG Multicluster](https://github.com/kubernetes/community/tree/master/sig-multicluster)
+as an example. The same process applies to eligible Kubernetes subprojects that
+publish official container images.
 
-## What Cluster Inventory API publishes
-
-Cluster Inventory API helps applications and tools work with multiple
-Kubernetes clusters. It publishes the
-[`secretreader`](https://github.com/kubernetes-sigs/cluster-inventory-api/tree/main/plugins/secretreader/cmd/plugin)
-and
-[`kubeconfig-secretreader`](https://github.com/kubernetes-sigs/cluster-inventory-api/tree/main/plugins/kubeconfig-secretreader/cmd/plugin)
-access-provider plugins as OCI images. Consumers mount these images as
-[image volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/).
-
-## My first plan: ghcr.io
+## My first attempt: GHCR
 
 I first tried a common GitHub release pattern: using GitHub Actions to publish
 images to `ghcr.io` on a tag push
@@ -39,7 +34,7 @@ private, so GHCR cannot be used for public distribution.
 {{< figure src="ghcr-path-blocked.svg" class="text-center" width="660" alt="The blocked GHCR path: a tag push triggers GitHub Actions, which pushes the image to ghcr.io, where it cannot be made public." >}}
 
 As described in the
-[artifacts documentation](https://github.com/kubernetes/k8s.io/tree/main/artifacts#staging-buckets),
+[registry.k8s.io documentation](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io),
 official images take a different route:
 [Prow](https://docs.prow.k8s.io/) (the Kubernetes project's CI/CD system)
 picks up a tag push and runs Google Cloud Build on Kubernetes-owned
@@ -47,13 +42,6 @@ infrastructure to push the image to a staging registry, and the image promoter
 then copies it to `registry.k8s.io`.
 
 {{< figure src="official-publishing-path.svg" class="text-center" width="820" alt="The official publishing path: a tag push triggers a Prow postsubmit job, which runs Cloud Build and pushes to a staging registry. The image promoter then copies the image to registry.k8s.io." >}}
-
-For this project, the images that finally shipped through that route were:
-
-```none
-registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
-registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
-```
 
 ## The first-time setup, step by step
 
@@ -63,33 +51,36 @@ repositories: [`kubernetes/k8s.io`](https://github.com/kubernetes/k8s.io),
 [`kubernetes/org`](https://github.com/kubernetes/org). The pieces depend on
 each other like this:
 
-{{< figure src="dependency-overview.svg" alt="A dependency graph for first-time registry.k8s.io image publishing. The image-owning repository provides cloudbuild.yaml and make release-staging, and a signed release tag triggers the kubernetes/test-infra image-pushing postsubmit job. In kubernetes/k8s.io, a staging Google Group must exist before the staging registry can be created, and that registry is the job's push target. The postsubmit job pushes the staging image. That staging image, together with image promoter config in kubernetes/k8s.io and OWNERS validation through kubernetes/org membership, promotes the image to registry.k8s.io." >}}
+{{< figure src="dependency-overview.svg" alt="A dependency graph for first-time registry.k8s.io image publishing. The image-owning repository provides cloudbuild.yaml and image build configuration, and a signed release tag triggers the kubernetes/test-infra image-pushing postsubmit job. In kubernetes/k8s.io, a staging Google Group must exist before the staging registry can be created, and that registry is the job's push target. The postsubmit job pushes the staging image. That staging image, together with image promoter config in kubernetes/k8s.io and OWNERS validation through kubernetes/org membership, promotes the image to registry.k8s.io." >}}
 
-### Before you start: choose registry paths, tag policy, and owners
+### Before you start: decide your project details
 
-Reading `registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3` from the
-example above: `<project>` is `cluster-inventory-api`, `<image>` is
-`secretreader`, and `v<version>` is `v0.1.3`. For your project, decide:
+Before setting up the publishing workflow, decide a few project-specific
+details. These values will be reused throughout the setup when creating the
+staging registry, configuring image builds, and setting up image promotion:
 
-- `<project>`, which also fixes the staging path
+- `<project>`, which determines the staging registry path
   `us-central1-docker.pkg.dev/k8s-staging-images/<project>`.
 - `<image>` for each image you ship.
-- The tag policy behind `<version>`.
-- Which SIG owns the project, and who reviews and approves.
-- Who goes in the promotion `OWNERS` file.
-- The staging access group name.
+- Decide how your project will version releases.
 
-### 1. Make the image-owning repository build images
+For the Cluster Inventory API example, these values form
+`registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3`, where `<project>`
+is `cluster-inventory-api`, `<image>` is `secretreader`, and `<version>` is
+`0.1.3`.
 
-Set up the repository so that a tag push can build and push a staging image.
-You need:
+### 1. Set up your project repository to build images
+
+Before Kubernetes infrastructure can build and publish your images, the
+image-owning repository must define how they are built. As described in the
+[image-pushing documentation](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md),
+this requires:
 
 - a `RELEASE.md` documenting the release steps,
-- a `cloudbuild.yaml` (the `test-infra` job in step 4 invokes this to build
-  and push the image),
-- a Dockerfile and/or Make target to build the image,
-- a release target that pushes to the staging registry (for example
-  `make release-staging`).
+- a `cloudbuild.yaml` file that invokes the project's image build and push
+  process,
+- the project-specific build configuration invoked by `cloudbuild.yaml`. See
+  the [build example](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#build-example).
 
 References:
 [cluster-inventory-api#53](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/53)
@@ -99,12 +90,19 @@ References:
 
 ### 2. Add a Google Group for staging artifacts
 
-Create the Google Group that will get push access to the staging registry, in
-your SIG's group configuration under `groups/` in `kubernetes/k8s.io`
-([kubernetes/k8s.io#9385](https://github.com/kubernetes/k8s.io/pull/9385)),
-and get approval from your SIG leads or chairs. Keep the group-name suffix
-within the 18-character limit
-([kubernetes/k8s.io#9402](https://github.com/kubernetes/k8s.io/pull/9402)).
+Kubernetes uses a Google Group to control who can push images into the staging
+registry. Before the registry can be created, this group must exist.
+
+Create a Google Group named
+`k8s-infra-staging-<project-name>@kubernetes.io` in your SIG's
+[`groups/` configuration](https://github.com/kubernetes/k8s.io/tree/main/groups)
+in `kubernetes/k8s.io`. After the PR merges, Kubernetes infrastructure creates
+the group automatically. For example, see
+[kubernetes/k8s.io#9385](https://github.com/kubernetes/k8s.io/pull/9385).
+
+Keep the `<project-name>` suffix within the **18-character limit**. See
+[kubernetes/k8s.io#9402](https://github.com/kubernetes/k8s.io/pull/9402) for an
+example where the group name was shortened to meet this requirement.
 
 ### 3. Add a staging registry in kubernetes/k8s.io
 
@@ -118,7 +116,9 @@ repository publicly readable. Reference:
 
 Add a job under `config/jobs/image-pushing/` that runs the image-owning
 repository's `cloudbuild.yaml` on a tag push and pushes to the staging
-registry. Reference:
+registry. See the
+[Prow config template](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#prow-config-template).
+For reference:
 [kubernetes/test-infra#36821](https://github.com/kubernetes/test-infra/pull/36821).
 
 ### 5. Push a release tag to build a staging image
@@ -133,16 +133,20 @@ git push origin v<version>
 gh release create v<version> --draft --generate-notes --verify-tag
 ```
 
-Then verify the staging image:
-
-```bash
-docker manifest inspect us-central1-docker.pkg.dev/k8s-staging-images/<project>/<image>:v<version>
-```
+Verify that the image was successfully published to the staging registry.
 
 Tag events are not processed retroactively: tags created before the release
 pipeline existed will not produce a staging image.
 
+Note: Staging registries have a 90-day retention policy and are intended only
+for intermediate builds. End users should consume images from
+`registry.k8s.io` after they have been promoted.
+
 ### 6. Add the image promoter configuration in kubernetes/k8s.io
+
+At this point, the image exists only in the staging registry. The next step
+configures the Image Promoter, which copies approved images into the public
+`registry.k8s.io` registry.
 
 Open a `kubernetes/k8s.io` PR that adds the promotion configuration for this
 project
@@ -152,6 +156,10 @@ project
 - `registry.k8s.io/images/k8s-staging-<project>/images.yaml` (the promotion
   target),
 - `registry.k8s.io/manifests/k8s-staging-<project>/promoter-manifest.yaml`.
+
+The `promoter-manifest.yaml` file stores credentials and other registry
+metadata, while `images.yaml` stores the image data. The `OWNERS` file lets more
+project members approve new images for promotion.
 
 For the first promotion, include the digest and tag entries for the staging
 images in `images.yaml`, and get `/lgtm` from a SIG lead. For later releases,
@@ -167,11 +175,21 @@ member, submit a membership request first
 
 ### 7. Verify the release and publish it
 
-Once the promotion PR merges, run the project's release verification and
-confirm the production image is available:
+Once the promotion PR merges, the image promoter workflow publishes the image
+from the staging registry to `registry.k8s.io`. The promotion is handled by
+Kubernetes CI jobs:
 
-```bash
-docker manifest inspect registry.k8s.io/<project>/<image>:v<version>
+- `post-k8sio-image-promo` runs after the merge and performs the promotion.
+- `ci-k8sio-image-promo` periodically retries promotions in case of transient
+  failures.
+
+Verify that the promotion jobs complete successfully and that the image is
+available from `registry.k8s.io`. For Cluster Inventory API, the images that
+shipped through this route were:
+
+```none
+registry.k8s.io/cluster-inventory-api/secretreader:v0.1.3
+registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.3
 ```
 
 When that works, publish or update the GitHub release and announce it in the
@@ -186,8 +204,8 @@ up with the work:
 
 | Channel | Use it for |
 | --- | --- |
-| `#github-management` | Repository access, GHCR questions, and Kubernetes organization membership |
-| `#sig-k8s-infra` | The staging Google Group and staging registry |
+| [`#github-management`](https://kubernetes.slack.com/archives/C01672LSZL0) | Repository access, Kubernetes organization membership, and GitHub-related questions |
+| [`#sig-k8s-infra`](https://kubernetes.slack.com/archives/CCK68P2Q2) | The staging Google Group, staging registry, and image publishing infrastructure |
 
 ## After the first time, it is much lighter
 
@@ -227,6 +245,7 @@ pull requests and guiding the infrastructure and promotion changes.
 - [Using Plugin OCI Images](https://github.com/kubernetes-sigs/cluster-inventory-api/blob/main/docs/plugin-images.md)
 - [Image volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/)
 - [registry.k8s.io: faster, cheaper and Generally Available (GA)](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/)
-- [Publishing official artifact images (`kubernetes/k8s.io/artifacts`)](https://github.com/kubernetes/k8s.io/tree/main/artifacts#staging-buckets)
+- [Managing Kubernetes container registries](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io)
+- [Image pushing jobs](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md)
 - [`kpromo` (promo-tools)](https://github.com/kubernetes-sigs/promo-tools)
 - [Kubernetes Slack](https://slack.k8s.io/)

--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/index.md
@@ -138,9 +138,11 @@ Verify that the image was successfully published to the staging registry.
 Tag events are not processed retroactively: tags created before the release
 pipeline existed will not produce a staging image.
 
-Note: Staging registries have a 90-day retention policy and are intended only
+{{< alert color="info" title="Note" >}}
+Staging registries have a 90-day retention policy and are intended only
 for intermediate builds. End users should consume images from
 `registry.k8s.io` after they have been promoted.
+{{< /alert >}}
 
 ### 6. Add the image promoter configuration in kubernetes/k8s.io
 

--- a/content/en/blog/2026/publishing-images-to-registry-k8s-io/official-publishing-path.svg
+++ b/content/en/blog/2026/publishing-images-to-registry-k8s-io/official-publishing-path.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 170" font-family="Arial, Helvetica, sans-serif" font-size="13" role="img" aria-label="The official publishing path: a tag push triggers a Prow postsubmit job, which runs Cloud Build and pushes to a staging registry. The image promoter then copies the image to registry.k8s.io.">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 z" fill="#37474f"/>
+    </marker>
+  </defs>
+
+  <rect x="10" y="10" width="960" height="150" rx="8" fill="#fafafa" stroke="#bdbdbd"/>
+  <text x="30" y="32" fill="#616161" font-weight="bold">The official path</text>
+
+  <rect x="30" y="65" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+  <text x="95" y="95" text-anchor="middle">tag push</text>
+
+  <rect x="190" y="65" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+  <text x="255" y="95" text-anchor="middle">Prow postsubmit</text>
+
+  <rect x="350" y="65" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+  <text x="415" y="95" text-anchor="middle">Cloud Build</text>
+
+  <rect x="510" y="65" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+  <text x="575" y="95" text-anchor="middle">staging registry</text>
+
+  <rect x="670" y="65" width="130" height="50" rx="6" fill="#eaf2fd" stroke="#5b8def"/>
+  <text x="735" y="95" text-anchor="middle">image promoter</text>
+
+  <rect x="830" y="65" width="130" height="50" rx="6" fill="#e8f5e9" stroke="#66bb6a"/>
+  <text x="895" y="95" text-anchor="middle" fill="#2e7d32">registry.k8s.io</text>
+
+  <line x1="164" y1="90" x2="186" y2="90" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="324" y1="90" x2="346" y2="90" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="484" y1="90" x2="506" y2="90" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="644" y1="90" x2="666" y2="90" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="804" y1="90" x2="826" y2="90" stroke="#37474f" stroke-width="1.5" marker-end="url(#arrow)"/>
+</svg>


### PR DESCRIPTION
## Description

This PR adds an English Kubernetes contributor blog post about publishing a Kubernetes SIG's container images through `registry.k8s.io`.

Moved from https://github.com/kubernetes/website/pull/56246 after blog team feedback that the content is more appropriate for `kubernetes/contributor-site`.

The post uses the `secretreader` and `kubeconfig-secretreader` images of `cluster-inventory-api` as a concrete example.
It explains why GHCR is not the official distribution path for Kubernetes project images, then documents the first-time setup across:

- image-owning repository
- `kubernetes/k8s.io`
- `kubernetes/test-infra`
- `kubernetes/org`

It also includes three SVG diagrams that compare the GHCR and official publication paths and show the dependency order for first-time `registry.k8s.io` setup.

## SIG feedback

https://kubernetes.slack.com/archives/CCK68P2Q2/p1785504175857279

## Issue

N/A

/area blog
/sig multicluster
