### PR TITLE
fix: link see-also KEP references to their pages on this site

### DIFF
--- a/layouts/keps/single.html
+++ b/layouts/keps/single.html
@@ -81,15 +81,7 @@
           <div class="kep-banner-sublabel">Related Enhancements</div>
           <ul class="kep-link-list">
             {{ range . }}
-            <li>
-              {{- if and (strings.HasPrefix . "http") (not (strings.Contains . "[")) -}}
-                <a href="{{ . }}" target="_blank" rel="noopener"><i class="fas fa-external-link-alt"></i> {{ . }}</a>
-              {{- else if and (strings.HasPrefix . "/") (not (strings.Contains . "[")) -}}
-                <a href="https://github.com/kubernetes/enhancements/tree/master{{ . }}" target="_blank" rel="noopener"><i class="fab fa-github"></i> {{ . }}</a>
-              {{- else -}}
-                {{ . | markdownify }}
-              {{- end -}}
-            </li>
+            <li>{{- partial "keps/see-also.html" . -}}</li>
             {{ end }}
           </ul>
         </div>

--- a/layouts/partials/keps/page-by-number.html
+++ b/layouts/partials/keps/page-by-number.html
@@ -1,11 +1,13 @@
-{{- /* Returns this site's page for a KEP number, or nil when that KEP has no page.
+{{- /* Returns this site's page for a KEP number, or "" when that KEP has no page.
        Not every KEP gets one — see content/en/resources/keps/_content.gotmpl for the
        stage/status filter. Keeps the /resources/keps/<number>/ URL scheme in one place.
 
        @param {string} context The KEP number, e.g. "4569".
-       @returns {page.Page}
+       @returns {page.Page|string} The page, or "" when there is none — falsy either way,
+                so callers can reach for `with`.
 */ -}}
 {{- $page := "" -}}
+{{- /* An empty number would make GetPage return the section page listing every KEP. */ -}}
 {{- with printf "%v" . -}}
   {{- $page = site.GetPage (printf "resources/keps/%s" .) -}}
 {{- end -}}

--- a/layouts/partials/keps/page-by-number.html
+++ b/layouts/partials/keps/page-by-number.html
@@ -1,0 +1,12 @@
+{{- /* Returns this site's page for a KEP number, or nil when that KEP has no page.
+       Not every KEP gets one — see content/en/resources/keps/_content.gotmpl for the
+       stage/status filter. Keeps the /resources/keps/<number>/ URL scheme in one place.
+
+       @param {string} context The KEP number, e.g. "4569".
+       @returns {page.Page}
+*/ -}}
+{{- $page := "" -}}
+{{- with printf "%v" . -}}
+  {{- $page = site.GetPage (printf "resources/keps/%s" .) -}}
+{{- end -}}
+{{- return $page -}}

--- a/layouts/partials/keps/see-also.html
+++ b/layouts/partials/keps/see-also.html
@@ -3,9 +3,11 @@
        - full URL:           "https://…"
        - root-relative path: "/keps/sig-scheduling/624-scheduling-framework"
        - bare repo path:     "keps/sig-node/4569-cgroup-v1-maintenance-mode/README.md"
+       - nested path:        "/keps/prod-readiness/sig-apps/3329"
+       - singular "/kep/":   "/kep/sig-network/0752-endpointslices/"
        - free text:          "KEP-32", "TBD", "n/a"
 
-       Both path shapes resolve to the referenced KEP's own page on this site, so every
+       Every path shape resolves to the referenced KEP's own page on this site, so every
        entry reads the same way regardless of how it was written. Paths we can't resolve
        fall back to GitHub, and anything else is left as text.
 
@@ -17,9 +19,14 @@
 {{- else if strings.HasPrefix $entry "http" -}}
   <a href="{{ $entry }}" target="_blank" rel="noopener"><i class="fas fa-external-link-alt"></i> {{ $entry }}</a>
 {{- else -}}
