### PR TITLE
fix: fail netlify periodic-build workflow loudly on hook failure

### DIFF
--- a/.github/workflows/netlify-periodic-build.yml
+++ b/.github/workflows/netlify-periodic-build.yml
@@ -11,6 +11,6 @@ jobs:
       contents: none
     steps:
     - name: Trigger webhook on netlify
-      run: curl -sS --fail-with-body -X POST "https://api.netlify.com/build_hooks/${TOKEN}"
+      run: curl -sS -f -X POST "https://api.netlify.com/build_hooks/${TOKEN}"
       env:
         TOKEN: ${{ secrets.NETLIFY_BUILD_HOOK_KEY }}

--- a/.github/workflows/netlify-periodic-build.yml
+++ b/.github/workflows/netlify-periodic-build.yml
@@ -11,6 +11,6 @@ jobs:
       contents: none
     steps:
     - name: Trigger webhook on netlify
-      run: curl -s -X POST "https://api.netlify.com/build_hooks/${TOKEN}"
+      run: curl -sS --fail-with-body -X POST "https://api.netlify.com/build_hooks/${TOKEN}"
       env:
         TOKEN: ${{ secrets.NETLIFY_BUILD_HOOK_KEY }}


### PR DESCRIPTION
## What
`.github/workflows/netlify-periodic-build.yml` used `curl -s` to hit the Netlify build hook, discarding the HTTP response. Non-2xx responses were swallowed, so the scheduled job reported green even when no build was actually triggered.

## Why
Relates to #830 the periodic build pointing to `master` (which doesnt exist anymore) was failing, but the GH actions were never failing in the logs.