### PR TITLE
fix(keps): point markdown links to GitHub blob view instead of raw

### DIFF
--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -108,15 +108,17 @@
         {{- /* Fix relative image and link paths to point to GitHub */ -}}
         {{- $repoBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
         {{- $kepDirUrl := printf "%skeps/%s/%s/" $repoBaseUrl $kep.owningSig $kep.name -}}
+        {{- $blobBase := "https://github.com/kubernetes/enhancements/blob/master/" -}}
+        {{- $linkDirUrl := printf "%skeps/%s/%s/" $blobBase $kep.owningSig $kep.name -}}
         
         {{- /* 1. Fix absolute-looking paths (starting with /) */ -}}
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $blobBase) $readmeContent -}}
         
         {{- /* 2. Fix relative paths (not starting with http, #, or / and not containing :) */ -}}
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $linkDirUrl) $readmeContent -}}
       {{- else -}}
         {{- warnf "Unable to load README for KEP %s URL=%s" $kep.kepNumber $readmeUrl -}}
       {{- end -}}

--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -106,18 +106,18 @@
         {{- $readmeContent = replace $readmeContent "((http" "(http" -}}
         
         {{- /* Fix relative image and link paths to point to GitHub */ -}}
-        {{- $repoBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
-        {{- $kepDirUrl := printf "%skeps/%s/%s/" $repoBaseUrl $kep.owningSig $kep.name -}}
+        {{- $rawBase := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
         {{- $blobBase := "https://github.com/kubernetes/enhancements/blob/master/" -}}
+        {{- $imgDirUrl := printf "%skeps/%s/%s/" $rawBase $kep.owningSig $kep.name -}}
         {{- $linkDirUrl := printf "%skeps/%s/%s/" $blobBase $kep.owningSig $kep.name -}}
         
         {{- /* 1. Fix absolute-looking paths (starting with /) */ -}}
-        {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $rawBase) $readmeContent -}}
         {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $blobBase) $readmeContent -}}
         
         {{- /* 2. Fix relative paths (not starting with http, #, or / and not containing :) */ -}}
-        {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $imgDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $imgDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $linkDirUrl) $readmeContent -}}
       {{- else -}}
         {{- warnf "Unable to load README for KEP %s URL=%s" $kep.kepNumber $readmeUrl -}}

--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -109,15 +109,18 @@
         {{- /* Fix relative image and link paths to point to GitHub */ -}}
         {{- $repoBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
         {{- $kepDirUrl := printf "%skeps/%s/" $repoBaseUrl $kepPath -}}
+        {{- $kepDirUrl := printf "%skeps/%s/%s/" $repoBaseUrl $kep.owningSig $kep.name -}}
+        {{- $blobBase := "https://github.com/kubernetes/enhancements/blob/master/" -}}
+        {{- $linkDirUrl := printf "%skeps/%s/%s/" $blobBase $kep.owningSig $kep.name -}}
         
         {{- /* 1. Fix absolute-looking paths (starting with /) */ -}}
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $blobBase) $readmeContent -}}
         
         {{- /* 2. Fix relative paths (not starting with http, #, or / and not containing :) */ -}}
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $linkDirUrl) $readmeContent -}}
       {{- else -}}
         {{- warnf "Unable to load README for KEP %s URL=%s" $kep.kepNumber $readmeUrl -}}
       {{- end -}}

--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -107,19 +107,18 @@
         {{- $readmeContent = replace $readmeContent "((http" "(http" -}}
         
         {{- /* Fix relative image and link paths to point to GitHub */ -}}
-        {{- $repoBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
-        {{- $kepDirUrl := printf "%skeps/%s/" $repoBaseUrl $kepPath -}}
-        {{- $kepDirUrl := printf "%skeps/%s/%s/" $repoBaseUrl $kep.owningSig $kep.name -}}
+        {{- $rawBase := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
         {{- $blobBase := "https://github.com/kubernetes/enhancements/blob/master/" -}}
+        {{- $imgDirUrl := printf "%skeps/%s/%s/" $rawBase $kep.owningSig $kep.name -}}
         {{- $linkDirUrl := printf "%skeps/%s/%s/" $blobBase $kep.owningSig $kep.name -}}
         
         {{- /* 1. Fix absolute-looking paths (starting with /) */ -}}
-        {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $rawBase) $readmeContent -}}
         {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $blobBase) $readmeContent -}}
         
         {{- /* 2. Fix relative paths (not starting with http, #, or / and not containing :) */ -}}
-        {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $imgDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $imgDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $linkDirUrl) $readmeContent -}}
       {{- else -}}
         {{- warnf "Unable to load README for KEP %s URL=%s" $kep.kepNumber $readmeUrl -}}


### PR DESCRIPTION
## Summary:
Fixes an issue where links inside rendered KEPs point to raw.githubusercontent.com, causing them to display unrendered ra Markdown instead of the rendered GitHub page.

## Changes:
- Update absolute and relative Markdown link rules to use GitHub blob URLs for rendered content.

## Fixes:
#848 