-  {{- $path := cond (strings.HasPrefix $entry "/") $entry (printf "/%s" $entry) -}}
+  {{- $path := printf "/%s" (strings.TrimPrefix "/" $entry) -}}
+  {{- /* A few entries write "/kep/…" for "/keps/…"; normalizing here fixes both the
+         lookup below and the directory name the GitHub fallback links to. */ -}}
+  {{- $path = replaceRE `^/kep/` "/keps/" $path -}}
   {{- $kep := "" -}}
-  {{- with findRESubmatch `^/keps/[^/]+/([0-9]+)([^/]*)` $path 1 -}}
+  {{- /* The SIG is usually the only directory before the number, but some entries nest
+         further ("/keps/prod-readiness/sig-apps/3329", kubeadm's own subdirectory). */ -}}
+  {{- with findRESubmatch `^/keps/(?:[^/]+/)*([0-9]+)([^/]*)` $path 1 -}}
     {{- $number := index . 0 1 -}}
     {{- $directory := printf "%s%s" $number (index . 0 2) -}}
     {{- with partial "keps/page-by-number.html" (strings.TrimLeft "0" $number) -}}

--- a/layouts/partials/keps/see-also.html
+++ b/layouts/partials/keps/see-also.html
@@ -17,7 +17,7 @@
 {{- if strings.Contains $entry "[" -}}
   {{ $entry | markdownify }}
 {{- else if strings.HasPrefix $entry "http" -}}
