### PR TITLE
fix: apply calendar week view aspect ratio

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -62,7 +62,7 @@ function renderCalendar(apiKey) {
           type: 'timeGrid',
           duration: { weeks: 1 },
           buttonText: 'week',
-          aspectRation: 10,
+          aspectRatio: 10,
           allDaySlot: false
         },
         monthView: {


### PR DESCRIPTION
The Week view ignored its configured ratio and fell back to FullCalendar defaults

How to repro
1. Open `https://www.kubernetes.dev/resources/calendar/` on desktop
2. Click Week
3. Before: default 74.0741% height. After: configured 10% height