### PR TITLE
fix: keep KEP detail card columns balanced

### DIFF
--- a/assets/scss/_kep_page.scss
+++ b/assets/scss/_kep_page.scss
@@ -12,7 +12,7 @@
 
   .kep-banner-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 
     @media (max-width: 991px) {
       grid-template-columns: 1fr;
@@ -22,6 +22,7 @@
   .kep-banner-col {
     padding: 2rem;
     position: relative;
+    min-width: 0;
 
     &.border-start-refined {
       border-left: 1px solid #e0e4e8;
@@ -228,18 +229,15 @@
         font-size: 0.85rem;
         color: $slate-700;
         text-decoration: none;
-        display: flex;
-        align-items: flex-start;
-        gap: 8px;
+        display: block;
         transition: all 0.2s ease;
         min-width: 0;
-        overflow-wrap: break-word;
+        overflow-wrap: anywhere;
 
         i {
           font-size: 0.7rem;
           color: $slate-400;
-          line-height: 1;
-          flex-shrink: 0;
+          margin-right: 8px;
         }
 
         &:hover {

--- a/assets/scss/_kep_page.scss
+++ b/assets/scss/_kep_page.scss
@@ -23,6 +23,7 @@
     padding: 2rem;
     position: relative;
     min-width: 0;
+    overflow: hidden;
 
     &.border-start-refined {
       border-left: 1px solid #e0e4e8;
@@ -221,9 +222,11 @@
     list-style: none;
     padding: 0;
     margin: 0;
+    min-width: 0;
 
     li {
       margin-bottom: 0.5rem;
+      min-width: 0;
 
       a {
         font-size: 0.85rem;
@@ -234,6 +237,7 @@
         gap: 8px;
         transition: all 0.2s ease;
         min-width: 0;
+        max-width: 100%;
         overflow-wrap: break-word;
 
         i {
@@ -241,6 +245,13 @@
           color: $slate-400;
           line-height: 1;
           flex-shrink: 0;
+        }
+
+        .kep-link-text {
+          min-width: 0;
+          flex: 1 1 0;
+          overflow-wrap: anywhere;
+          word-break: break-word;
         }
 
         &:hover {

--- a/assets/scss/_kep_page.scss
+++ b/assets/scss/_kep_page.scss
@@ -229,15 +229,18 @@
         font-size: 0.85rem;
         color: $slate-700;
         text-decoration: none;
-        display: block;
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
         transition: all 0.2s ease;
         min-width: 0;
-        overflow-wrap: anywhere;
+        overflow-wrap: break-word;
 
         i {
           font-size: 0.7rem;
           color: $slate-400;
-          margin-right: 8px;
+          line-height: 1;
+          flex-shrink: 0;
         }
 
         &:hover {

--- a/layouts/keps/single.html
+++ b/layouts/keps/single.html
@@ -83,9 +83,9 @@
             {{ range . }}
             <li>
               {{- if and (strings.HasPrefix . "http") (not (strings.Contains . "[")) -}}
-                <a href="{{ . }}" target="_blank" rel="noopener"><i class="fas fa-external-link-alt"></i> {{ . }}</a>
+                <a href="{{ . }}" target="_blank" rel="noopener"><i class="fas fa-external-link-alt"></i><span class="kep-link-text">{{ . }}</span></a>
               {{- else if and (strings.HasPrefix . "/") (not (strings.Contains . "[")) -}}
-                <a href="https://github.com/kubernetes/enhancements/tree/master{{ . }}" target="_blank" rel="noopener"><i class="fab fa-github"></i> {{ . }}</a>
+                <a href="https://github.com/kubernetes/enhancements/tree/master{{ . }}" target="_blank" rel="noopener"><i class="fab fa-github"></i><span class="kep-link-text">{{ . }}</span></a>
               {{- else -}}
                 {{ . | markdownify }}
               {{- end -}}


### PR DESCRIPTION
Fixes uneven column widths in the KEP detail metadata card. Closes:  #837 

The KEP metadata banner uses a two-column CSS grid, but long content in the "Related Enhancements" section could influence the intrinsic size of the first column. As a result, the Implementation History column expanded while the Ownership column became noticeably narrower, making the card look unbalanced on desktop and medium-sized screens.

CSS only, scoped to `.kep-page` in `assets/scss/_kep_page.scss`. No markup or content changes.

Changes:
- Use `minmax(0, 1fr)` for the metadata banner grid so both columns share the available width evenly.
- Allow banner columns to shrink correctly by adding `min-width: 0`.
- Allow long Related Enhancement links to wrap naturally using `overflow-wrap: anywhere`.
- Replace the flex layout for Related Enhancement links with a block layout so wrapped links no longer affect the column width calculation.
- Keep the leading icon aligned by replacing `flex-shrink` with a right margin.

Verified locally with the pinned Hugo v0.144.2 (`make container-server`). The KEP pages build successfully and the metadata banner maintains balanced columns.

- Deploy preview :
https://deploy-preview-838--kubernetes-contributor.netlify.app/resources/keps/6060/

## Before

<img width="1833" height="1017" alt="KEP detail card before fix — uneven columns, long URLs overflow into Ownership column" src="https://github.com/user-attachments/assets/304ae94b-9aed-4d6a-8d06-ace1f2fb4db4" />

## After

<img width="1834" height="1013" alt="KEP detail card after fix — balanced columns, URLs wrap in left column" src="https://github.com/user-attachments/assets/26402067-050d-4a8e-9c0e-ccbcd9749ce8" />
