### PR TITLE
Add language/en OWNERS file for content/en prs

### DIFF
--- a/content/en/OWNERS
+++ b/content/en/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the directory for English source content.
+# Teams and members are visible at https://github.com/orgs/kubernetes/teams.
+
+labels:
+- language/en


### PR DESCRIPTION
This PR adds a `language/en` OWNERS file to the `content/en` directory. 

This automatically applies the `language/en` label to pull requests that modify files in `content/en`.