-  <a href="{{ $entry }}" target="_blank" rel="noopener"><i class="fas fa-external-link-alt"></i> {{ $entry }}</a>
+  <a href="{{ $entry }}" target="_blank" rel="noopener"><i class="fas fa-external-link-alt" aria-hidden="true"></i> {{ $entry }}</a>
 {{- else -}}
   {{- $path := printf "/%s" (strings.TrimPrefix "/" $entry) -}}
   {{- /* A few entries write "/kep/…" for "/keps/…"; normalizing here fixes both the
@@ -29,7 +29,8 @@
   {{- with findRESubmatch `^/keps/(?:[^/]+/)*([0-9]+)([^/]*)` $path 1 -}}
     {{- $number := index . 0 1 -}}
     {{- $directory := printf "%s%s" $number (index . 0 2) -}}
-    {{- with partial "keps/page-by-number.html" (strings.TrimLeft "0" $number) -}}
+    {{- $lookup := strings.TrimLeft "0" $number -}}
+    {{- with partialCached "keps/page-by-number.html" $lookup $lookup -}}
       {{- /* A zero-padded number is legacy per-directory numbering ("0006-apply.md",
              kubeadm's "0023-kubeadm-config.md") that only coincidentally matches a
              modern KEP number, so require an exact directory match before trusting it.
@@ -41,9 +42,9 @@
     {{- end -}}
   {{- end -}}
   {{- if $kep -}}
-    <a href="{{ $kep.RelPermalink }}"><i class="fas fa-link"></i> KEP-{{ $kep.Params.kepNumber }}: {{ $kep.Title }}</a>
+    <a href="{{ $kep.RelPermalink }}"><i class="fas fa-link" aria-hidden="true"></i> KEP-{{ $kep.Params.kepNumber }}: {{ $kep.Title }}</a>
   {{- else if strings.Contains $path "/keps/" -}}
-    <a href="https://github.com/kubernetes/enhancements/tree/master{{ $path }}" target="_blank" rel="noopener"><i class="fab fa-github"></i> {{ $entry }}</a>
+    <a href="https://github.com/kubernetes/enhancements/tree/master{{ $path }}" target="_blank" rel="noopener"><i class="fab fa-github" aria-hidden="true"></i> {{ $entry }}</a>
   {{- else -}}
     {{ $entry | markdownify }}
   {{- end -}}

--- a/layouts/partials/keps/see-also.html
+++ b/layouts/partials/keps/see-also.html
@@ -1,0 +1,43 @@
+{{- /* Renders one KEP `seeAlso` entry as a link. Shapes present in keps.json:
+       - markdown link:      "[Title](https://…)"
+       - full URL:           "https://…"
+       - root-relative path: "/keps/sig-scheduling/624-scheduling-framework"
+       - bare repo path:     "keps/sig-node/4569-cgroup-v1-maintenance-mode/README.md"
+       - free text:          "KEP-32", "TBD", "n/a"
+
+       Both path shapes resolve to the referenced KEP's own page on this site, so every
+       entry reads the same way regardless of how it was written. Paths we can't resolve
+       fall back to GitHub, and anything else is left as text.
+
+       @param {string} context One seeAlso entry.
+*/ -}}
+{{- $entry := . -}}
+{{- if strings.Contains $entry "[" -}}
+  {{ $entry | markdownify }}
+{{- else if strings.HasPrefix $entry "http" -}}
+  <a href="{{ $entry }}" target="_blank" rel="noopener"><i class="fas fa-external-link-alt"></i> {{ $entry }}</a>
+{{- else -}}
+  {{- $path := cond (strings.HasPrefix $entry "/") $entry (printf "/%s" $entry) -}}
+  {{- $kep := "" -}}
+  {{- with findRESubmatch `^/keps/[^/]+/([0-9]+)([^/]*)` $path 1 -}}
+    {{- $number := index . 0 1 -}}
+    {{- $directory := printf "%s%s" $number (index . 0 2) -}}
+    {{- with partial "keps/page-by-number.html" (strings.TrimLeft "0" $number) -}}
+      {{- /* A zero-padded number is legacy per-directory numbering ("0006-apply.md",
+             kubeadm's "0023-kubeadm-config.md") that only coincidentally matches a
+             modern KEP number, so require an exact directory match before trusting it.
+             Unpadded numbers are global KEP numbers and stay correct even when the
+             KEP's directory has since been renamed. */ -}}
+      {{- if or (not (strings.HasPrefix $number "0")) (eq .Params.name $directory) -}}
+        {{- $kep = . -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $kep -}}
+    <a href="{{ $kep.RelPermalink }}"><i class="fas fa-link"></i> KEP-{{ $kep.Params.kepNumber }}: {{ $kep.Title }}</a>
+  {{- else if strings.Contains $path "/keps/" -}}
+    <a href="https://github.com/kubernetes/enhancements/tree/master{{ $path }}" target="_blank" rel="noopener"><i class="fab fa-github"></i> {{ $entry }}</a>
+  {{- else -}}
+    {{ $entry | markdownify }}
+  {{- end -}}
+{{- end -}}

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -19,7 +19,6 @@
 {{- end -}}
 
 {{- $validStages := slice "alpha" "beta" "stable" "deprecated" -}}
-{{- $validStatuses := slice "implementable" "implemented" -}}
 
 {{- /* Build unique release and SIG lists */ -}}
 {{- $releaseSet := dict -}}
@@ -114,9 +113,8 @@
       </thead>
       <tbody>
         {{ range $data := $kepData }}
-          {{- $hasValidStage := and $data.stage (in $validStages $data.stage) -}}
-          {{- $hasValidStatus := and $data.status (in $validStatuses $data.status) -}}
-          {{- $hasPage := or $hasValidStage $hasValidStatus -}}
+          {{- /* The KEP's own page on this site, or nil when it has none. */ -}}
+          {{- $kepPage := partial "keps/page-by-number.html" $data.kepNumber -}}
           {{- $stage := $data.stage -}}
           {{- if not $stage }}
             {{- if or (eq $data.status "implementable") (eq $data.status "implemented") }}
@@ -144,15 +142,15 @@
           {{- $allAuthors = strings.TrimLeft $allAuthors " " -}}
           <tr data-stage="{{ $stage }}" data-latest-milestone="{{ if $latest }}{{ strings.TrimPrefix "v" $latest }}{{ end }}" data-sig="{{ $data.owningSig }}" data-kep="{{ $data.kepNumber }}" data-created="{{ $data.creationDate }}" data-authors="{{ $allAuthors }}">
             <td class="kep-col-number" data-order="{{ $data.kepNumber }}">
