### PR TITLE
Add Hugo heading render hook to enable Docsy heading anchor links

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,1 @@
+{{ template "_default/_markup/td-render-heading.html" . -}}


### PR DESCRIPTION
While browsing and reading through KEPs at https://www.kubernetes.dev/resources/keps/, I thought I'd be useful to have copyable links to individual subheadings directly. So here's an attempt at that

With this change:

<img width="1512" height="745" alt="image" src="https://github.com/user-attachments/assets/a58f56ed-40bd-4d69-922d-1bcd7f3ab2e7" />

