### PR TITLE
Publish KCD San Francisco Bay Area blog 

### DIFF
--- a/content/en/blog/2026/kcd-around-the-world-san-francisco/index.md
+++ b/content/en/blog/2026/kcd-around-the-world-san-francisco/index.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: "KCD Around the World: San Francisco Bay Area"
-draft: true
+date: 2026-08-19
 slug: kcd-around-the-world-san-francisco
 author: >
   [Rey Lejano](https://github.com/reylejano) (Red Hat),


### PR DESCRIPTION
Remove draft status in front matter for the KCD San Francisco Bay Area blog to publish