### PR TITLE
cleanup: move blogs authors to hugo blog frontmatter and adjusts 2022 kcseu title

### DIFF
--- a/content/en/blog/2021/contributor-celebration.md
+++ b/content/en/blog/2021/contributor-celebration.md
@@ -2,10 +2,8 @@
 title: "Announcing the Kubernetes Contributor Celebration 2021"
 linkTitle: "Contributor Celebration 2021"
 date: 2021-12-07
-author: "Debabrata Panigrahi"
+author: "[Debabrata Panigrahi](https://twitter.com/debaelopedev)"
 ---
-
-By [Debabrata Panigrahi](https://twitter.com/debaelopedev)
 
 ## Contributor Celebration 2021
 

--- a/content/en/blog/2021/contributor-story.md
+++ b/content/en/blog/2021/contributor-story.md
@@ -3,9 +3,8 @@ title: "Announcing the Kubernetes Contributor Stories Series"
 linkTitle: "Share your Kubernetes Contributor Story"
 date: 2021-05-14
 slug: contributor-stories-series
+author: "[Matt Broberg](https://twitter.com/mbbroberg)"
 ---
-
-By [Matt Broberg](https://twitter.com/mbbroberg)
 
 The Kubernetes contributor community is vast. We have tens of thousands of members by any conservative estimate and many hundreds involved day-to-day. We are from all around the world, all kinds of backgrounds, all types of expertise, and we are all Kubernetes contributors.
 

--- a/content/en/blog/2021/non-code-contribution.md
+++ b/content/en/blog/2021/non-code-contribution.md
@@ -2,9 +2,8 @@
 title: "How to choose a SIG as a non-code Kubernetes contributor"
 linkTitle: "How to choose a SIG as a non-code Kubernetes contributor"
 date: 2021-07-09
-author: "Chris Short"
+author: "[Chris Short](https://twitter.com/ChrisShort)"
 ---
-By [Chris Short](https://twitter.com/ChrisShort)
 
 Kubernetes contributors aren't people in capes or part of some secret society. How to start committing to the GitHub repos that make up the project [is well documented](https://www.kubernetes.dev/docs/guide/), yet it remains intimidating for many.
 

--- a/content/en/blog/2021/peeyush-contributor-story.md
+++ b/content/en/blog/2021/peeyush-contributor-story.md
@@ -2,7 +2,8 @@
 layout: blog
 title: "From Kubernetes for work to Kubernetes for play" 
 date: 2021-06-01
-Slug: peeyush-contributor-story
+slug: peeyush-contributor-story
+author: "[Peeyush Gupta](https://twitter.com/pensu91)"
 ---
 
 {{% alert color="primary" %}}
@@ -28,8 +29,6 @@ We have started to collect some of our <a href="https://github.com/cncf/memorial
 If you would like to share some of your own, please <a href="https://github.com/cncf/memorials/blob/main/peeyush-gupta.md" target="_blank" rel="noreferrer">open a PR adding your own memories of him.</a>
 
 {{% /alert %}}
-
-By [Peeyush Gupta](https://twitter.com/pensu91)
 
 My first encounter with Kubernetes was at my first job when a large banking customer wanted to evaluate Kubernetes on ppc64le architecture for application deployment. I was intrigued as it wasn't every day when a bank seeks to consider something new! That was also my first interaction with Golang and I loved it instantly. I mean, who doesn't love a cross compiled statically linked binary?! Before that, I was mostly working with Python and OpenStack, which are great as well. But Kubernetes opened a whole new world for me. Being familiar with Docker, which still was pretty new at that time, and the awesome cross-compilation capabilities of Go, I was quickly able to build a proof of concept, and my team loved it. 
 

--- a/content/en/events/2022/kcseu/social.md
+++ b/content/en/events/2022/kcseu/social.md
@@ -1,10 +1,9 @@
 ---
-title: Contributor Social
+title: Contributor Social at La Casa Del Mar
+linkTitle: Contributor Social
 type: docs
 weight: 5
 ---
-
-## Contributor Social at La Casa Del Mar
 
 <img align="right" src="/events/2022/kcseu/casadelmar.jpg" width="30%" alt="La Casa de la Mar venue">
 

--- a/content/en/events/2022/kcseu/social.md
+++ b/content/en/events/2022/kcseu/social.md
@@ -1,9 +1,10 @@
 ---
-title: Contributor Social at La Casa Del Mar
-linkTitle: Contributor Social
+title: Contributor Social
 type: docs
 weight: 5
 ---
+
+## Contributor Social at La Casa Del Mar
 
 <img align="right" src="/events/2022/kcseu/casadelmar.jpg" width="30%" alt="La Casa de la Mar venue">
 


### PR DESCRIPTION
Refs: https://github.com/kubernetes/contributor-site/pull/761

- fixes the author section to be within the hugo blog frontmatter
- moves 2022 kcseu page h2 to `title`

### Preview Pages to Test
- [Announcing the Kubernetes Contributor Celebration 2021](https://deploy-preview-818--kubernetes-contributor.netlify.app/blog/2021/12/07/announcing-the-kubernetes-contributor-celebration-2021/)
- [Announcing the Kubernetes Contributor Stories Series](https://deploy-preview-818--kubernetes-contributor.netlify.app/blog/2021/05/14/contributor-stories-series/)
- [How to choose a SIG as a non-code Kubernetes contributor](https://deploy-preview-818--kubernetes-contributor.netlify.app/blog/2021/07/09/how-to-choose-a-sig-as-a-non-code-kubernetes-contributor/)
- [From Kubernetes for work to Kubernetes for play](https://deploy-preview-818--kubernetes-contributor.netlify.app/blog/2021/06/01/peeyush-contributor-story/)
- [Contributor Social at La Casa Del Mar](https://deploy-preview-818--kubernetes-contributor.netlify.app/events/2022/kcseu/social/)

cc. @chris-short 
