### PR TITLE
feat(layouts): add title fallback for pages without front matter

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,5 +1,5 @@
 <div class="td-content">
-	<h1>{{ .Title }}</h1>
+	<h1>{{ partial "page-title.html" . }}</h1>
     {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
         {{ partial "reading-time.html" . -}}

--- a/layouts/community/content.html
+++ b/layouts/community/content.html
@@ -1,5 +1,5 @@
 <div class="td-content">
-  <h1>{{ .Title }}</h1>
+  <h1>{{ partial "page-title.html" . }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
   
   {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <div class="td-content">
-	<h1>{{ .Title }}</h1>
+	<h1>{{ partial "page-title.html" . }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
 		{{ partial "taxonomy_terms_article_wrapper.html" . -}}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -5,7 +5,7 @@ This file needs to be removed once Docsy has been updated to 0.10.0.
 
 {{ define "main" }}
 <div class="td-content">
-	<h1>{{ .Title }}</h1>
+	<h1>{{ partial "page-title.html" . }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
 		{{ partial "taxonomy_terms_article_wrapper.html" . -}}

--- a/layouts/partials/page-title.html
+++ b/layouts/partials/page-title.html
@@ -1,0 +1,7 @@
+{{- /* Hugo does not derive .Title from the filename; upstream markdown often
+       has no front matter, which would render an empty <h1>. */ -}}
+{{- with .Title }}{{ . }}{{ else }}{{ with .File -}}
+  {{- $n := .BaseFileName -}}
+  {{- if or (eq $n "_index") (eq $n "index") }}{{ $n = path.Base .Dir }}{{ end -}}
+  {{- $n | replaceRE "[-_]+" " " | title -}}
+{{- end }}{{ end -}}

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <div class="td-content">
-	<h1>{{ .Title }}</h1>
+	<h1>{{ partial "page-title.html" . }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
 		{{ partial "taxonomy_terms_article_wrapper.html" . -}}


### PR DESCRIPTION
Adds a filename fallback for pages with no title in front matter.

| Page | Expected |
|------|----------|
| `/docs/guide/` | Title unchanged |
| `/community/` | Title unchanged |
| `/resources/` | Title unchanged |

This PR was written in part with the assistance of generative AI.
