### PR TITLE
fix: correct broken social page link on KCSNA 2022 FAQ

### DIFF
--- a/content/en/events/2022/kcsna/faq.md
+++ b/content/en/events/2022/kcsna/faq.md
@@ -106,7 +106,7 @@ Until then, here are some additional resources you may find useful:
 
 Contributors will be allowed to bring a single family member
 or partner to the social (a "plus one"). 
-[See the Social page to request a guest pass](/event/2022/kcsna/social/).
+[See the Social page to request a guest pass](/events/2022/kcsna/social/).
 
 ### I have a question! How do I contact the event staff?
 


### PR DESCRIPTION
The KCSNA 2022 FAQ links to the contributor social page as `/event/2022/kcsna/social/`, but the section is `/events/` (plural), so the link 404s. Every other reference to that page in the repo already uses `/events/`.

Fix: change the single link in `content/en/events/2022/kcsna/faq.md` from `/event/` to `/events/`.

Repro:
1. open https://www.kubernetes.dev/events/2022/kcsna/faq/
2. under "Can I bring a guest to the Social?", click "See the Social page to request a guest pass"
3. it lands on https://www.kubernetes.dev/event/2022/kcsna/social/ which is a 404
4. the real page is https://www.kubernetes.dev/events/2022/kcsna/social/

Built locally with Hugo 0.144.2 (the pinned version), site builds clean and the link resolves after the change.
