### PR TITLE
Fix KEP links pointing at raw.githubusercontent.com

### DIFF
--- a/content/en/resources/keps/_content.gotmpl
+++ b/content/en/resources/keps/_content.gotmpl
@@ -105,18 +105,23 @@
         {{- $readmeContent = replace $readmeContent "/))" "/)" -}}
         {{- $readmeContent = replace $readmeContent "((http" "(http" -}}
         
-        {{- /* Fix relative image and link paths to point to GitHub */ -}}
+        {{- /* Fix relative image and link paths to point to GitHub.
+               Images stay on raw.githubusercontent.com so they render as images.
+               Links go to the blob view so following one lands on the rendered
+               page instead of raw markdown source. */ -}}
         {{- $repoBaseUrl := "https://raw.githubusercontent.com/kubernetes/enhancements/master/" -}}
+        {{- $repoBlobUrl := "https://github.com/kubernetes/enhancements/blob/master/" -}}
         {{- $kepDirUrl := printf "%skeps/%s/%s/" $repoBaseUrl $kep.owningSig $kep.name -}}
-        
+        {{- $kepBlobDirUrl := printf "%skeps/%s/%s/" $repoBlobUrl $kep.owningSig $kep.name -}}
+
         {{- /* 1. Fix absolute-looking paths (starting with /) */ -}}
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(/(.*?)\)` (printf "![${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $repoBaseUrl) $readmeContent -}}
-        
+        {{- $readmeContent = replaceRE `\[(.*?)\]\(/(.*?)\)` (printf "[${1}](%s${2})" $repoBlobUrl) $readmeContent -}}
+
         {{- /* 2. Fix relative paths (not starting with http, #, or / and not containing :) */ -}}
         {{- $readmeContent = replaceRE `!\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "![${1}](%s${2})" $kepDirUrl) $readmeContent -}}
         {{- $readmeContent = replaceRE `<img\s+[^>]*src="([^/#:][^:"]*)"` (printf `<img src="%s${1}"` $kepDirUrl) $readmeContent -}}
-        {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepDirUrl) $readmeContent -}}
+        {{- $readmeContent = replaceRE `\[(.*?)\]\(([^/#:][^:]*?)\)` (printf "[${1}](%s${2})" $kepBlobDirUrl) $readmeContent -}}
       {{- else -}}
         {{- warnf "Unable to load README for KEP %s URL=%s" $kep.kepNumber $readmeUrl -}}
       {{- end -}}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Links inside a rendered KEP page (e.g. links to other files in the same KEP directory) were rewritten to point at `raw.githubusercontent.com`, so clicking one landed on unrendered raw markdown instead of a normal GitHub page. Images correctly need the raw base URL to render as images, so this splits the two: images keep using `raw.githubusercontent.com`, links now use the blob view (`github.com/.../blob/master/...`).

## Which issue(s) this PR fixes:
Fixes #848

## Special notes for your reviewer:
Verified against the issue's own example (KEP-24): the link now resolves to the blob view. Confirmed images elsewhere (e.g. KEP-1024) are unaffected and still use raw.githubusercontent.com.