### PR TITLE
fix: center GitHub link icon/text in KEP related-enhancements list

### DIFF
--- a/assets/scss/_kep_page.scss
+++ b/assets/scss/_kep_page.scss
@@ -229,7 +229,7 @@
         color: $slate-700;
         text-decoration: none;
         display: flex;
-        align-items: flex-start;
+        align-items: center;
         gap: 8px;
         transition: all 0.2s ease;
         min-width: 0;


### PR DESCRIPTION
Centers the icon for Related Enhancements:

<img width="489" height="106" alt="image" src="https://github.com/user-attachments/assets/cc2d49c5-0439-49d0-90d3-88e8d1080f3a" />

Page to test: https://deploy-preview-824--kubernetes-contributor.netlify.app/resources/keps/6072/