### PR TITLE
fix: own the RSS template and emit a single blog feed

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -16,6 +16,20 @@ disableKinds:
 permalinks:
   blog: '/:section/:year/:month/:day/:slug/'
 
+# Be explicit about the output formats. We only want an RSS feed for the home
+# page, rendered by layouts/index.rss.xml. Leaving RSS on `section` would emit a
+# feed for every section, none of which carry dates, and leaving it unset lets
+# Hugo's built-in template range over every page on the site.
+# Mirrors https://github.com/kubernetes/website/blob/main/hugo.toml#L84-L88
+outputs:
+  home:
+    - HTML
+    - RSS
+  page:
+    - HTML
+  section:
+    - HTML
+
 # Image processing configuration.
 imaging:
   resampleFilter: CatmullRom

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -38,6 +38,9 @@ services:
   googleAnalytics:
     # Fake ID in support of [params.ui.feedback]. The real GA ID is set in the Netlify config.
     id: UA-00000000-0
+  rss:
+    # Number of items in the feed, read by layouts/index.rss.xml.
+    limit: 50
 
 # Hugo internal caching
 caches:

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -1,0 +1,51 @@
+{{/*
+  Copy of node_modules/docsy/layouts/blog/baseof.html, changed in one place: the
+  RSS button reads site.Home instead of .CurrentSection.
+
+  hugo.yaml sets `section: [HTML]`, so Docsy's `.CurrentSection.OutputFormats.Get
+  "rss"` is nil and the button never renders. This site emits a single feed, from
+  the home page, via layouts/index.rss.xml — so the button points there.
+
+  Mirrors kubernetes/website, which hit the same wall and solved it the same way:
+  https://github.com/kubernetes/website/blob/main/layouts/partials/blog-meta-links.html
+
+  Re-diff against Docsy's copy on the next theme bump; nothing else here is ours.
+*/}}
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+    {{ with site.Home.OutputFormats.Get "rss" -}}
+    <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}" title="{{ site.Title }}">
+    {{ end -}}
+  </head>
+  <body class="td-{{ .Kind }} td-blog {{- with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+            {{ partial "sidebar.html" . }}
+          </aside>
+          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+            {{ partial "page-meta-links.html" . }}
+            {{ partial "toc.html" . }}
+            {{ partial "taxonomy_terms_clouds.html" . }}
+          </aside>
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main">
+            {{ with site.Home.OutputFormats.Get "rss" -}}
+            <a class="td-rss-button" title="RSS" href="{{ .Permalink | safeURL }}" target="_blank" rel="noopener">
+              <i class="fa-solid fa-rss" aria-hidden="true"></i>
+            </a>
+            {{ end -}}
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -1,0 +1,56 @@
+{{/*
+  Home-page RSS feed, copied from kubernetes/website's layouts/index.rss.xml:
+  https://github.com/kubernetes/website/blob/main/layouts/index.rss.xml
+  Only the <description> text differs, since it names this site's blog.
+
+  This site owns its feed template rather than inheriting one from the theme.
+  Docsy shipped layouts/_default/list.rss.xml through v0.9.1 and removed it in
+  v0.10.0 (google/docsy#1948); with no local template, Hugo fell back to its
+  built-in RSS, which ranges over every regular page with no section filter and
+  no item cap. kubernetes/website has never been exposed to that, having owned
+  this file since it moved to Hugo in 2018:
+  https://github.com/kubernetes/website/commit/7f3b633a
+
+  Paired with the `outputs` block in hugo.yaml, which emits RSS for the home
+  page only, mirroring:
+  https://github.com/kubernetes/website/blob/main/hugo.toml#L84-L88
+  Section feeds are deliberately not generated.
+*/}}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.Title }} Blog</title>
+    <link>{{ .Permalink }}</link>
+    <description>The Kubernetes contributor blog is used by the project to communicate community reports, contributor news, and any updates that might be relevant to people contributing to Kubernetes.</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with site.Author.email }}
+    <managingEditor>{{.}}{{ with site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with site.Author.email }}
+    <webMaster>{{.}}{{ with site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    <image>
+      <url>https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png</url>
+      <title>The Kubernetes project logo</title>
+      <link>{{ .Permalink }}</link>
+    </image>
+    {{ with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ end }}
+    {{ range first 50 (where site.RegularPages "Type" "in" (slice "blog")) }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with site.Author.email }}<author>{{.}}{{ with site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      <description>
+        {{ $img := (.Resources.ByType "image").GetMatch "*featured*" }}
+        {{ with $img }}
+        {{ $img := .Resize "640x" }}
+        {{ printf "<![CDATA[<img src=\"%s\" width=\"%d\" height=\"%d\"/>]]>" $img.Permalink $img.Width $img.Height | safeHTML }}
+        {{ end }}
+        {{ .Content | html }}
+      </description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -1,7 +1,11 @@
 {{/*
-  Home-page RSS feed, copied from kubernetes/website's layouts/index.rss.xml:
+  Home-page RSS feed, inspired from kubernetes/website's layouts/index.rss.xml:
   https://github.com/kubernetes/website/blob/main/layouts/index.rss.xml
-  Only the <description> text differs, since it names this site's blog.
+
+  The item count is read from services.rss.limit in hugo.yaml rather than
+  hardcoded. That key is 0 when unset and Hugo treats `first 0` as unlimited,
+  so the fallback below keeps a missing key from restoring the whole-site feed
+  this template exists to prevent.
 
   This site owns its feed template rather than inheriting one from the theme.
   Docsy shipped layouts/_default/list.rss.xml through v0.9.1 and removed it in
@@ -35,7 +39,9 @@
     {{ with .OutputFormats.Get "RSS" }}
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range first 50 (where site.RegularPages "Type" "in" (slice "blog")) }}
+    {{- $limit := site.Config.Services.RSS.Limit }}
+    {{- if lt $limit 1 }}{{ $limit = 50 }}{{ end }}
+    {{ range first $limit (where site.RegularPages "Type" "in" (slice "blog")) }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -54,7 +54,7 @@
         {{ $img := .Resize "640x" }}
         {{ printf "<![CDATA[<img src=\"%s\" width=\"%d\" height=\"%d\"/>]]>" $img.Permalink $img.Width $img.Height | safeHTML }}
         {{ end }}
-        {{ .Content | html }}
+        {{ .Content | transform.XMLEscape | safeHTML }}
       </description>
     </item>
     {{ end }}

--- a/static/_redirects
+++ b/static/_redirects
@@ -48,3 +48,6 @@
 /summit/unconf    /events/2024/kcsna 302
 /summit/notes     https://drive.google.com/drive/folders/1j3i9I4a3lbmjqQNTYKxK0Gc6JgooDn14 302
 /summit/sched     /events/2024/kcsna/schedule 302
+
+# Section feeds are no longer generated; the blog feed lives at /index.xml.
+/blog/index.xml   /index.xml 301


### PR DESCRIPTION
Fixes #854

### Problem

Docsy shipped `layouts/_default/list.rss.xml` through v0.9.1 and [removed it in v0.10.0](https://github.com/google/docsy/releases/tag/v0.10.0) (google/docsy#1948). This site owned no feed template, so when #805 merged (0647fe9, 2026-08-09) every feed fell back to Hugo's [`_internal/rss.xml`](https://github.com/gohugoio/hugo/blob/v0.144.2/tpl/tplimpl/embedded/templates/_default/rss.xml) — no section filter, no item cap.

### Fix

Adopt what kubernetes/website has done since [`7f3b633a`](https://github.com/kubernetes/website/commit/7f3b633a) (2018): own the template, emit RSS for the home page only. That repo was never affected because it never used the theme's.

- **`layouts/index.rss.xml`** — copied from [theirs](https://github.com/kubernetes/website/blob/main/layouts/index.rss.xml); only `<description>` differs. Filters to blog and caps at 50 in the template, not via a theme param — Docsy still declares `rss_sections` but nothing has read it since the layout was deleted, and no release through v0.16.0 restores one.
- **`hugo.yaml`** — `outputs` restricted, mirroring [their `hugo.toml`](https://github.com/kubernetes/website/blob/main/hugo.toml#L84-L88). Drops 73 dateless section feeds. `print`/`HEADERS`/`REDIRECTS` omitted; unused here.
- **`static/_redirects`** — `/blog/index.xml` → `/index.xml`, so subscribers keep working.

Docsy stays on 0.10.0.