### PR TITLE
fix(layouts): use a valid variable in include shortcode error

### DIFF
--- a/layouts/shortcodes/include.html
+++ b/layouts/shortcodes/include.html
@@ -16,7 +16,7 @@
 	{{- with $page }}
 	{{ .Content }}
 	{{- else -}}
-	{{ errorf "[%s] no Resource or Page matching %q." $.Page.Lang ($pattern | safeHTML ) }}
+	{{ errorf "[%s] no Resource or Page matching %q." $.Page.Lang $name }}
 	{{- end -}}
 	{{- end -}}
 	{{- else -}}


### PR DESCRIPTION
Fixes an undefined variable that made a missing include fail with the wrong error.

| Page | Expected |
|------|----------|
| `/community/code-of-conduct/` | Both includes render |

This PR was written in part with the assistance of generative AI.
