### PR TITLE
feat(community): implement dynamic mailing list integration for group cards

### DIFF
--- a/layouts/shortcodes/sigs-list.html
+++ b/layouts/shortcodes/sigs-list.html
@@ -197,6 +197,13 @@
                         <i class="fab fa-slack"></i>
                       </a>
                       {{ end }}
+                      {{ if .contact.mailing_list }}
+                      <a href="{{ .contact.mailing_list }}" class="btn btn-sm btn-outline-dark rounded-pill px-2"
+                        target="_blank" rel="noopener noreferrer" title="Join Mailing List"
+                        aria-label="Join Mailing List">
+                        <i class="fas fa-envelope"></i>
+                      </a>
+                      {{ end }}
 
                       <a href="/community/community-groups/sigs/{{ .dir | replaceRE "^sig-" "" }}/" class="btn btn-sm btn-outline-primary rounded-pill px-3">
                         Visit <i class="fas fa-arrow-right ms-1"></i>
@@ -311,6 +318,13 @@
                         <i class="fab fa-slack"></i>
                       </a>
                       {{ end }}
+                      {{ if .contact.mailing_list }}
+                      <a href="{{ .contact.mailing_list }}" class="btn btn-sm btn-outline-dark rounded-pill px-2"
+                        target="_blank" rel="noopener noreferrer" title="Join Mailing List"
+                        aria-label="Join Mailing List">
+                        <i class="fas fa-envelope"></i>
+                      </a>
+                      {{ end }}
 
                       <a href="/community/community-groups/wg/{{ .dir | replaceRE "^wg-" "" }}/" class="btn btn-sm btn-outline-primary rounded-pill px-3">
                         Visit <i class="fas fa-arrow-right ms-1"></i>
@@ -422,6 +436,13 @@
                       {{ if .contact.slack }}
                       <a href="https://kubernetes.slack.com/messages/{{ .contact.slack }}" class="btn btn-sm btn-outline-dark rounded-pill px-2" target="_blank" title="Slack">
                         <i class="fab fa-slack"></i>
+                      </a>
+                      {{ end }}
+                      {{ if .contact.mailing_list }}
+                      <a href="{{ .contact.mailing_list }}" class="btn btn-sm btn-outline-dark rounded-pill px-2"
+                        target="_blank" rel="noopener noreferrer" title="Join Mailing List"
+                        aria-label="Join Mailing List">
+                        <i class="fas fa-envelope"></i>
                       </a>
                       {{ end }}
 


### PR DESCRIPTION
<!-- Reference the issue being resolved -->
Fixes #827 

#### What this PR does / why we need it:
On the Community Groups page, each group card currently displays a Slack icon button that links directly to its dedicated communication channel. However, there is no visual equivalent linking to the group's official mailing list.

This PR adds a "Join Mailing List" button (represented by an envelope icon) inline right next to the existing Slack button on each card. It dynamically binds to the `.contact.mailing_list` data field when present, matching data synced from `kubernetes/community` (`sigs.yaml`).

#### Which issue(s) this PR fixes:
Fixes #827 

#### Visual Proof:

<img width="1920" height="1080" alt="Screenshot from 2026-07-30 02-05-25" src="https://github.com/user-attachments/assets/42aea56c-1ec3-419f-9e4c-46793062062f" />


[Screencast from 2026-07-30 01-54-34.webm](https://github.com/user-attachments/assets/1d6fcc02-23ef-4a2c-a4c0-f3deda3f37e8)

