### PR TITLE
Add contributor event pages for KubeCon NA 2026

### DIFF
--- a/content/en/events/2026/kcsna/_index.md
+++ b/content/en/events/2026/kcsna/_index.md
@@ -1,0 +1,44 @@
+---
+title: "Contributor Events at KubeCon NA 2026"
+type: docs
+weight: 1
+eventDate: 2026-11-09
+date: 2026-01-01
+description: >
+  Contributor events at KubeCon, hosted in Salt Lake City, Utah.
+---
+
+### Events at KubeCon North America 2026
+
+Several events at
+<a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon North America 2026</a>
+are aimed at Kubernetes contributors and at people who want to become
+contributors. KubeCon runs November 9-12, 2026 in Salt Lake City, Utah, at the
+Salt Palace Convention Center. The contributor events are:
+
+- [Maintainer Summit North America 2026] - a dedicated day for maintainers to collaborate in person, with keynotes, submitted talks, an unconference, and project meetings.
+- [Kubernetes 101: New Contributor Orientation] - a guided introduction to the project for people who want to contribute but do not know where to start.
+- [Kubernetes Meet and Greet] - a lunchtime drop-in where SIGs and WGs answer questions about getting involved.
+
+Two other sessions are worth noting for Kubernetes contributors, both on
+Tuesday, November 10:
+
+- [Steering the Ship: Ask the Kubernetes Steering Committee](https://kubecon-cloudnativecon-north-america-2026.sessionize.com/session/1289694) at 11:30, Room 251 A-C.
+- [Kubernetes SIG ContribEx: Sub-Project and Governance Updates](https://kubecon-cloudnativecon-north-america-2026.sessionize.com/session/1289639) at 15:40, Room 250 A-C.
+
+To ask about any of these events, use the
+<a href="https://kubernetes.slack.com/messages/contributor-summit" rel="noopener noreferrer" target="_blank">#contributor-summit</a>
+channel on Kubernetes Slack.
+
+### Code of Conduct
+
+Attendees agree to abide by the Kubernetes [Code of Conduct] and the
+KubeCon + CloudNativeCon [event Code of Conduct], which also explains how to
+report an incident to the CNCF event staff.
+
+[Code of Conduct]: /community/code-of-conduct
+[event Code of Conduct]: https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/attend/code-of-conduct/
+
+[Maintainer Summit North America 2026]: /events/2026/kcsna/maintainer-summit-na/
+[Kubernetes 101: New Contributor Orientation]: /events/2026/kcsna/new-contributor-workshop/
+[Kubernetes Meet and Greet]: /events/2026/kcsna/meet-and-greet/

--- a/content/en/events/2026/kcsna/maintainer-summit-na.md
+++ b/content/en/events/2026/kcsna/maintainer-summit-na.md
@@ -1,0 +1,100 @@
+---
+title: "Maintainer Summit North America 2026"
+type: docs
+weight: 2
+eventDate: 2026-11-09
+date: 2026-01-01
+description: >
+  CNCF Maintainer Summit North America, hosted in Salt Lake City, Utah.
+---
+
+### About
+
+The North America edition of the Maintainer Summit takes place on
+**Sunday, November 8, 2026**, in Salt Lake City, Utah, alongside
+<a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon North America 2026</a>.
+
+**Venue**<br/>
+Salt Palace Convention Center<br/>
+90 South West Temple<br/>
+Salt Lake City, Utah 84101<br/>
+
+The Summit is a dedicated day for maintainers to collaborate in person.
+Programming focuses on sharing best practices, digging into contributing
+processes, and solving problems that projects have in common.
+
+### Schedule
+
+The schedule went live on August 26, 2026. Read it in the
+[schedule section](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/maintainer-summit/#schedule)
+of the official event page, or browse sessions and build a personal agenda in
+the [session planner](https://maintainer-summit-na-2026.sessionize.com/).
+
+The day runs from 08:15 to 20:00 and includes:
+
+- **Keynotes** open the day at 09:00 and close it at 16:45 with Closing Remarks
+  and the Awards.
+- **Submitted talks** run in two tracks through the morning, covering topics
+  such as reviewing AI-generated pull requests, handling vulnerability reports,
+  and CNCF project reviews.
+- **Unconference sessions** fill the afternoon: ten slots across three rooms,
+  starting at 13:35 and running until 16:35.
+- **Project meetings** run in parallel all afternoon, including SIG-etcd,
+  Gateway API, Karmada, OpenTelemetry, and KubeVirt.
+- **Reception** closes the evening from 17:30 to 20:00.
+
+Kubernetes contributors may want to note
+[Steering the Ship: Ask the Kubernetes Steering Committee](https://maintainer-summit-na-2026.sessionize.com/session/1284587)
+at 13:35, an open-format session with members of the Kubernetes Steering
+Committee. Bring questions about project governance, the direction of the
+project, or how to get more involved. A form is provided for asking questions
+anonymously.
+
+### Unconference
+
+The unconference is the largest single block of the day: ten sessions across
+three rooms, in four slots from 13:35 to 16:35. Topics are pitched and chosen
+by attendees rather than selected in advance through the Call for Proposals,
+which is what makes the block useful for problems that surface late or that cut
+across projects. Come with a topic in mind.
+
+The Call for Proposals closed on July 19, 2026. Submissions are no longer
+possible, but the unconference slots remain open to topics raised on the day.
+
+### Registration
+
+[Register for the Maintainer Summit](https://register.linuxfoundation.org/kccnc-na-maintainer-summit-2026).
+
+- You must **also** be registered for KubeCon + CloudNativeCon North America 2026.
+- Maintainer Summit registrations enter a pending queue, and CNCF staff validate
+  them on a weekly basis. Allow time for yours to be confirmed.
+
+### Volunteering and staffing
+
+SIG Contributor Experience tracks staffing and volunteer coordination for
+Kubernetes activities at KubeCon North America 2026 in the
+[kubernetes/community](https://github.com/kubernetes/community/issues/8984) issue.
+
+### Eligibility
+
+Space is limited, so attendance is restricted to people who are already
+actively engaged in a CNCF project. You can attend the Maintainer Summit if you
+are one of the following:
+
+- Sandbox Project Maintainer
+- Incubating Project Org Member
+- Graduated Project Org Member
+- CNCF TOC Member
+- CNCF TAG Chair, Technical Lead, or Working Group Lead
+
+For more information, visit the
+[official event page](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/maintainer-summit/).
+
+### Code of Conduct
+
+Attendees agree to abide by the Kubernetes [Code of Conduct] and the
+KubeCon + CloudNativeCon [event Code of Conduct], which also explains how to
+report an incident to the CNCF event staff.
+
+[Code of Conduct]: /community/code-of-conduct
+[event Code of Conduct]: https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/attend/code-of-conduct/

--- a/content/en/events/2026/kcsna/meet-and-greet.md
+++ b/content/en/events/2026/kcsna/meet-and-greet.md
@@ -1,0 +1,55 @@
+---
+title: "Kubernetes Meet and Greet"
+type: docs
+weight: 4
+eventDate: 2026-11-09
+date: 2026-01-01
+description: >
+  Kubernetes Meet and Greet at KubeCon North America 2026.
+---
+
+### About
+
+Grab your lunch and come join the Kubernetes Meet and Greet. This event is for
+SIGs and WGs, and for new and experienced contributors alike. Representatives
+from many SIGs and WGs are on hand to answer questions and talk about how to get
+involved.
+
+The Kubernetes Meet and Greet is for both:
+
+- Experienced Kubernetes contributors who want to expand their involvement into
+  new SIGs or WGs, or spend time with their SIG and WG collaborators.
+- New contributors who are looking for somewhere to start contributing to
+  Kubernetes.
+
+### Details
+
+The Kubernetes Meet and Greet takes place during
+<a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon North America 2026</a>
+(November 9-12) at the Salt Palace Convention Center in Salt Lake City.
+
+The CNCF events team is still confirming the day, time, and room. Check back for
+the session link and a map of the room once the KubeCon schedule is published.
+
+### Instructions for new contributors
+
+Grab your lunch in the main exhibit hall, then head to the Meet and Greet room.
+Look for one or more SIGs, WGs, or other teams that interest you, sit down, and
+ask them about their group.
+
+SIGs and WGs share tables, with more than one group at a table. If you have
+trouble finding the group you want, a volunteer from SIG Contributor Experience
+can guide you to the right table.
+
+### Instructions for SIG members and current contributors
+
+Grab your lunch in the main exhibit hall, then head to the Meet and Greet room
+and look for your SIG or WG, or the one whose contributions you want to discuss.
+
+You may be the first member of your SIG or WG to arrive. In that case, take the
+sign and the bag of SIG pins and find an empty table, or a table with enough
+space for another SIG to join. When the last member of your SIG leaves, pack up
+the pins and the sign and return them to ContribEx.
+
+SIG members do not need to stay for the entire session. Instead, pick a period
+of one to two hours when you can staff the table.

--- a/content/en/events/2026/kcsna/new-contributor-workshop.md
+++ b/content/en/events/2026/kcsna/new-contributor-workshop.md
@@ -1,0 +1,48 @@
+---
+title: "Kubernetes 101: New Contributor Orientation"
+type: docs
+weight: 3
+eventDate: 2026-11-09
+date: 2026-01-01
+description: >
+  An introductory session for people new to contributing to Kubernetes.
+---
+
+### About
+
+[Kubernetes 101: New Contributor Orientation] is a guided introduction to
+contributing, aimed at people who want to start but do not know where to begin.
+The session uses Kubernetes as a roadmap for how a very large project actually
+works: how the community is structured, how the people in it communicate, and
+where a newcomer fits. It also covers how to avoid common pitfalls such as the
+"good first issue" trap, and where the better opportunities tend to hide.
+
+Come away with a concrete plan for your first move in the Kubernetes ecosystem.
+
+### Details
+
+**When**<br/>
+Tuesday, November 10, 2026, 16:40 to 18:00<br/>
+
+**Where**<br/>
+Salt Palace Convention Center, Level 2, Room 255 A<br/>
+
+The session runs as part of the ContribFest track at
+<a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/" rel="noopener noreferrer" target="_blank">KubeCon + CloudNativeCon North America 2026</a>.
+Your KubeCon registration covers it, and no separate sign-up is needed.
+
+Speakers: Kat Cosgrove, Rey Lejano, Kaslin Fields, Arpit Agrawal, and
+Chris Short.
+
+### Getting started before then
+
+These resources are worth reading first, and they stay useful afterwards:
+
+- [Kubernetes Contributor Guide](/docs/guide/)
+- [Contributor onboarding](/docs/onboarding/)
+
+You can also drop in at the [Kubernetes Meet and Greet], which helps new
+contributors find a SIG or WG to join.
+
+[Kubernetes 101: New Contributor Orientation]: https://kubecon-cloudnativecon-north-america-2026.sessionize.com/session/1294772
+[Kubernetes Meet and Greet]: /events/2026/kcsna/meet-and-greet/

--- a/static/_redirects
+++ b/static/_redirects
@@ -39,15 +39,17 @@
 /kcseu2024        /events/2024/kcseu 301
 /kcsna2024        /events/2024/kcsna 301
 
+/kcsna2026        /events/2026/kcsna 301
+
 /services         /resources/services 301
 /requests         /resources/services 301
 
-/summit           /events/2024/kcsna  302
-/summit/reg       /events/2024/kcsna/registration 302
-/summit/cfp       /events/2024/kcsna/schedule 302
-/summit/unconf    /events/2024/kcsna 302
+/summit           /events/2026/kcsna  302
+/summit/reg       /events/2026/kcsna/maintainer-summit-na 302
+/summit/cfp       /events/2026/kcsna/maintainer-summit-na 302
+/summit/unconf    /events/2026/kcsna/maintainer-summit-na 302
 /summit/notes     https://drive.google.com/drive/folders/1j3i9I4a3lbmjqQNTYKxK0Gc6JgooDn14 302
-/summit/sched     /events/2024/kcsna/schedule 302
+/summit/sched     /events/2026/kcsna/maintainer-summit-na 302
 
 # Section feeds are no longer generated; the blog feed lives at /index.xml.
 /blog/index.xml   /index.xml 301


### PR DESCRIPTION
Adds `content/en/events/2026/kcsna/`, following the structure introduced for
KubeCon EU 2026 (landing page plus one page per activity).

| Page | Status |
|---|---|
| Maintainer Summit North America 2026 | Sunday, November 8, Salt Palace. Schedule published. |
| Kubernetes 101: New Contributor Orientation | Tuesday, November 10, 16:40–18:00, Room 255 A. |
| Kubernetes Meet and Greet | Not yet on the KubeCon schedule; day, time and room marked as being confirmed. |

The landing page also links the Steering Committee AMA and the SIG ContribEx
governance session, both on November 10.

/kind feature
/sig contributor-experience