-              {{- if $hasPage }}
-              <a href="/resources/keps/{{ $data.kepNumber }}/" class="kep-number-link">{{ $data.kepNumber }}</a>
+              {{- with $kepPage }}
+              <a href="{{ .RelPermalink }}" class="kep-number-link">{{ $data.kepNumber }}</a>
               {{- else }}
               <a href="https://features.k8s.io/{{ $data.kepNumber }}" class="kep-number-link">{{ $data.kepNumber }}</a>
               {{- end }}
             </td>
             <td class="kep-col-title">
-              {{- if $hasPage }}
-              <a href="/resources/keps/{{ $data.kepNumber }}/" class="kep-title-link">{{ $data.title }}</a>
+              {{- with $kepPage }}
+              <a href="{{ .RelPermalink }}" class="kep-title-link">{{ $data.title }}</a>
               {{- else }}
               <a href="https://features.k8s.io/{{ $data.kepNumber }}" class="kep-title-link">{{ $data.title }}</a>
               {{- end }}

--- a/layouts/shortcodes/keps-data.html
+++ b/layouts/shortcodes/keps-data.html
@@ -113,8 +113,13 @@
       </thead>
       <tbody>
         {{ range $data := $kepData }}
-          {{- /* The KEP's own page on this site, or nil when it has none. */ -}}
-          {{- $kepPage := partial "keps/page-by-number.html" $data.kepNumber -}}
+          {{- /* Link to the KEP's own page on this site, falling back to the enhancements
+                 repo for the KEPs that have no page. Cached because this table lists every
+                 KEP and most of them repeat the same lookup. */ -}}
+          {{- $kepUrl := printf "https://features.k8s.io/%s" $data.kepNumber -}}
+          {{- with partialCached "keps/page-by-number.html" $data.kepNumber $data.kepNumber -}}
+            {{- $kepUrl = .RelPermalink -}}
+          {{- end -}}
           {{- $stage := $data.stage -}}
           {{- if not $stage }}
             {{- if or (eq $data.status "implementable") (eq $data.status "implemented") }}
@@ -142,18 +147,10 @@
           {{- $allAuthors = strings.TrimLeft $allAuthors " " -}}
           <tr data-stage="{{ $stage }}" data-latest-milestone="{{ if $latest }}{{ strings.TrimPrefix "v" $latest }}{{ end }}" data-sig="{{ $data.owningSig }}" data-kep="{{ $data.kepNumber }}" data-created="{{ $data.creationDate }}" data-authors="{{ $allAuthors }}">
             <td class="kep-col-number" data-order="{{ $data.kepNumber }}">
-              {{- with $kepPage }}
-              <a href="{{ .RelPermalink }}" class="kep-number-link">{{ $data.kepNumber }}</a>
-              {{- else }}
-              <a href="https://features.k8s.io/{{ $data.kepNumber }}" class="kep-number-link">{{ $data.kepNumber }}</a>
-              {{- end }}
+              <a href="{{ $kepUrl }}" class="kep-number-link">{{ $data.kepNumber }}</a>
             </td>
             <td class="kep-col-title">
-              {{- with $kepPage }}
-              <a href="{{ .RelPermalink }}" class="kep-title-link">{{ $data.title }}</a>
-              {{- else }}
-              <a href="https://features.k8s.io/{{ $data.kepNumber }}" class="kep-title-link">{{ $data.title }}</a>
-              {{- end }}
+              <a href="{{ $kepUrl }}" class="kep-title-link">{{ $data.title }}</a>
             </td>
             <td class="kep-col-sig">
               {{- $sigSlug := strings.TrimPrefix "sig-" $data.owningSig -}}


### PR DESCRIPTION
Fixes #822

## Problem

"Related Enhancements" on a KEP page rendered the same kind of reference three different ways, depending only on how the `seeAlso` value happened to be written in `keps.json`:

