### PR TITLE
feat(content): add CLA page sourced from kubernetes/community

### DIFF
--- a/content/en/CLA.md
+++ b/content/en/CLA.md
@@ -1,0 +1,7 @@
+---
+title: Contributor License Agreement
+description: |
+  The CLA defines the legal status of contributed code for the CNCF.
+---
+
+{{< include-remote "https://raw.githubusercontent.com/kubernetes/community/master/CLA.md" >}}

--- a/content/en/CLA.md
+++ b/content/en/CLA.md
@@ -4,4 +4,4 @@ description: |
   The CLA defines the legal status of contributed code for the CNCF.
 ---
 
-{{< include-remote "https://raw.githubusercontent.com/kubernetes/community/master/CLA.md" >}}
+{{< include-remote "https://raw.githubusercontent.com/kubernetes/community/main/CLA.md" >}}

--- a/layouts/shortcodes/include-remote.html
+++ b/layouts/shortcodes/include-remote.html
@@ -1,0 +1,7 @@
+{{- /* GetRemote returns markdown source, so markdownify it; safeHTML would
+       emit literal link syntax. */ -}}
+{{- with resources.GetRemote (.Get 0) -}}
+{{- trim .Content "\n\r " | markdownify -}}
+{{- else -}}
+{{- warnf "include-remote: cannot fetch %s" ($.Get 0) -}}
+{{- end -}}


### PR DESCRIPTION
Serves the CNCF CLA at /cla/ from kubernetes/community instead of duplicating it here.

| Page | Expected |
|------|----------|
| `/cla/` | CLA renders, links resolve |

This PR was written in part with the assistance of generative AI.