| Shape in `keps.json` | Rendered as |
| --- | --- |
| `/keps/sig-scheduling/624-scheduling-framework` | raw path, linking off to GitHub |
| `keps/sig-node/4569-cgroup-v1-maintenance-mode/README.md` | plain unlinked text |
| `https://…` | external link |

The issue reports the second row, using https://www.kubernetes.dev/resources/keps/6132/ as the example of what "correct" should look like — but 6132's own entry is the *first* row, so making only bare paths nicer would have left the majority shape looking wrong.

## Pages to test

Deploy preview: https://deploy-preview-825--kubernetes-contributor.netlify.app

Each row is a "Related Enhancements" entry of a different shape. The "Today" column links to the live page on kubernetes.dev, so each row can be opened side by side with its preview.

| Page | `seeAlso` entry it exercises | Today | On this branch |
| --- | --- | --- | --- |
| KEP-5573 | `keps/sig-node/4569-cgroup-v1-maintenance-mode/README.md` | [plain unlinked text](https://www.kubernetes.dev/resources/keps/5573/) — **the screenshot in #822** | [links to KEP-4569](https://deploy-preview-825--kubernetes-contributor.netlify.app/resources/keps/5573/) |
| KEP-6132 | `/keps/sig-scheduling/624-scheduling-framework` | [GitHub link](https://www.kubernetes.dev/resources/keps/6132/) | [links to KEP-624](https://deploy-preview-825--kubernetes-contributor.netlify.app/resources/keps/6132/) — the page #822 cites as "correct" |
| KEP-1672 | `/kep/sig-network/0752-endpointslices/` | [GitHub link, under a `/kep/` path that 404s](https://www.kubernetes.dev/resources/keps/1672/) | [links to KEP-752](https://deploy-preview-825--kubernetes-contributor.netlify.app/resources/keps/1672/) |
| KEP-5307 | `/keps/prod-readiness/sig-apps/3329` (extra directory before the number) | [GitHub link](https://www.kubernetes.dev/resources/keps/5307/) | [links to KEP-3329](https://deploy-preview-825--kubernetes-contributor.netlify.app/resources/keps/5307/) |
| KEP-1771 | `/kep/sig-cloud-provider/20180530-….md` | [GitHub link under `/kep/`](https://www.kubernetes.dev/resources/keps/1771/) | [still a GitHub link, now under the real `/keps/` directory](https://deploy-preview-825--kubernetes-contributor.netlify.app/resources/keps/1771/) |
| KEP-1381 | `/keps/sig-cluster-lifecycle/kubeadm/0023-kubeadm-config.md` | [GitHub link](https://www.kubernetes.dev/resources/keps/1381/) | [**unchanged**](https://deploy-preview-825--kubernetes-contributor.netlify.app/resources/keps/1381/) — legacy per-directory numbering must not be read as KEP-23 |
| KEP-555 | `n/a` | [plain text](https://www.kubernetes.dev/resources/keps/555/) | [**unchanged**](https://deploy-preview-825--kubernetes-contributor.netlify.app/resources/keps/555/) — free text stays text |
| KEP index table | n/a | [649 rows, 600 on-site / 49 features.k8s.io](https://www.kubernetes.dev/resources/keps/) | [649 rows, **602** on-site / 47](https://deploy-preview-825--kubernetes-contributor.netlify.app/resources/keps/) |

The index table gains two links because looking the page up directly replaces a `stage`/`status` predicate that mirrored `content/en/resources/keps/_content.gotmpl`. The predicate got two duplicate-`kepNumber` rows wrong.

I checked every `seeAlso` entry rather than these eight, by building `main` and this branch and diffing the rendered "Related Enhancements" lists across all 262 KEP pages that have one (415 entries):

- entries rendered as plain text: **67 on `main` → 15 here**, and the 15 are all genuine free text (`n/a`, `TBD`, `KEP 0004`, `none`)
- entries that are a link on `main` but not here: **0**
